### PR TITLE
Improve/ext collection: reduce unnecessary command calls with a better way to parse `PlistBuddy` output

### DIFF
--- a/src/plist_parser.rs
+++ b/src/plist_parser.rs
@@ -28,36 +28,19 @@ impl PlistParser {
         if let Ok(output) = count_output {
             let content = String::from_utf8_lossy(&output.stdout);
 
-            // Count document types
-            let doc_type_count = content.lines().filter(|line| line.contains("Dict")).count();
-
-            if doc_type_count > 0 {
-                // Iterate through each document type
-                for i in 0..doc_type_count {
-                    let ext_output = Command::new("/usr/libexec/PlistBuddy")
-                        .arg("-c")
-                        .arg(&format!(
-                            "Print :CFBundleDocumentTypes:{}:CFBundleTypeExtensions",
-                            i
-                        ))
-                        .arg(plist_path)
-                        .output();
-
-                    if let Ok(ext_output) = ext_output {
-                        let ext_content = String::from_utf8_lossy(&ext_output.stdout);
-
-                        // Parse extensions
-                        for line in ext_content.lines() {
-                            let line = line.trim();
-                            if !line.is_empty()
-                                && !line.contains("Array {")
-                                && !line.contains("}")
-                                && !line.contains("Dict")
-                            {
-                                extensions.insert(line.to_string());
-                            }
-                        }
-                    }
+            let mut is_collecting = false;
+            for line in content.lines() {
+                let line = line.trim();
+                if line == "}" && is_collecting {
+                    is_collecting = false;
+                    continue;
+                }
+                if is_collecting && line != "" {
+                    extensions.insert(line.to_string());
+                    continue;
+                }
+                if line == "CFBundleTypeExtensions = Array {" {
+                    is_collecting = true;
                 }
             }
         }


### PR DESCRIPTION
### **User description**
#### What's changed

Collect file extensions by just parsing `PlistBuddy -c 'Print :CFBundleDocumentTypes' /path/to/yout/Info.plist` output, getting rid of unnecessary command calls and optimizing bootstrap speed.

#### Why it works

`PlistBuddy -c 'Print :CFBundleDocumentTypes' /path/to/yout/Info.plist` output looks like this: a list of `Dict` with `CFBundleTypeExtensions` including the file extensions. 

```
Dict {
        ...
        CFBundleTypeExtensions = Array {
            asp
            aspx
            cshtml
            jshtm
            jsp
            phtml
            shtml
        }
        ...
    }
```

So just start collecting exts when encountering `CFBundleTypeExtensions = Array {` and stop when meeting `}`. No need to call `Print :CFBundleDocumentTypes:i:CFBundleTypeExtensions` to collect them dict by dict.

#### Preference

I've tested the duration of the extension collecting phase and here's what I got:
```rust
...
for app_path in &apps {
        if let Some(app_name) = Path::new(&app_path).file_stem().and_then(|n| n.to_str()) {
            let info_plist_path = format!("{}/Contents/Info.plist", app_path);

            if let Ok(extensions) = plist_parser.parse_extensions(&info_plist_path) {
                if !extensions.is_empty() {
                    app_extensions.insert(app_name.to_string(), extensions);
                }
            }
        }
    }
```
before:
<img width="656" height="218" alt="before" src="https://github.com/user-attachments/assets/fa1bc9a1-ced2-4d4a-a1ec-b99e6ea8b59e" />
after: 
<img width="633" height="218" alt="after" src="https://github.com/user-attachments/assets/a0a9ff37-8f7a-4a50-a42f-22bbc7728899" />


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize extension collection by parsing single PlistBuddy output

- Eliminate nested command calls for each document type

- Reduce bootstrap time significantly through streamlined parsing

- Parse CFBundleTypeExtensions array directly from output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PlistBuddy output"] --> B["Parse single output"]
  B --> C["Detect CFBundleTypeExtensions"]
  C --> D["Collect extensions directly"]
  D --> E["Return extensions set"]
  style A fill:#e1f5ff
  style E fill:#c8e6c9
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plist_parser.rs</strong><dd><code>Streamline PlistBuddy output parsing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plist_parser.rs

<ul><li>Replaced iterative command calls with single-pass parsing<br> <li> Removed nested loop that called PlistBuddy for each document type<br> <li> Implemented state machine approach using <code>is_collecting</code> flag<br> <li> Simplified extension extraction by detecting array boundaries</ul>


</details>


  </td>
  <td><a href="https://github.com/tsonglew/dutis/pull/17/files#diff-5d46c890134a437ed2d411b6a69e65d5aaea3195f11c67ab592dc2f3d1a3dbf2">+13/-30</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

