### PR TITLE
fix: keep Homebrew formula test stable

### DIFF
--- a/scripts/render_homebrew_formula.rb
+++ b/scripts/render_homebrew_formula.rb
@@ -12,19 +12,18 @@ formula = <<~RUBY
     desc "Manage default applications for file extensions on macOS"
     homepage "https://github.com/tsonglew/dutis"
     url "#{url}"
-    version "#{version}"
     sha256 "#{sha256}"
     license "MIT"
 
-    depends_on :macos
     depends_on "duti"
+    depends_on :macos
 
     def install
       bin.install "dutis"
     end
 
     test do
-      assert_match "Dutis - macOS", shell_output("\#{bin}/dutis --help")
+      assert_match version.to_s, shell_output("\#{bin}/dutis --version")
     end
   end
 RUBY


### PR DESCRIPTION
## Summary
- test generated Homebrew formulae through the stable version command
- avoid coupling formula validation to changing help copy

## Verification
- Ruby syntax check passed for the renderer and generated formula
- generated formula contains the requested v2.5.0 version assertion
- all 17 Rust tests passed