### PR TITLE
feat: add agent-ready CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,12 +65,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "colored"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -31,11 +127,14 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "dutis"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
+ "clap",
  "colored",
  "plist",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -51,6 +150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +164,18 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "memchr"
@@ -71,6 +188,12 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "plist"
@@ -125,6 +248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -144,7 +268,37 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -195,12 +349,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -259,3 +434,9 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"
@@ -17,7 +17,10 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
 plist = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 # Terminal output formatting
 colored = "3.1"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A comprehensive Rust application for viewing file extensions supported by macOS 
 - 🧭 **Accurate App Selection**: Preserves full application paths, including nested and duplicate names
 - 🧩 **Modern Metadata Support**: Reads legacy document types and modern UTI declarations
 - ✅ **Verified Updates**: Verifies the selected default application after applying it
+- 🤖 **Agent-ready CLI**: Stable JSON output, dry runs, deterministic selectors, and explicit exit codes
 
 ## Installation
 
@@ -71,6 +72,39 @@ The application starts in interactive mode where you can:
 3. **Set Default Apps**: Choose an application to set as the default for a specific file type
 4. **Debug Information**: Access detailed scanning information
 
+### Command Line Mode
+
+Use explicit commands from shell scripts or AI agents. A leading dot on an
+extension is optional.
+
+```bash
+# Inspect installed applications and supported handlers
+dutis list
+dutis query md
+dutis get .md
+
+# Emit a versioned JSON response
+dutis query json --json
+
+# Preview a change without mutating the system
+dutis set md com.microsoft.VSCode --dry-run --json
+
+# Apply and verify a change; --yes is required for non-interactive writes
+dutis set md com.microsoft.VSCode --yes
+
+# Check local readiness
+dutis doctor --json
+```
+
+Applications can be selected by exact bundle ID, exact application path, or an
+unambiguous application name. JSON responses use API version `1`. Exit codes are
+`0` for success, `2` for usage errors, `3` for no match, `4` for ambiguous
+selectors, `5` for an unavailable dependency, and `6` for operation failure.
+
+The product and engineering sequence for declarative configuration, rollback,
+MCP, agent policies, profiles, and drift detection is documented in the
+[Agent Roadmap](docs/agent-roadmap.md).
+
 ## How It Works
 
 ### Application Scanning
@@ -98,6 +132,8 @@ The application starts in interactive mode where you can:
 - **anyhow**: Error handling and propagation
 - **colored**: Terminal output formatting and colors
 - **plist**: Native XML and binary plist parsing
+- **clap**: Command parsing and generated help
+- **serde / serde_json**: Versioned machine-readable output
 
 ## Releases
 

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -1,0 +1,139 @@
+# Dutis Agent Roadmap
+
+This roadmap evolves Dutis from an interactive macOS utility into a safe,
+composable capability for people, scripts, and AI agents. Each phase should be
+useful on its own and must preserve the existing interactive experience.
+
+## Product principles
+
+- Mutations are never implicit. Read operations and write operations remain
+  separate, and non-interactive writes require explicit confirmation.
+- Every write follows `plan -> apply -> verify`. Dry runs must not invoke a
+  mutating system command.
+- Machine output is versioned. JSON stdout contains only the response envelope;
+  warnings and diagnostics go to stderr.
+- Selectors resolve deterministically. Ambiguous application names fail instead
+  of choosing an arbitrary installation.
+- Autonomous enforcement comes only after snapshots and rollback are available.
+- The local machine remains the source of truth. Recommendations never silently
+  override user policy.
+
+## Phase 1: Agent-ready CLI
+
+Status: implemented for v2.5.0
+
+Deliver a stable command interface while keeping `dutis` without arguments as
+the interactive mode.
+
+Commands:
+
+```text
+dutis list [--json]
+dutis query <extension> [--json]
+dutis get <extension> [--json]
+dutis set <extension> <bundle-id|path|name> [--dry-run] [--yes] [--json]
+dutis doctor [--json]
+```
+
+Acceptance criteria:
+
+- JSON responses include an `api_version`, command name, and data or error.
+- `set --dry-run` resolves the target and prints the exact planned command
+  without changing Launch Services.
+- A real non-interactive `set` requires `--yes` and verifies the resulting
+  association.
+- Bundle IDs and exact paths are preferred selectors; names must be unique.
+- Exit codes distinguish usage (`2`), not found (`3`), ambiguity (`4`), missing
+  dependencies (`5`), and operation failure (`6`).
+- Unit tests cover parsing, normalization, selection, JSON envelopes, and duti
+  output parsing. CI runs format, Clippy, and all tests.
+
+## Phase 2: Declarative configuration
+
+Add a checked-in `dutis.toml` format and idempotent workflows:
+
+```text
+dutis plan dutis.toml
+dutis diff dutis.toml
+dutis apply dutis.toml --yes
+```
+
+The plan contains current state, desired state, proposed changes, unresolved
+applications, and a deterministic plan digest. `apply` rejects stale plans and
+returns per-item verification results.
+
+Acceptance criteria:
+
+- Reapplying a converged configuration makes no changes.
+- Partial failures are reported per association and produce a non-zero exit.
+- Config and result schemas have documented versions and migration rules.
+
+## Phase 3: Snapshots, history, and rollback
+
+Capture associations before every multi-item apply and expose:
+
+```text
+dutis snapshot create
+dutis history
+dutis rollback <snapshot-id> --dry-run
+dutis rollback <snapshot-id> --yes
+```
+
+Acceptance criteria:
+
+- Snapshots are local, inspectable, and do not contain credentials.
+- Rollback uses the same plan/apply/verify pipeline.
+- Failed applies retain enough state to recover safely.
+
+## Phase 4: MCP server and agent tools
+
+Expose the core library through a local MCP server. Keep read tools (`list`,
+`query`, `get`, `diff`) separate from mutation tools (`apply`, `rollback`). Write
+tools accept a plan digest and explicit approval token rather than free-form
+shell commands.
+
+Acceptance criteria:
+
+- An agent can discover installed handlers and produce a plan without write
+  permission.
+- Write capabilities can be disabled independently.
+- Tool schemas, errors, and audit events are stable and tested.
+
+## Phase 5: Agent skill and policy layer
+
+Ship a Dutis skill for common workflows and add local policy controls such as
+allowed extensions, allowed applications, protected associations, and required
+approval modes. Record who requested each change and which verified plan was
+used.
+
+Acceptance criteria:
+
+- Policy denial happens before a system command executes.
+- Every mutation has a local audit record with plan, result, and verification.
+- The skill defaults to inspection and dry-run before requesting approval.
+
+## Phase 6: Profiles and recommendations
+
+Add reusable profiles such as developer, designer, media, and minimal macOS,
+plus explainable recommendations based on installed applications and current
+associations. Recommendations remain proposals and include their evidence.
+
+## Phase 7: Drift detection
+
+Add `dutis watch` and an optional LaunchAgent to detect differences from a
+declared policy. Start with notifications and reports. Automatic remediation is
+opt-in and requires rollback-ready snapshots.
+
+## Phase 8: Broader association support
+
+Expand the model beyond filename extensions to URL schemes, UTIs, MIME types,
+and Launch Services roles. Preserve one normalized planning and verification
+pipeline across all association types.
+
+## Near-term engineering sequence
+
+1. Finish and release Phase 1 as the first stable automation contract.
+2. Extract the catalog and system adapter into a library crate before Phase 2.
+3. Write the configuration and plan schemas before implementing `apply`.
+4. Build rollback before exposing any autonomous or continuously running mode.
+5. Add MCP and skills only on top of the tested CLI/library semantics.

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,0 +1,150 @@
+use crate::app_scanner::AppScanner;
+use crate::plist_parser::PlistParser;
+use anyhow::Result;
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct Application {
+    pub name: String,
+    pub path: PathBuf,
+    pub bundle_id: Option<String>,
+    pub extensions: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct ApplicationCatalog {
+    pub applications: Vec<Application>,
+    pub metadata_failures: usize,
+}
+
+impl ApplicationCatalog {
+    pub fn scan() -> Result<Self> {
+        let installed_apps = AppScanner::new().scan_applications()?;
+        let parser = PlistParser::new();
+        let mut metadata_failures = 0;
+        let applications = installed_apps
+            .into_iter()
+            .map(|installed| {
+                let plist_path = installed.path.join("Contents/Info.plist");
+                let metadata = parser.parse_metadata(&plist_path);
+                if metadata.is_err() {
+                    metadata_failures += 1;
+                }
+                let metadata = metadata.ok();
+                Application {
+                    name: installed.name,
+                    path: installed.path,
+                    bundle_id: metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.bundle_id.clone()),
+                    extensions: metadata
+                        .map(|metadata| metadata.extensions)
+                        .unwrap_or_default(),
+                }
+            })
+            .collect();
+
+        Ok(Self {
+            applications,
+            metadata_failures,
+        })
+    }
+}
+
+pub fn find_apps_for_extension<'a>(
+    applications: &'a [Application],
+    extension: &str,
+) -> Vec<&'a Application> {
+    applications
+        .iter()
+        .filter(|app| {
+            app.extensions
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(extension))
+        })
+        .collect()
+}
+
+pub fn find_fuzzy_matches<'a>(
+    applications: &'a [Application],
+    search_term: &str,
+) -> Vec<&'a Application> {
+    let search_term = search_term.to_ascii_lowercase();
+    applications
+        .iter()
+        .filter(|app| {
+            app.name.to_ascii_lowercase().contains(&search_term)
+                || app
+                    .extensions
+                    .iter()
+                    .any(|extension| extension.to_ascii_lowercase().contains(&search_term))
+        })
+        .collect()
+}
+
+pub fn resolve_app<'a>(applications: &'a [Application], selector: &str) -> Vec<&'a Application> {
+    let path_matches = applications
+        .iter()
+        .filter(|app| app.path.to_string_lossy() == selector)
+        .collect::<Vec<_>>();
+    if !path_matches.is_empty() {
+        return path_matches;
+    }
+
+    let bundle_matches = applications
+        .iter()
+        .filter(|app| app.bundle_id.as_deref() == Some(selector))
+        .collect::<Vec<_>>();
+    if !bundle_matches.is_empty() {
+        return bundle_matches;
+    }
+
+    applications
+        .iter()
+        .filter(|app| app.name.eq_ignore_ascii_case(selector))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app(name: &str, path: &str, bundle_id: Option<&str>) -> Application {
+        Application {
+            name: name.to_owned(),
+            path: PathBuf::from(path),
+            bundle_id: bundle_id.map(str::to_owned),
+            extensions: vec!["txt".to_owned()],
+        }
+    }
+
+    #[test]
+    fn resolves_by_path_bundle_id_and_name() {
+        let applications = vec![
+            app("Editor", "/Applications/Editor.app", Some("dev.editor")),
+            app("Viewer", "/Applications/Viewer.app", Some("dev.viewer")),
+        ];
+
+        assert_eq!(
+            resolve_app(&applications, "/Applications/Editor.app").len(),
+            1
+        );
+        assert_eq!(resolve_app(&applications, "dev.viewer").len(), 1);
+        assert_eq!(resolve_app(&applications, "editor").len(), 1);
+        assert!(resolve_app(&applications, "missing").is_empty());
+    }
+
+    #[test]
+    fn leaves_duplicate_names_ambiguous() {
+        let applications = vec![
+            app("Editor", "/Applications/Editor.app", Some("dev.editor")),
+            app(
+                "Editor",
+                "/Applications/Alt/Editor.app",
+                Some("dev.editor.alt"),
+            ),
+        ];
+        assert_eq!(resolve_app(&applications, "Editor").len(), 2);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,94 @@
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "dutis",
+    version,
+    about = "Manage default macOS applications by file extension",
+    after_help = "Run without a command to start interactive mode.\nMore information: https://github.com/tsonglew/dutis"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<CliCommand>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CliCommand {
+    /// List installed applications and their declared extensions
+    List(OutputArgs),
+    /// Find installed applications that declare support for an extension
+    Query(ExtensionArgs),
+    /// Read the current default application for an extension
+    Get(ExtensionArgs),
+    /// Set the default application for an extension
+    Set(SetArgs),
+    /// Check whether dutis and its runtime dependency are ready
+    Doctor(OutputArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct OutputArgs {
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct ExtensionArgs {
+    /// Filename extension, with or without a leading dot
+    pub extension: String,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SetArgs {
+    /// Filename extension, with or without a leading dot
+    pub extension: String,
+    /// Exact bundle ID, application path, or unambiguous application name
+    pub app_selector: String,
+    /// Resolve and display the operation without changing the system
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Confirm a non-interactive system change
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parses_agent_facing_commands() {
+        let cli = Cli::try_parse_from(["dutis", "query", ".md", "--json"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Query(ExtensionArgs { json: true, .. }))
+        ));
+
+        let cli = Cli::try_parse_from([
+            "dutis",
+            "set",
+            "md",
+            "com.example.Editor",
+            "--dry-run",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Set(SetArgs {
+                dry_run: true,
+                yes: false,
+                json: true,
+                ..
+            }))
+        ));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,79 +1,438 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
+use application::{
+    find_apps_for_extension, find_fuzzy_matches, resolve_app, Application, ApplicationCatalog,
+};
+use clap::Parser;
+use cli::{Cli, CliCommand, ExtensionArgs, OutputArgs, SetArgs};
 use colored::*;
+use serde::Serialize;
 use std::io::{self, Write};
-use std::path::Path;
-use std::process::Command;
+use std::process::ExitCode;
 
 mod app_scanner;
+mod application;
+mod cli;
 mod plist_parser;
+mod system;
 
-use app_scanner::{AppScanner, InstalledApplication};
-use plist_parser::PlistParser;
+const API_VERSION: &str = "1";
 
 #[derive(Debug)]
-struct Application {
-    installed: InstalledApplication,
-    extensions: Vec<String>,
+struct CliError {
+    code: u8,
+    kind: &'static str,
+    message: String,
 }
 
-fn main() -> Result<()> {
-    if std::env::args()
-        .nth(1)
-        .is_some_and(|arg| arg == "--help" || arg == "-h")
-    {
-        print_help();
-        return Ok(());
+impl CliError {
+    fn usage(message: impl Into<String>) -> Self {
+        Self::new(2, "usage", message)
     }
 
+    fn not_found(message: impl Into<String>) -> Self {
+        Self::new(3, "not_found", message)
+    }
+
+    fn ambiguous(message: impl Into<String>) -> Self {
+        Self::new(4, "ambiguous_selector", message)
+    }
+
+    fn dependency(message: impl Into<String>) -> Self {
+        Self::new(5, "dependency_unavailable", message)
+    }
+
+    fn operation(message: impl Into<String>) -> Self {
+        Self::new(6, "operation_failed", message)
+    }
+
+    fn new(code: u8, kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct JsonEnvelope<T> {
+    api_version: &'static str,
+    command: &'static str,
+    data: T,
+}
+
+#[derive(Serialize)]
+struct JsonErrorEnvelope<'a> {
+    api_version: &'static str,
+    command: &'static str,
+    error: JsonError<'a>,
+}
+
+#[derive(Serialize)]
+struct JsonError<'a> {
+    code: u8,
+    kind: &'static str,
+    message: &'a str,
+}
+
+#[derive(Serialize)]
+struct ApplicationList<'a> {
+    applications: &'a [Application],
+    metadata_failures: usize,
+}
+
+#[derive(Serialize)]
+struct QueryResult<'a> {
+    extension: &'a str,
+    applications: Vec<&'a Application>,
+    metadata_failures: usize,
+}
+
+#[derive(Serialize)]
+struct SetResult<'a> {
+    status: &'static str,
+    extension: &'a str,
+    application: &'a Application,
+    command: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct DoctorResult {
+    platform: &'static str,
+    duti_available: bool,
+    duti_version: Option<String>,
+    ready_for_read_only_commands: bool,
+    ready_for_changes: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let command_name = cli
+        .command
+        .as_ref()
+        .map(command_name)
+        .unwrap_or("interactive");
+    let json = cli.command.as_ref().is_some_and(command_uses_json);
+
+    match dispatch(cli.command) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            if json {
+                let response = JsonErrorEnvelope {
+                    api_version: API_VERSION,
+                    command: command_name,
+                    error: JsonError {
+                        code: error.code,
+                        kind: error.kind,
+                        message: &error.message,
+                    },
+                };
+                if let Err(serialization_error) = write_json(&response) {
+                    eprintln!("failed to serialize error response: {serialization_error:?}");
+                }
+            } else {
+                eprintln!("Error: {}", error.message);
+            }
+            ExitCode::from(error.code)
+        }
+    }
+}
+
+fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
+    match command {
+        None => run_interactive().map_err(|error| CliError::operation(format!("{error:#}"))),
+        Some(CliCommand::List(args)) => run_list(args),
+        Some(CliCommand::Query(args)) => run_query(args),
+        Some(CliCommand::Get(args)) => run_get(args),
+        Some(CliCommand::Set(args)) => run_set(args),
+        Some(CliCommand::Doctor(args)) => run_doctor(args),
+    }
+}
+
+fn command_name(command: &CliCommand) -> &'static str {
+    match command {
+        CliCommand::List(_) => "list",
+        CliCommand::Query(_) => "query",
+        CliCommand::Get(_) => "get",
+        CliCommand::Set(_) => "set",
+        CliCommand::Doctor(_) => "doctor",
+    }
+}
+
+fn command_uses_json(command: &CliCommand) -> bool {
+    match command {
+        CliCommand::List(args) | CliCommand::Doctor(args) => args.json,
+        CliCommand::Query(args) | CliCommand::Get(args) => args.json,
+        CliCommand::Set(args) => args.json,
+    }
+}
+
+fn run_list(args: OutputArgs) -> Result<(), CliError> {
+    let catalog = scan_catalog()?;
+    report_metadata_failures(catalog.metadata_failures);
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "list",
+            data: ApplicationList {
+                applications: &catalog.applications,
+                metadata_failures: catalog.metadata_failures,
+            },
+        })?;
+    } else {
+        for app in &catalog.applications {
+            let bundle_id = app.bundle_id.as_deref().unwrap_or("unknown bundle ID");
+            println!("{}\t{}\t{}", app.name, bundle_id, app.path.display());
+        }
+        println!("\n{} applications", catalog.applications.len());
+    }
+    Ok(())
+}
+
+fn run_query(args: ExtensionArgs) -> Result<(), CliError> {
+    let extension =
+        normalize_extension(&args.extension).map_err(|error| CliError::usage(error.to_string()))?;
+    let catalog = scan_catalog()?;
+    report_metadata_failures(catalog.metadata_failures);
+    let applications = find_apps_for_extension(&catalog.applications, &extension);
+    if applications.is_empty() {
+        return Err(CliError::not_found(format!(
+            "no installed applications declare support for .{extension}"
+        )));
+    }
+
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "query",
+            data: QueryResult {
+                extension: &extension,
+                applications,
+                metadata_failures: catalog.metadata_failures,
+            },
+        })?;
+    } else {
+        println!("Applications supporting .{extension}:");
+        for app in applications {
+            println!("{}\t{}", app.name, app.path.display());
+        }
+    }
+    Ok(())
+}
+
+fn run_get(args: ExtensionArgs) -> Result<(), CliError> {
+    let extension =
+        normalize_extension(&args.extension).map_err(|error| CliError::usage(error.to_string()))?;
+    system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
+    let default = system::get_default_app(&extension)
+        .map_err(|error| CliError::operation(format!("{error:#}")))?
+        .ok_or_else(|| {
+            CliError::not_found(format!(
+                "no default application is registered for .{extension}"
+            ))
+        })?;
+
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "get",
+            data: default,
+        })?;
+    } else {
+        println!("Default application for .{}:", extension);
+        if let Some(name) = default.name {
+            println!("Name: {name}");
+        }
+        if let Some(path) = default.path {
+            println!("Path: {path}");
+        }
+        println!("Bundle ID: {}", default.bundle_id);
+    }
+    Ok(())
+}
+
+fn run_set(args: SetArgs) -> Result<(), CliError> {
+    let extension =
+        normalize_extension(&args.extension).map_err(|error| CliError::usage(error.to_string()))?;
+    if !args.dry_run && !args.yes {
+        return Err(CliError::usage(
+            "refusing to change the system without --yes; use --dry-run to preview",
+        ));
+    }
+
+    let catalog = scan_catalog()?;
+    report_metadata_failures(catalog.metadata_failures);
+    let matches = resolve_app(&catalog.applications, &args.app_selector);
+    let app = match matches.as_slice() {
+        [] => {
+            return Err(CliError::not_found(format!(
+                "no installed application matches '{}'",
+                args.app_selector
+            )))
+        }
+        [app] => *app,
+        matches => {
+            let paths = matches
+                .iter()
+                .map(|app| app.path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(CliError::ambiguous(format!(
+                "application name '{}' is ambiguous; use a bundle ID or exact path ({paths})",
+                args.app_selector
+            )));
+        }
+    };
+    let bundle_id = app.bundle_id.as_deref().ok_or_else(|| {
+        CliError::operation(format!(
+            "{} has no readable bundle identifier",
+            app.path.display()
+        ))
+    })?;
+    let command = vec![
+        "duti".to_owned(),
+        "-s".to_owned(),
+        bundle_id.to_owned(),
+        format!(".{extension}"),
+        "all".to_owned(),
+    ];
+
+    let status = apply_or_preview(
+        args.dry_run,
+        &extension,
+        bundle_id,
+        |extension, bundle_id| {
+            system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
+            system::set_default_app(extension, bundle_id)
+                .map_err(|error| CliError::operation(format!("{error:#}")))
+        },
+    )?;
+
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "set",
+            data: SetResult {
+                status,
+                extension: &extension,
+                application: app,
+                command,
+            },
+        })?;
+    } else if args.dry_run {
+        println!(
+            "Dry run: would set .{extension} to {} ({bundle_id})",
+            app.name
+        );
+        println!("Command: {}", shell_display(&command));
+    } else {
+        println!(
+            "Set .{extension} to {} ({bundle_id}) and verified it",
+            app.name
+        );
+    }
+    Ok(())
+}
+
+fn apply_or_preview<F>(
+    dry_run: bool,
+    extension: &str,
+    bundle_id: &str,
+    apply: F,
+) -> Result<&'static str, CliError>
+where
+    F: FnOnce(&str, &str) -> Result<(), CliError>,
+{
+    if dry_run {
+        return Ok("planned");
+    }
+    apply(extension, bundle_id)?;
+    Ok("applied")
+}
+
+fn run_doctor(args: OutputArgs) -> Result<(), CliError> {
+    let duti = system::duti_version();
+    let duti_available = duti.is_ok();
+    let result = DoctorResult {
+        platform: std::env::consts::OS,
+        duti_available,
+        duti_version: duti.ok(),
+        ready_for_read_only_commands: cfg!(target_os = "macos"),
+        ready_for_changes: cfg!(target_os = "macos") && duti_available,
+    };
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "doctor",
+            data: result,
+        })?;
+    } else {
+        println!("Platform: {}", result.platform);
+        println!(
+            "duti: {}",
+            result.duti_version.as_deref().unwrap_or("not available")
+        );
+        println!(
+            "Read-only commands ready: {}",
+            result.ready_for_read_only_commands
+        );
+        println!("Changes ready: {}", result.ready_for_changes);
+    }
+    Ok(())
+}
+
+fn scan_catalog() -> Result<ApplicationCatalog, CliError> {
+    ApplicationCatalog::scan().map_err(|error| CliError::operation(format!("{error:#}")))
+}
+
+fn report_metadata_failures(count: usize) {
+    if count > 0 {
+        eprintln!(
+            "Warning: could not read metadata for {count} applications; they remain in the application list"
+        );
+    }
+}
+
+fn write_json<T: Serialize>(value: &T) -> Result<(), CliError> {
+    let json = serde_json::to_string_pretty(value)
+        .map_err(|error| CliError::operation(format!("failed to serialize JSON: {error}")))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn shell_display(arguments: &[String]) -> String {
+    arguments
+        .iter()
+        .map(|argument| {
+            if argument
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric() || "./_+-".contains(character))
+            {
+                argument.clone()
+            } else {
+                format!("'{argument}'")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn run_interactive() -> Result<()> {
     println!("🔍 macOS Application File Extension Manager");
     println!("Scanning system applications...\n");
 
-    let installed_apps = AppScanner::new().scan_applications()?;
+    let catalog = ApplicationCatalog::scan()?;
     println!(
         "Found {} applications, loading supported file extensions...\n",
-        installed_apps.len()
+        catalog.applications.len()
     );
-
-    let parser = PlistParser::new();
-    let mut parse_failures = 0;
-    let applications = installed_apps
-        .into_iter()
-        .map(|installed| {
-            let plist_path = installed.path.join("Contents/Info.plist");
-            let extensions = match parser.parse_extensions(&plist_path) {
-                Ok(extensions) => extensions,
-                Err(_) => {
-                    parse_failures += 1;
-                    Vec::new()
-                }
-            };
-            Application {
-                installed,
-                extensions,
-            }
-        })
-        .collect::<Vec<_>>();
-
-    if parse_failures > 0 {
+    if catalog.metadata_failures > 0 {
         eprintln!(
-            "⚠️ Could not read metadata for {parse_failures} applications; they remain available in the full application list."
+            "⚠️ Could not read metadata for {} applications; they remain available in the full application list.",
+            catalog.metadata_failures
         );
     }
-
-    interactive_query(&applications)
-}
-
-fn print_help() {
-    println!("Dutis - macOS Application File Extension Manager\n");
-    println!("USAGE:\n    dutis [OPTIONS]\n");
-    println!("OPTIONS:\n    -h, --help    Print this help message\n");
-    println!("DESCRIPTION:");
-    println!("    View file extensions supported by installed macOS applications and");
-    println!("    set default applications interactively. Setting defaults requires duti.\n");
-    println!("EXAMPLES:");
-    println!("    dutis                    # Start interactive mode");
-    println!("    dutis --help             # Show this help message\n");
-    println!("For more information, visit: https://github.com/tsonglew/dutis");
+    interactive_query(&catalog.applications)
 }
 
 fn interactive_query(applications: &[Application]) -> Result<()> {
@@ -131,7 +490,7 @@ fn interactive_query(applications: &[Application]) -> Result<()> {
                 for app in fuzzy_matches.iter().take(5) {
                     println!(
                         "   • {}: {}",
-                        app.installed.name.bright_blue(),
+                        app.name.bright_blue(),
                         app.extensions.join(", ").yellow()
                     );
                 }
@@ -156,8 +515,8 @@ fn interactive_query(applications: &[Application]) -> Result<()> {
                 println!(
                     "   {}. {} ({})",
                     index + 1,
-                    app.installed.name.bright_blue(),
-                    app.installed.path.display()
+                    app.name.bright_blue(),
+                    app.path.display()
                 );
             }
 
@@ -202,13 +561,13 @@ fn read_prompt(prompt: &str) -> Result<Option<String>> {
 fn normalize_extension(input: &str) -> Result<String> {
     let extension = input.trim().trim_start_matches('.').to_ascii_lowercase();
     if extension.is_empty() {
-        bail!("Please enter a valid file extension");
+        bail!("please enter a valid file extension");
     }
     if !extension
         .chars()
         .all(|character| character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '_'))
     {
-        bail!("File extensions may only contain letters, numbers, '+', '-' or '_'");
+        bail!("file extensions may only contain letters, numbers, '+', '-' or '_'");
     }
     Ok(extension)
 }
@@ -228,144 +587,27 @@ fn display_debug_info(applications: &[Application]) {
     {
         println!(
             "  {}: {}",
-            app.installed.name.bright_blue(),
+            app.name.bright_blue(),
             app.extensions.join(", ").yellow()
         );
     }
     println!();
 }
 
-fn find_apps_for_extension<'a>(
-    applications: &'a [Application],
-    extension: &str,
-) -> Vec<&'a Application> {
-    applications
-        .iter()
-        .filter(|app| {
-            app.extensions
-                .iter()
-                .any(|candidate| candidate.eq_ignore_ascii_case(extension))
-        })
-        .collect()
-}
-
-fn find_fuzzy_matches<'a>(
-    applications: &'a [Application],
-    search_term: &str,
-) -> Vec<&'a Application> {
-    let search_term = search_term.to_ascii_lowercase();
-    applications
-        .iter()
-        .filter(|app| {
-            app.installed
-                .name
-                .to_ascii_lowercase()
-                .contains(&search_term)
-                || app
-                    .extensions
-                    .iter()
-                    .any(|extension| extension.to_ascii_lowercase().contains(&search_term))
-        })
-        .collect()
-}
-
 fn set_default_and_report(extension: &str, app: &Application) {
-    match set_default_app_for_extension(extension, app) {
+    let result = app
+        .bundle_id
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("{} has no readable bundle identifier", app.path.display()))
+        .and_then(|bundle_id| system::set_default_app(extension, bundle_id));
+    match result {
         Ok(()) => println!(
             "✅ Successfully set {} as the default application for .{} files!",
-            app.installed.name.bright_green(),
+            app.name.bright_green(),
             extension.yellow()
         ),
         Err(error) => println!("❌ Failed to set default application: {error:#}"),
     }
-}
-
-fn set_default_app_for_extension(extension: &str, app: &Application) -> Result<()> {
-    ensure_duti_available()?;
-    let bundle_id = get_bundle_id(&app.installed.path)?;
-    let extension_argument = format!(".{extension}");
-
-    let output = Command::new("duti")
-        .args(["-s", &bundle_id, &extension_argument, "all"])
-        .output()
-        .context("failed to run duti")?;
-    if !output.status.success() {
-        bail!(
-            "duti could not apply the setting: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-
-    verify_default_app(extension, &bundle_id)
-}
-
-fn ensure_duti_available() -> Result<()> {
-    let output = Command::new("duti").arg("-V").output().map_err(|error| {
-        if error.kind() == io::ErrorKind::NotFound {
-            anyhow!("duti is required to change defaults; install it with `brew install duti`")
-        } else {
-            anyhow!(error).context("failed to check duti")
-        }
-    })?;
-
-    if !output.status.success() {
-        bail!(
-            "duti is installed but unavailable: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    Ok(())
-}
-
-fn get_bundle_id(app_path: &Path) -> Result<String> {
-    let plist_path = app_path.join("Contents/Info.plist");
-    let output = Command::new("/usr/libexec/PlistBuddy")
-        .args(["-c", "Print :CFBundleIdentifier"])
-        .arg(&plist_path)
-        .output()
-        .with_context(|| format!("failed to read {}", plist_path.display()))?;
-
-    if !output.status.success() {
-        bail!(
-            "could not read the bundle identifier for {}: {}",
-            app_path.display(),
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-
-    let bundle_id = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-    if bundle_id.is_empty() || bundle_id == "(null)" {
-        bail!("{} has no bundle identifier", app_path.display());
-    }
-    Ok(bundle_id)
-}
-
-fn verify_default_app(extension: &str, expected_bundle_id: &str) -> Result<()> {
-    let output = Command::new("duti")
-        .args(["-x", extension])
-        .output()
-        .context("failed to verify the new default application")?;
-    if !output.status.success() {
-        bail!(
-            "duti applied the setting but verification failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-
-    let actual_bundle_id = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .next_back()
-        .unwrap_or_default()
-        .trim()
-        .to_owned();
-    if actual_bundle_id != expected_bundle_id {
-        bail!(
-            "verification returned bundle ID '{}' instead of '{}'",
-            actual_bundle_id,
-            expected_bundle_id
-        );
-    }
-    Ok(())
 }
 
 fn show_all_apps_menu(extension: &str, applications: &[Application]) -> Result<()> {
@@ -387,8 +629,8 @@ fn show_all_apps_menu(extension: &str, applications: &[Application]) -> Result<(
             println!(
                 "   {}. {} ({})",
                 start + index + 1,
-                app.installed.name.bright_blue(),
-                app.installed.path.display()
+                app.name.bright_blue(),
+                app.path.display()
             );
         }
 
@@ -434,10 +676,9 @@ mod tests {
 
     fn app(name: &str, extensions: &[&str]) -> Application {
         Application {
-            installed: InstalledApplication {
-                name: name.to_owned(),
-                path: PathBuf::from(format!("/Applications/{name}.app")),
-            },
+            name: name.to_owned(),
+            path: PathBuf::from(format!("/Applications/{name}.app")),
+            bundle_id: Some(format!("example.{name}")),
             extensions: extensions.iter().map(|value| (*value).to_owned()).collect(),
         }
     }
@@ -455,7 +696,7 @@ mod tests {
         let applications = vec![app("Editor", &["txt", "MD"]), app("Viewer", &["pdf"])];
         let matches = find_apps_for_extension(&applications, "md");
         assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].installed.name, "Editor");
+        assert_eq!(matches[0].name, "Editor");
     }
 
     #[test]
@@ -463,5 +704,27 @@ mod tests {
         let applications = vec![app("Text Editor", &["txt"]), app("Viewer", &["pdf"])];
         assert_eq!(find_fuzzy_matches(&applications, "editor").len(), 1);
         assert_eq!(find_fuzzy_matches(&applications, "pd").len(), 1);
+    }
+
+    #[test]
+    fn json_envelope_includes_api_version() {
+        let value = JsonEnvelope {
+            api_version: API_VERSION,
+            command: "test",
+            data: vec!["ok"],
+        };
+        let json = serde_json::to_value(value).unwrap();
+        assert_eq!(json["api_version"], "1");
+        assert_eq!(json["command"], "test");
+        assert_eq!(json["data"][0], "ok");
+    }
+
+    #[test]
+    fn dry_run_never_calls_mutating_operation() {
+        let status = apply_or_preview(true, "md", "com.example.Editor", |_, _| {
+            panic!("dry-run attempted a mutation")
+        })
+        .unwrap();
+        assert_eq!(status, "planned");
     }
 }

--- a/src/plist_parser.rs
+++ b/src/plist_parser.rs
@@ -5,15 +5,28 @@ use std::path::Path;
 
 pub struct PlistParser;
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AppMetadata {
+    pub bundle_id: Option<String>,
+    pub extensions: Vec<String>,
+}
+
 impl PlistParser {
     pub fn new() -> Self {
         Self
     }
 
-    pub fn parse_extensions(&self, plist_path: &Path) -> Result<Vec<String>> {
+    pub fn parse_metadata(&self, plist_path: &Path) -> Result<AppMetadata> {
         let plist = Value::from_file(plist_path)
             .with_context(|| format!("failed to parse {}", plist_path.display()))?;
-        Ok(extract_extensions(&plist))
+        Ok(AppMetadata {
+            bundle_id: plist
+                .as_dictionary()
+                .and_then(|root| root.get("CFBundleIdentifier"))
+                .and_then(Value::as_string)
+                .map(str::to_owned),
+            extensions: extract_extensions(&plist),
+        })
     }
 }
 
@@ -134,5 +147,28 @@ mod tests {
         )]);
 
         assert_eq!(extract_extensions(&plist), vec!["json"]);
+    }
+
+    #[test]
+    fn extracts_bundle_identifier_with_extensions() {
+        let plist = dictionary([
+            (
+                "CFBundleIdentifier",
+                Value::String("com.example.Editor".into()),
+            ),
+            (
+                "CFBundleDocumentTypes",
+                Value::Array(vec![dictionary([(
+                    "CFBundleTypeExtensions",
+                    Value::String("txt".into()),
+                )])]),
+            ),
+        ]);
+        let root = plist.as_dictionary().unwrap();
+        assert_eq!(
+            root.get("CFBundleIdentifier").and_then(Value::as_string),
+            Some("com.example.Editor")
+        );
+        assert_eq!(extract_extensions(&plist), vec!["txt"]);
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,0 +1,122 @@
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Serialize;
+use std::io;
+use std::process::Command;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct DefaultApplication {
+    pub extension: String,
+    pub name: Option<String>,
+    pub path: Option<String>,
+    pub bundle_id: String,
+}
+
+pub fn duti_version() -> Result<String> {
+    let output = Command::new("duti").arg("-V").output().map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            anyhow!("duti is required; install it with `brew install duti`")
+        } else {
+            anyhow!(error).context("failed to check duti")
+        }
+    })?;
+
+    if !output.status.success() {
+        bail!(
+            "duti is installed but unavailable: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    Ok(if version.is_empty() {
+        "unknown".to_owned()
+    } else {
+        version
+    })
+}
+
+pub fn get_default_app(extension: &str) -> Result<Option<DefaultApplication>> {
+    duti_version()?;
+    let output = Command::new("duti")
+        .args(["-x", extension])
+        .output()
+        .context("failed to query the default application")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("Failed to get default application") {
+            return Ok(None);
+        }
+        bail!("duti could not query .{extension}: {}", stderr.trim());
+    }
+
+    parse_default_app(extension, &String::from_utf8_lossy(&output.stdout)).map(Some)
+}
+
+pub fn set_default_app(extension: &str, bundle_id: &str) -> Result<()> {
+    duti_version()?;
+    let extension_argument = format!(".{extension}");
+    let output = Command::new("duti")
+        .args(["-s", bundle_id, &extension_argument, "all"])
+        .output()
+        .context("failed to run duti")?;
+    if !output.status.success() {
+        bail!(
+            "duti could not apply the setting: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let actual = get_default_app(extension)?
+        .ok_or_else(|| anyhow!("verification found no default application for .{extension}"))?;
+    if actual.bundle_id != bundle_id {
+        bail!(
+            "verification returned bundle ID '{}' instead of '{}'",
+            actual.bundle_id,
+            bundle_id
+        );
+    }
+    Ok(())
+}
+
+fn parse_default_app(extension: &str, output: &str) -> Result<DefaultApplication> {
+    let lines = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let Some(bundle_id) = lines.last() else {
+        bail!("no default application is registered for .{extension}");
+    };
+
+    Ok(DefaultApplication {
+        extension: extension.to_owned(),
+        name: lines.first().map(|value| (*value).to_owned()),
+        path: lines.get(1).map(|value| (*value).to_owned()),
+        bundle_id: (*bundle_id).to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_duti_query_output() {
+        let result = parse_default_app(
+            "txt",
+            "TextEdit\n/System/Applications/TextEdit.app\ncom.apple.TextEdit\n",
+        )
+        .unwrap();
+        assert_eq!(result.extension, "txt");
+        assert_eq!(result.name.as_deref(), Some("TextEdit"));
+        assert_eq!(
+            result.path.as_deref(),
+            Some("/System/Applications/TextEdit.app")
+        );
+        assert_eq!(result.bundle_id, "com.apple.TextEdit");
+    }
+
+    #[test]
+    fn rejects_empty_duti_query_output() {
+        assert!(parse_default_app("unknown", "\n").is_err());
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,45 @@
+use serde_json::Value;
+use std::process::Command;
+
+fn dutis() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_dutis"))
+}
+
+#[test]
+fn reports_package_version() {
+    let output = dutis().arg("--version").output().unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim(),
+        format!("dutis {}", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn json_usage_errors_have_a_stable_envelope_and_exit_code() {
+    let output = dutis()
+        .args(["query", "../../etc/passwd", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stderr.is_empty());
+
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["api_version"], "1");
+    assert_eq!(response["command"], "query");
+    assert_eq!(response["error"]["code"], 2);
+    assert_eq!(response["error"]["kind"], "usage");
+}
+
+#[test]
+fn set_requires_confirmation_before_scanning_or_mutating() {
+    let output = dutis()
+        .args(["set", "md", "com.example.Editor", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "set");
+    assert_eq!(response["error"]["kind"], "usage");
+}


### PR DESCRIPTION
## Summary
- add an AI Agent era product and engineering roadmap
- add list, query, get, set, and doctor commands with versioned JSON output
- require explicit confirmation for writes and support side-effect-free dry runs
- add deterministic app selection, exit-code contracts, docs, and CLI integration tests
- bump the project to v2.5.0 for the existing automatic release workflow

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --all-targets --locked (17 passed)
- cargo build --release --locked
- smoke-tested list/query/get/set/doctor, md/json/pdf queries, name/path/bundle selectors, interactive EOF, and error exit codes

No real default-application mutation was performed; set was exercised with --dry-run.