### PR TITLE
feat: add declarative association plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -63,6 +63,21 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -116,7 +131,26 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -126,8 +160,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dutis"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -135,6 +179,8 @@ dependencies = [
  "plist",
  "serde",
  "serde_json",
+ "sha2",
+ "toml",
 ]
 
 [[package]]
@@ -142,6 +188,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "hashbrown"
@@ -176,6 +232,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "memchr"
@@ -285,6 +347,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +425,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,19 +484,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -379,61 +505,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "memchr",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"
@@ -21,6 +21,8 @@ clap = { version = "4.5", features = ["derive"] }
 plist = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
+toml = "0.8"
 
 # Terminal output formatting
 colored = "3.1"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A comprehensive Rust application for viewing file extensions supported by macOS 
 - 🧩 **Modern Metadata Support**: Reads legacy document types and modern UTI declarations
 - ✅ **Verified Updates**: Verifies the selected default application after applying it
 - 🤖 **Agent-ready CLI**: Stable JSON output, dry runs, deterministic selectors, and explicit exit codes
+- 📋 **Declarative Configuration**: Plan, diff, apply, and verify a versioned TOML policy
 
 ## Installation
 
@@ -96,10 +97,27 @@ dutis set md com.microsoft.VSCode --yes
 dutis doctor --json
 ```
 
+Manage several associations as one reviewed, idempotent plan:
+
+```bash
+cp dutis.example.toml dutis.toml
+dutis plan dutis.toml --json
+dutis diff dutis.toml
+dutis apply dutis.toml --dry-run
+dutis apply dutis.toml --plan-digest <reviewed-digest> --yes
+```
+
+`apply` rebuilds the plan immediately before changing the system and rejects a
+stale digest. Every change is verified, unchanged entries are skipped, and
+partial failures include a result for every association. See the
+[declarative configuration guide](docs/declarative-configuration.md) for the
+schema and safety contract.
+
 Applications can be selected by exact bundle ID, exact application path, or an
 unambiguous application name. JSON responses use API version `1`. Exit codes are
 `0` for success, `2` for usage errors, `3` for no match, `4` for ambiguous
 selectors, `5` for an unavailable dependency, and `6` for operation failure.
+Declarative apply also uses `7` for a stale plan and `8` for partial failure.
 
 The product and engineering sequence for declarative configuration, rollback,
 MCP, agent policies, profiles, and drift detection is documented in the
@@ -134,6 +152,8 @@ MCP, agent policies, profiles, and drift detection is documented in the
 - **plist**: Native XML and binary plist parsing
 - **clap**: Command parsing and generated help
 - **serde / serde_json**: Versioned machine-readable output
+- **toml**: Strict declarative configuration parsing
+- **sha2**: Deterministic reviewed-plan digests
 
 ## Releases
 

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -50,6 +50,8 @@ Acceptance criteria:
 
 ## Phase 2: Declarative configuration
 
+Status: implemented for v2.6.0
+
 Add a checked-in `dutis.toml` format and idempotent workflows:
 
 ```text
@@ -132,8 +134,8 @@ pipeline across all association types.
 
 ## Near-term engineering sequence
 
-1. Finish and release Phase 1 as the first stable automation contract.
-2. Extract the catalog and system adapter into a library crate before Phase 2.
-3. Write the configuration and plan schemas before implementing `apply`.
-4. Build rollback before exposing any autonomous or continuously running mode.
-5. Add MCP and skills only on top of the tested CLI/library semantics.
+1. Release Phase 2 and validate declarative apply across representative macOS
+   application sets.
+2. Build snapshots and rollback before exposing any autonomous or continuously
+   running mode.
+3. Add MCP and skills only on top of the tested CLI/library semantics.

--- a/docs/declarative-configuration.md
+++ b/docs/declarative-configuration.md
@@ -1,0 +1,92 @@
+# Declarative configuration
+
+Dutis v2.6 adds a versioned TOML configuration and a reviewable
+`plan -> apply -> verify` workflow for scripts and AI agents.
+
+## Schema version 1
+
+```toml
+version = 1
+
+[associations]
+md = "com.microsoft.VSCode"
+json = "/Applications/Visual Studio Code.app"
+txt = "TextEdit"
+```
+
+Association keys are filename extensions. A leading dot and uppercase letters
+are accepted and normalized. Each value must resolve to exactly one installed
+application using, in priority order:
+
+1. Exact application path.
+2. Exact bundle identifier.
+3. Case-insensitive, unambiguous application name.
+
+Unknown fields, unsupported schema versions, invalid extensions, empty
+selectors, and duplicate normalized extensions are rejected.
+
+## Review and apply
+
+Create a plan without changing the system:
+
+```bash
+dutis plan dutis.toml
+dutis plan dutis.toml --json
+```
+
+The plan records current and desired bundle identifiers, resolved application
+paths, changes, unchanged entries, unresolved selectors, and a SHA-256 digest.
+The digest covers the normalized desired state and the current state.
+
+Show only differences and unresolved entries:
+
+```bash
+dutis diff dutis.toml
+```
+
+Preview the apply path without making changes:
+
+```bash
+dutis apply dutis.toml --dry-run --json
+```
+
+Apply a reviewed plan by copying its digest:
+
+```bash
+dutis apply dutis.toml \
+  --plan-digest <digest-from-plan> \
+  --yes \
+  --json
+```
+
+Dutis rebuilds the plan immediately before applying it. If defaults, installed
+applications, or configuration changed since review, the digest differs and
+the command exits with code `7` without making changes.
+
+Each changed association is applied and read back for verification. An error
+for one association does not hide other results: Dutis continues, returns every
+per-entry result, and exits with code `8` when any item fails. Entries already
+in the desired state are skipped, so reapplying a converged configuration is a
+no-op.
+
+## Versioning and migration
+
+- `version` is the configuration schema version and is currently `1`.
+- `schema_version` in plan JSON is currently `1`.
+- `api_version` in the CLI JSON envelope remains `1`.
+- Unknown configuration fields are rejected so misspellings cannot silently
+  change policy.
+- A future incompatible schema will use a new configuration version and include
+  explicit migration documentation. Dutis never silently upgrades a file.
+
+## Exit codes
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | Success, including a converged no-op |
+| `2` | Invalid command or configuration |
+| `3` | Unresolved application selector |
+| `5` | `duti` is unavailable |
+| `6` | State inspection or operation failed |
+| `7` | Reviewed plan is stale |
+| `8` | One or more associations failed to apply or verify |

--- a/dutis.example.toml
+++ b/dutis.example.toml
@@ -1,0 +1,7 @@
+# Dutis declarative configuration schema v1.
+version = 1
+
+# Values may be an exact bundle ID, exact .app path, or unique application name.
+[associations]
+md = "com.apple.TextEdit"
+txt = "com.apple.TextEdit"

--- a/src/app_scanner.rs
+++ b/src/app_scanner.rs
@@ -7,6 +7,7 @@ pub struct InstalledApplication {
     pub path: PathBuf,
 }
 
+#[derive(Default)]
 pub struct AppScanner;
 
 impl AppScanner {

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,6 +1,6 @@
 use crate::app_scanner::AppScanner;
 use crate::plist_parser::PlistParser;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -106,6 +106,20 @@ pub fn resolve_app<'a>(applications: &'a [Application], selector: &str) -> Vec<&
         .collect()
 }
 
+pub fn normalize_extension(input: &str) -> Result<String> {
+    let extension = input.trim().trim_start_matches('.').to_ascii_lowercase();
+    if extension.is_empty() {
+        bail!("please enter a valid file extension");
+    }
+    if !extension
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '_'))
+    {
+        bail!("file extensions may only contain letters, numbers, '+', '-' or '_'");
+    }
+    Ok(extension)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,5 +160,13 @@ mod tests {
             ),
         ];
         assert_eq!(resolve_app(&applications, "Editor").len(), 2);
+    }
+
+    #[test]
+    fn normalizes_and_validates_extensions() {
+        assert_eq!(normalize_extension(" .TXT ").unwrap(), "txt");
+        assert_eq!(normalize_extension("c++").unwrap(), "c++");
+        assert!(normalize_extension("../../txt").is_err());
+        assert!(normalize_extension("...").is_err());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -22,6 +23,12 @@ pub enum CliCommand {
     Get(ExtensionArgs),
     /// Set the default application for an extension
     Set(SetArgs),
+    /// Build a deterministic plan from a declarative configuration
+    Plan(ConfigArgs),
+    /// Show associations that differ from a declarative configuration
+    Diff(ConfigArgs),
+    /// Apply and verify a previously reviewed declarative plan
+    Apply(ApplyArgs),
     /// Check whether dutis and its runtime dependency are ready
     Doctor(OutputArgs),
 }
@@ -49,6 +56,33 @@ pub struct SetArgs {
     /// Exact bundle ID, application path, or unambiguous application name
     pub app_selector: String,
     /// Resolve and display the operation without changing the system
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Confirm a non-interactive system change
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct ConfigArgs {
+    /// Path to a versioned dutis TOML configuration
+    pub config: PathBuf,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct ApplyArgs {
+    /// Path to a versioned dutis TOML configuration
+    pub config: PathBuf,
+    /// Digest returned by a freshly reviewed plan command
+    #[arg(long)]
+    pub plan_digest: Option<String>,
+    /// Rebuild and display the plan without changing the system
     #[arg(long)]
     pub dry_run: bool,
     /// Confirm a non-interactive system change
@@ -90,5 +124,35 @@ mod tests {
                 ..
             }))
         ));
+
+        let cli = Cli::try_parse_from([
+            "dutis",
+            "apply",
+            "dutis.toml",
+            "--plan-digest",
+            "abc123",
+            "--yes",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Apply(ApplyArgs {
+                dry_run: false,
+                yes: true,
+                json: true,
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn parses_apply_safety_options_for_structured_validation() {
+        assert!(Cli::try_parse_from(["dutis", "apply", "dutis.toml", "--yes"]).is_ok());
+        assert!(
+            Cli::try_parse_from(["dutis", "apply", "dutis.toml", "--plan-digest", "abc123"])
+                .is_ok()
+        );
+        assert!(Cli::try_parse_from(["dutis", "apply", "dutis.toml", "--dry-run"]).is_ok());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,100 @@
+use crate::application::normalize_extension;
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+pub const CONFIG_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DutisConfig {
+    pub version: u32,
+    pub associations: BTreeMap<String, String>,
+}
+
+impl DutisConfig {
+    pub fn load(path: &Path) -> Result<Self> {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read configuration {}", path.display()))?;
+        Self::parse(&contents).with_context(|| format!("invalid configuration {}", path.display()))
+    }
+
+    pub fn parse(contents: &str) -> Result<Self> {
+        let parsed: Self = toml::from_str(contents).context("failed to parse TOML")?;
+        if parsed.version != CONFIG_VERSION {
+            bail!(
+                "unsupported configuration version {}; expected {}",
+                parsed.version,
+                CONFIG_VERSION
+            );
+        }
+
+        let mut associations = BTreeMap::new();
+        for (input_extension, input_selector) in parsed.associations {
+            let extension = normalize_extension(&input_extension)?;
+            let selector = input_selector.trim();
+            if selector.is_empty() {
+                bail!("application selector for .{extension} cannot be empty");
+            }
+            if associations
+                .insert(extension.clone(), selector.to_owned())
+                .is_some()
+            {
+                bail!("duplicate normalized extension .{extension}");
+            }
+        }
+
+        Ok(Self {
+            version: parsed.version,
+            associations,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_and_normalizes_versioned_configuration() {
+        let config = DutisConfig::parse(
+            r#"
+                version = 1
+
+                [associations]
+                ".MD" = "com.example.Editor"
+                json = "/Applications/Editor.app"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.version, 1);
+        assert_eq!(config.associations["md"], "com.example.Editor");
+        assert_eq!(config.associations["json"], "/Applications/Editor.app");
+    }
+
+    #[test]
+    fn rejects_unknown_versions_and_duplicate_normalized_extensions() {
+        assert!(DutisConfig::parse("version = 2\n[associations]\nmd = 'Editor'").is_err());
+        assert!(
+            DutisConfig::parse("version = 1\n[associations]\nmd = 'Editor'\n'.MD' = 'Other'")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_fields_and_empty_selectors() {
+        assert!(
+            DutisConfig::parse("version = 1\nextra = true\n[associations]\nmd = 'Editor'").is_err()
+        );
+        assert!(DutisConfig::parse("version = 1\n[associations]\nmd = '   '").is_err());
+    }
+
+    #[test]
+    fn repository_example_uses_the_current_schema() {
+        let config = DutisConfig::parse(include_str!("../dutis.example.toml")).unwrap();
+        assert_eq!(config.version, CONFIG_VERSION);
+        assert!(!config.associations.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod app_scanner;
+pub mod application;
+pub mod config;
+pub mod planner;
+pub mod plist_parser;
+pub mod system;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,23 @@
-use anyhow::{bail, Context, Result};
-use application::{
-    find_apps_for_extension, find_fuzzy_matches, resolve_app, Application, ApplicationCatalog,
-};
+use anyhow::{Context, Result};
 use clap::Parser;
-use cli::{Cli, CliCommand, ExtensionArgs, OutputArgs, SetArgs};
+use cli::{ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, OutputArgs, SetArgs};
 use colored::*;
+use dutis::application::{
+    find_apps_for_extension, find_fuzzy_matches, normalize_extension, resolve_app, Application,
+    ApplicationCatalog,
+};
+use dutis::config::DutisConfig;
+use dutis::planner::{
+    apply_plan, build_plan, ApplyReport, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
+};
+use dutis::system;
 use serde::Serialize;
+use serde_json::Value;
 use std::io::{self, Write};
+use std::path::Path;
 use std::process::ExitCode;
 
-mod app_scanner;
-mod application;
 mod cli;
-mod plist_parser;
-mod system;
 
 const API_VERSION: &str = "1";
 
@@ -22,6 +26,7 @@ struct CliError {
     code: u8,
     kind: &'static str,
     message: String,
+    details: Option<Value>,
 }
 
 impl CliError {
@@ -45,12 +50,26 @@ impl CliError {
         Self::new(6, "operation_failed", message)
     }
 
+    fn stale_plan(message: impl Into<String>, details: Value) -> Self {
+        Self::new(7, "stale_plan", message).with_details(details)
+    }
+
+    fn partial_failure(message: impl Into<String>, details: Value) -> Self {
+        Self::new(8, "partial_failure", message).with_details(details)
+    }
+
     fn new(code: u8, kind: &'static str, message: impl Into<String>) -> Self {
         Self {
             code,
             kind,
             message: message.into(),
+            details: None,
         }
+    }
+
+    fn with_details(mut self, details: Value) -> Self {
+        self.details = Some(details);
+        self
     }
 }
 
@@ -73,6 +92,8 @@ struct JsonError<'a> {
     code: u8,
     kind: &'static str,
     message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<&'a Value>,
 }
 
 #[derive(Serialize)]
@@ -105,6 +126,13 @@ struct DoctorResult {
     ready_for_changes: bool,
 }
 
+#[derive(Serialize)]
+struct DiffResult<'a> {
+    plan_digest: &'a str,
+    summary: &'a PlanSummary,
+    entries: Vec<&'a PlanEntry>,
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     let command_name = cli
@@ -125,6 +153,7 @@ fn main() -> ExitCode {
                         code: error.code,
                         kind: error.kind,
                         message: &error.message,
+                        details: error.details.as_ref(),
                     },
                 };
                 if let Err(serialization_error) = write_json(&response) {
@@ -145,6 +174,9 @@ fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
         Some(CliCommand::Query(args)) => run_query(args),
         Some(CliCommand::Get(args)) => run_get(args),
         Some(CliCommand::Set(args)) => run_set(args),
+        Some(CliCommand::Plan(args)) => run_plan(args),
+        Some(CliCommand::Diff(args)) => run_diff(args),
+        Some(CliCommand::Apply(args)) => run_apply(args),
         Some(CliCommand::Doctor(args)) => run_doctor(args),
     }
 }
@@ -155,6 +187,9 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Query(_) => "query",
         CliCommand::Get(_) => "get",
         CliCommand::Set(_) => "set",
+        CliCommand::Plan(_) => "plan",
+        CliCommand::Diff(_) => "diff",
+        CliCommand::Apply(_) => "apply",
         CliCommand::Doctor(_) => "doctor",
     }
 }
@@ -164,6 +199,8 @@ fn command_uses_json(command: &CliCommand) -> bool {
         CliCommand::List(args) | CliCommand::Doctor(args) => args.json,
         CliCommand::Query(args) | CliCommand::Get(args) => args.json,
         CliCommand::Set(args) => args.json,
+        CliCommand::Plan(args) | CliCommand::Diff(args) => args.json,
+        CliCommand::Apply(args) => args.json,
     }
 }
 
@@ -332,6 +369,194 @@ fn run_set(args: SetArgs) -> Result<(), CliError> {
         );
     }
     Ok(())
+}
+
+fn run_plan(args: ConfigArgs) -> Result<(), CliError> {
+    let plan = build_declarative_plan(&args.config)?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "plan",
+            data: plan,
+        })?;
+    } else {
+        print_plan(&plan, false);
+    }
+    Ok(())
+}
+
+fn run_diff(args: ConfigArgs) -> Result<(), CliError> {
+    let plan = build_declarative_plan(&args.config)?;
+    if args.json {
+        let entries = plan
+            .entries
+            .iter()
+            .filter(|entry| entry.action != PlanAction::Unchanged)
+            .collect();
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "diff",
+            data: DiffResult {
+                plan_digest: &plan.digest,
+                summary: &plan.summary,
+                entries,
+            },
+        })?;
+    } else {
+        print_plan(&plan, true);
+    }
+    Ok(())
+}
+
+fn run_apply(args: ApplyArgs) -> Result<(), CliError> {
+    if !args.dry_run && !args.yes {
+        return Err(CliError::usage(
+            "refusing to apply configuration without --yes; use --dry-run to preview",
+        ));
+    }
+    if !args.dry_run && args.plan_digest.is_none() {
+        return Err(CliError::usage(
+            "--plan-digest is required when applying changes",
+        ));
+    }
+
+    let plan = build_declarative_plan(&args.config)?;
+    if args.dry_run {
+        if args.json {
+            write_json(&JsonEnvelope {
+                api_version: API_VERSION,
+                command: "apply",
+                data: plan,
+            })?;
+        } else {
+            println!("Dry run; no associations will be changed.\n");
+            print_plan(&plan, false);
+        }
+        return Ok(());
+    }
+
+    if plan.has_unresolved() {
+        let details = serde_json::to_value(&plan)
+            .map_err(|error| CliError::operation(format!("failed to serialize plan: {error}")))?;
+        if !args.json {
+            print_plan(&plan, false);
+        }
+        return Err(CliError::not_found(format!(
+            "plan contains {} unresolved association(s); no changes were made",
+            plan.summary.unresolved
+        ))
+        .with_details(details));
+    }
+
+    let reviewed_digest = args
+        .plan_digest
+        .as_deref()
+        .ok_or_else(|| CliError::usage("--plan-digest is required when applying changes"))?;
+    if reviewed_digest != plan.digest {
+        return Err(CliError::stale_plan(
+            "current state no longer matches the reviewed plan; run `dutis plan` again",
+            serde_json::json!({
+                "reviewed_digest": reviewed_digest,
+                "current_digest": plan.digest,
+            }),
+        ));
+    }
+
+    let report = apply_plan(&plan, system::set_default_app);
+    if report.failed > 0 {
+        let details = serde_json::to_value(&report)
+            .map_err(|error| CliError::operation(format!("failed to serialize report: {error}")))?;
+        if !args.json {
+            print_apply_report(&report);
+        }
+        return Err(CliError::partial_failure(
+            format!(
+                "{} association(s) failed; {} applied and {} skipped",
+                report.failed, report.applied, report.skipped
+            ),
+            details,
+        ));
+    }
+
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "apply",
+            data: report,
+        })?;
+    } else {
+        print_apply_report(&report);
+    }
+    Ok(())
+}
+
+fn build_declarative_plan(path: &Path) -> Result<AssociationPlan, CliError> {
+    let config = DutisConfig::load(path).map_err(|error| CliError::usage(format!("{error:#}")))?;
+    let catalog = scan_catalog()?;
+    report_metadata_failures(catalog.metadata_failures);
+    system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
+    build_plan(&config, &catalog.applications, system::query_default_app)
+        .map_err(|error| CliError::operation(format!("failed to inspect current state: {error:#}")))
+}
+
+fn print_plan(plan: &AssociationPlan, changes_only: bool) {
+    for entry in &plan.entries {
+        if changes_only && entry.action == PlanAction::Unchanged {
+            continue;
+        }
+        match entry.action {
+            PlanAction::Change => {
+                let current = entry
+                    .current
+                    .as_ref()
+                    .map(|app| app.bundle_id.as_str())
+                    .unwrap_or("<none>");
+                let target = entry
+                    .target
+                    .as_ref()
+                    .map(|app| app.bundle_id.as_str())
+                    .unwrap_or("<unresolved>");
+                println!("CHANGE    .{}: {} -> {}", entry.extension, current, target);
+            }
+            PlanAction::Unchanged => {
+                let bundle_id = entry
+                    .target
+                    .as_ref()
+                    .map(|app| app.bundle_id.as_str())
+                    .unwrap_or("<unknown>");
+                println!("UNCHANGED .{}: {}", entry.extension, bundle_id);
+            }
+            PlanAction::Unresolved => println!(
+                "UNRESOLVED .{}: {}",
+                entry.extension,
+                entry.reason.as_deref().unwrap_or("unknown reason")
+            ),
+        }
+    }
+    println!(
+        "\nSummary: {} change(s), {} unchanged, {} unresolved",
+        plan.summary.changes, plan.summary.unchanged, plan.summary.unresolved
+    );
+    println!("Plan digest: {}", plan.digest);
+}
+
+fn print_apply_report(report: &ApplyReport) {
+    for result in &report.results {
+        println!(
+            "{:?} .{}{}",
+            result.status,
+            result.extension,
+            result
+                .error
+                .as_ref()
+                .map(|error| format!(": {error}"))
+                .unwrap_or_default()
+        );
+    }
+    println!(
+        "\nApplied: {}, skipped: {}, failed: {}",
+        report.applied, report.skipped, report.failed
+    );
 }
 
 fn apply_or_preview<F>(
@@ -558,20 +783,6 @@ fn read_prompt(prompt: &str) -> Result<Option<String>> {
     Ok((bytes_read != 0).then_some(input))
 }
 
-fn normalize_extension(input: &str) -> Result<String> {
-    let extension = input.trim().trim_start_matches('.').to_ascii_lowercase();
-    if extension.is_empty() {
-        bail!("please enter a valid file extension");
-    }
-    if !extension
-        .chars()
-        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '_'))
-    {
-        bail!("file extensions may only contain letters, numbers, '+', '-' or '_'");
-    }
-    Ok(extension)
-}
-
 fn display_debug_info(applications: &[Application]) {
     let with_extensions = applications
         .iter()
@@ -681,14 +892,6 @@ mod tests {
             bundle_id: Some(format!("example.{name}")),
             extensions: extensions.iter().map(|value| (*value).to_owned()).collect(),
         }
-    }
-
-    #[test]
-    fn normalizes_extensions() {
-        assert_eq!(normalize_extension(" .TXT ").unwrap(), "txt");
-        assert_eq!(normalize_extension("c++").unwrap(), "c++");
-        assert!(normalize_extension("../../txt").is_err());
-        assert!(normalize_extension("...").is_err());
     }
 
     #[test]

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -1,0 +1,415 @@
+use crate::application::{resolve_app, Application};
+use crate::config::DutisConfig;
+use crate::system::DefaultApplication;
+use anyhow::Result;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+
+pub const PLAN_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanAction {
+    Change,
+    Unchanged,
+    Unresolved,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct PlannedApplication {
+    pub name: String,
+    pub path: PathBuf,
+    pub bundle_id: String,
+}
+
+impl PlannedApplication {
+    fn from_application(application: &Application) -> Option<Self> {
+        Some(Self {
+            name: application.name.clone(),
+            path: application.path.clone(),
+            bundle_id: application.bundle_id.clone()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct PlanEntry {
+    pub extension: String,
+    pub selector: String,
+    pub current: Option<DefaultApplication>,
+    pub target: Option<PlannedApplication>,
+    pub action: PlanAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct PlanSummary {
+    pub total: usize,
+    pub changes: usize,
+    pub unchanged: usize,
+    pub unresolved: usize,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct AssociationPlan {
+    pub schema_version: u32,
+    pub config_version: u32,
+    pub digest: String,
+    pub summary: PlanSummary,
+    pub entries: Vec<PlanEntry>,
+}
+
+impl AssociationPlan {
+    pub fn has_unresolved(&self) -> bool {
+        self.summary.unresolved > 0
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyStatus {
+    Applied,
+    Skipped,
+    Failed,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ApplyEntryResult {
+    pub extension: String,
+    pub bundle_id: Option<String>,
+    pub status: ApplyStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ApplyReport {
+    pub plan_digest: String,
+    pub applied: usize,
+    pub skipped: usize,
+    pub failed: usize,
+    pub results: Vec<ApplyEntryResult>,
+}
+
+pub fn build_plan<F>(
+    config: &DutisConfig,
+    applications: &[Application],
+    mut query_default: F,
+) -> Result<AssociationPlan>
+where
+    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+{
+    let mut entries = Vec::with_capacity(config.associations.len());
+    for (extension, selector) in &config.associations {
+        let matches = resolve_app(applications, selector);
+        let entry = match matches.as_slice() {
+            [] => unresolved_entry(
+                extension,
+                selector,
+                format!("no installed application matches '{selector}'"),
+            ),
+            [application] if application.bundle_id.is_none() => unresolved_entry(
+                extension,
+                selector,
+                format!(
+                    "{} has no readable bundle identifier",
+                    application.path.display()
+                ),
+            ),
+            [application] => {
+                let current = query_default(extension)?;
+                let action = if current.as_ref().map(|app| app.bundle_id.as_str())
+                    == application.bundle_id.as_deref()
+                {
+                    PlanAction::Unchanged
+                } else {
+                    PlanAction::Change
+                };
+                PlanEntry {
+                    extension: extension.clone(),
+                    selector: selector.clone(),
+                    current,
+                    target: PlannedApplication::from_application(application),
+                    action,
+                    reason: None,
+                }
+            }
+            matches => unresolved_entry(
+                extension,
+                selector,
+                format!(
+                    "selector is ambiguous: {}",
+                    matches
+                        .iter()
+                        .map(|app| app.path.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            ),
+        };
+        entries.push(entry);
+    }
+
+    let summary = summarize(&entries);
+    let digest = calculate_digest(config.version, &entries)?;
+    Ok(AssociationPlan {
+        schema_version: PLAN_SCHEMA_VERSION,
+        config_version: config.version,
+        digest,
+        summary,
+        entries,
+    })
+}
+
+pub fn apply_plan<F>(plan: &AssociationPlan, mut apply: F) -> ApplyReport
+where
+    F: FnMut(&str, &str) -> Result<()>,
+{
+    let mut results = Vec::with_capacity(plan.entries.len());
+    for entry in &plan.entries {
+        let result = match entry.action {
+            PlanAction::Unchanged => ApplyEntryResult {
+                extension: entry.extension.clone(),
+                bundle_id: entry.target.as_ref().map(|target| target.bundle_id.clone()),
+                status: ApplyStatus::Skipped,
+                error: None,
+            },
+            PlanAction::Unresolved => ApplyEntryResult {
+                extension: entry.extension.clone(),
+                bundle_id: None,
+                status: ApplyStatus::Failed,
+                error: entry.reason.clone(),
+            },
+            PlanAction::Change => {
+                let bundle_id = entry
+                    .target
+                    .as_ref()
+                    .map(|target| target.bundle_id.as_str())
+                    .expect("resolved plan entries have bundle IDs");
+                match apply(&entry.extension, bundle_id) {
+                    Ok(()) => ApplyEntryResult {
+                        extension: entry.extension.clone(),
+                        bundle_id: Some(bundle_id.to_owned()),
+                        status: ApplyStatus::Applied,
+                        error: None,
+                    },
+                    Err(error) => ApplyEntryResult {
+                        extension: entry.extension.clone(),
+                        bundle_id: Some(bundle_id.to_owned()),
+                        status: ApplyStatus::Failed,
+                        error: Some(format!("{error:#}")),
+                    },
+                }
+            }
+        };
+        results.push(result);
+    }
+
+    ApplyReport {
+        plan_digest: plan.digest.clone(),
+        applied: results
+            .iter()
+            .filter(|result| result.status == ApplyStatus::Applied)
+            .count(),
+        skipped: results
+            .iter()
+            .filter(|result| result.status == ApplyStatus::Skipped)
+            .count(),
+        failed: results
+            .iter()
+            .filter(|result| result.status == ApplyStatus::Failed)
+            .count(),
+        results,
+    }
+}
+
+fn unresolved_entry(extension: &str, selector: &str, reason: String) -> PlanEntry {
+    PlanEntry {
+        extension: extension.to_owned(),
+        selector: selector.to_owned(),
+        current: None,
+        target: None,
+        action: PlanAction::Unresolved,
+        reason: Some(reason),
+    }
+}
+
+fn summarize(entries: &[PlanEntry]) -> PlanSummary {
+    PlanSummary {
+        total: entries.len(),
+        changes: entries
+            .iter()
+            .filter(|entry| entry.action == PlanAction::Change)
+            .count(),
+        unchanged: entries
+            .iter()
+            .filter(|entry| entry.action == PlanAction::Unchanged)
+            .count(),
+        unresolved: entries
+            .iter()
+            .filter(|entry| entry.action == PlanAction::Unresolved)
+            .count(),
+    }
+}
+
+#[derive(Serialize)]
+struct DigestMaterial<'a> {
+    schema_version: u32,
+    config_version: u32,
+    entries: Vec<DigestEntry<'a>>,
+}
+
+#[derive(Serialize)]
+struct DigestEntry<'a> {
+    extension: &'a str,
+    selector: &'a str,
+    current_bundle_id: Option<&'a str>,
+    target_bundle_id: Option<&'a str>,
+    target_path: Option<String>,
+    action: PlanAction,
+    reason: Option<&'a str>,
+}
+
+fn calculate_digest(config_version: u32, entries: &[PlanEntry]) -> Result<String> {
+    let material = DigestMaterial {
+        schema_version: PLAN_SCHEMA_VERSION,
+        config_version,
+        entries: entries
+            .iter()
+            .map(|entry| DigestEntry {
+                extension: &entry.extension,
+                selector: &entry.selector,
+                current_bundle_id: entry.current.as_ref().map(|app| app.bundle_id.as_str()),
+                target_bundle_id: entry.target.as_ref().map(|app| app.bundle_id.as_str()),
+                target_path: entry
+                    .target
+                    .as_ref()
+                    .map(|app| app.path.display().to_string()),
+                action: entry.action,
+                reason: entry.reason.as_deref(),
+            })
+            .collect(),
+    };
+    let canonical = serde_json::to_vec(&material)?;
+    let hash = Sha256::digest(canonical);
+    Ok(hash.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn app(name: &str, bundle_id: &str) -> Application {
+        Application {
+            name: name.to_owned(),
+            path: PathBuf::from(format!("/Applications/{name}.app")),
+            bundle_id: Some(bundle_id.to_owned()),
+            extensions: vec!["md".to_owned(), "json".to_owned()],
+        }
+    }
+
+    fn config(entries: &[(&str, &str)]) -> DutisConfig {
+        DutisConfig {
+            version: 1,
+            associations: entries
+                .iter()
+                .map(|(extension, selector)| ((*extension).to_owned(), (*selector).to_owned()))
+                .collect::<BTreeMap<_, _>>(),
+        }
+    }
+
+    fn current(extension: &str, bundle_id: &str) -> DefaultApplication {
+        DefaultApplication {
+            extension: extension.to_owned(),
+            name: None,
+            path: None,
+            bundle_id: bundle_id.to_owned(),
+        }
+    }
+
+    #[test]
+    fn builds_deterministic_change_and_unchanged_plan() {
+        let applications = vec![app("Editor", "com.example.Editor")];
+        let config = config(&[("json", "Editor"), ("md", "com.example.Editor")]);
+        let build = || {
+            build_plan(&config, &applications, |extension| {
+                Ok(Some(if extension == "md" {
+                    current(extension, "com.example.Editor")
+                } else {
+                    current(extension, "com.example.Other")
+                }))
+            })
+            .unwrap()
+        };
+
+        let first = build();
+        let second = build();
+        assert_eq!(first.digest, second.digest);
+        assert_eq!(first.digest.len(), 64);
+        assert_eq!(first.summary.changes, 1);
+        assert_eq!(first.summary.unchanged, 1);
+        assert_eq!(first.entries[0].action, PlanAction::Change);
+        assert_eq!(first.entries[1].action, PlanAction::Unchanged);
+    }
+
+    #[test]
+    fn current_state_changes_the_digest() {
+        let applications = vec![app("Editor", "com.example.Editor")];
+        let config = config(&[("md", "Editor")]);
+        let missing = build_plan(&config, &applications, |_| Ok(None)).unwrap();
+        let converged = build_plan(&config, &applications, |extension| {
+            Ok(Some(current(extension, "com.example.Editor")))
+        })
+        .unwrap();
+        assert_ne!(missing.digest, converged.digest);
+    }
+
+    #[test]
+    fn records_unresolved_and_ambiguous_selectors() {
+        let applications = vec![
+            app("Editor", "com.example.Editor"),
+            app("Editor", "com.example.EditorBeta"),
+        ];
+        let config = config(&[("json", "Missing"), ("md", "Editor")]);
+        let plan = build_plan(&config, &applications, |_| {
+            panic!("unresolved entries must not query current state")
+        })
+        .unwrap();
+        assert_eq!(plan.summary.unresolved, 2);
+        assert!(plan.has_unresolved());
+    }
+
+    #[test]
+    fn apply_continues_after_a_partial_failure() {
+        let applications = vec![app("Editor", "com.example.Editor")];
+        let config = config(&[("json", "Editor"), ("md", "Editor")]);
+        let plan = build_plan(&config, &applications, |_| Ok(None)).unwrap();
+        let report = apply_plan(&plan, |extension, _| {
+            if extension == "json" {
+                anyhow::bail!("simulated failure");
+            }
+            Ok(())
+        });
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.failed, 1);
+        assert_eq!(report.results.len(), 2);
+    }
+
+    #[test]
+    fn converged_apply_is_idempotent() {
+        let applications = vec![app("Editor", "com.example.Editor")];
+        let config = config(&[("md", "Editor")]);
+        let plan = build_plan(&config, &applications, |extension| {
+            Ok(Some(current(extension, "com.example.Editor")))
+        })
+        .unwrap();
+        let report = apply_plan(&plan, |_, _| panic!("unchanged entry was applied"));
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.skipped, 1);
+        assert_eq!(report.failed, 0);
+    }
+}

--- a/src/plist_parser.rs
+++ b/src/plist_parser.rs
@@ -3,6 +3,7 @@ use plist::{Dictionary, Value};
 use std::collections::BTreeSet;
 use std::path::Path;
 
+#[derive(Default)]
 pub struct PlistParser;
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/src/system.rs
+++ b/src/system.rs
@@ -36,6 +36,10 @@ pub fn duti_version() -> Result<String> {
 
 pub fn get_default_app(extension: &str) -> Result<Option<DefaultApplication>> {
     duti_version()?;
+    query_default_app(extension)
+}
+
+pub fn query_default_app(extension: &str) -> Result<Option<DefaultApplication>> {
     let output = Command::new("duti")
         .args(["-x", extension])
         .output()
@@ -65,7 +69,7 @@ pub fn set_default_app(extension: &str, bundle_id: &str) -> Result<()> {
         );
     }
 
-    let actual = get_default_app(extension)?
+    let actual = query_default_app(extension)?
         .ok_or_else(|| anyhow!("verification found no default application for .{extension}"))?;
     if actual.bundle_id != bundle_id {
         bail!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -43,3 +43,21 @@ fn set_requires_confirmation_before_scanning_or_mutating() {
     assert_eq!(response["command"], "set");
     assert_eq!(response["error"]["kind"], "usage");
 }
+
+#[test]
+fn apply_requires_a_reviewed_digest_before_reading_configuration() {
+    let output = dutis()
+        .args(["apply", "missing.toml", "--yes", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stderr.is_empty());
+
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "apply");
+    assert_eq!(response["error"]["kind"], "usage");
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("--plan-digest"));
+}


### PR DESCRIPTION
## Summary
- implement roadmap Phase 2 with versioned TOML configuration
- add plan, diff, and apply commands with deterministic SHA-256 plan digests
- reject stale plans before mutation and require explicit confirmation
- verify each applied association, preserve per-entry partial failure results, and skip converged entries
- extract application, configuration, planning, and system operations into a reusable library core
- add schema documentation, example configuration, JSON error details, and v2.6.0 release version

## Safety
- apply dry-run never invokes mutation
- real apply requires both a reviewed digest and yes confirmation
- unresolved selectors prevent all changes
- stale state exits with code 7 before changes
- partial apply or verification failures exit with code 8 and include all results

## Verification
- cargo fmt check
- cargo clippy with warnings denied
- cargo test: 28 passed
- release build
- cargo package verification
- live plan, diff, dry-run, unresolved selector, invalid config, and stale digest smoke tests

No real default-application changes were performed during verification.