### PR TITLE
Fix release workflow to update existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,11 @@ jobs:
         run: |
           cargo build --release --target x86_64-apple-darwin
           
-      - name: Create release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create or update release
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           body: |
             ## What's Changed
             
@@ -75,15 +73,7 @@ jobs:
             dutis                    # Start interactive mode
             dutis --help            # Show help
             ```
+          files: ./target/x86_64-apple-darwin/release/dutis
+          overwrite_files: true
           draft: false
           prerelease: false
-          
-      - name: Upload binary asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./target/x86_64-apple-darwin/release/dutis
-          asset_name: dutis-macos-x86_64
-          asset_content_type: application/octet-stream


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace deprecated GitHub Actions with softprops/action-gh-release@v2

- Consolidate release creation and binary upload into single action

- Fix tag_name parameter to use github.ref_name instead of github.ref

- Enable automatic file overwriting for existing releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Workflow:<br/>create-release@v1<br/>+ upload-release-asset@v1"] -->|"Replace with"| B["New Workflow:<br/>softprops/action-gh-release@v2"]
  B -->|"Benefits"| C["Single action<br/>Auto file overwrite<br/>Correct tag reference"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Modernize release workflow with consolidated action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Replaced deprecated <code>actions/create-release@v1</code> with <br><code>softprops/action-gh-release@v2</code><br> <li> Removed separate <code>actions/upload-release-asset@v1</code> step and consolidated <br>into single action<br> <li> Fixed <code>tag_name</code> parameter from <code>github.ref</code> to <code>github.ref_name</code> for <br>correct tag reference<br> <li> Added <code>files</code> and <code>overwrite_files</code> parameters to enable automatic binary <br>upload and overwriting</ul>


</details>


  </td>
  <td><a href="https://github.com/tsonglew/dutis/pull/19/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+6/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is how GitHub Releases are created/updated and how the built binary is attached, which could affect release publishing if misconfigured.
> 
> **Overview**
> Updates the `release.yml` GitHub Actions workflow to use `softprops/action-gh-release@v2` to **create or update** a release for the pushed tag, instead of separately creating a release and uploading an asset.
> 
> The workflow now attaches the built `dutis` macOS binary directly via the action’s `files` option and enables `overwrite_files` so reruns can replace existing assets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0199ac933fc5743b009880f5987d6afabf154ed5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->