### PR TITLE
feat: add snapshots and rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -180,6 +180,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "time",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"
@@ -22,6 +22,7 @@ plist = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+time = { version = "0.3", features = ["formatting"] }
 toml = "0.8"
 
 # Terminal output formatting

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A comprehensive Rust application for viewing file extensions supported by macOS 
 - ✅ **Verified Updates**: Verifies the selected default application after applying it
 - 🤖 **Agent-ready CLI**: Stable JSON output, dry runs, deterministic selectors, and explicit exit codes
 - 📋 **Declarative Configuration**: Plan, diff, apply, and verify a versioned TOML policy
+- ↩️ **Snapshots and Rollback**: Persist pre-change state and restore it through the verified plan pipeline
 
 ## Installation
 
@@ -113,6 +114,20 @@ partial failures include a result for every association. See the
 [declarative configuration guide](docs/declarative-configuration.md) for the
 schema and safety contract.
 
+Create, inspect, and restore local snapshots:
+
+```bash
+dutis snapshot create --config dutis.toml
+dutis history
+dutis rollback <snapshot-id> --dry-run
+dutis rollback <snapshot-id> --yes
+```
+
+Real declarative applies and rollbacks automatically store a safety snapshot
+before the first mutation. See [snapshots and rollback](docs/snapshots-and-rollback.md)
+for storage, recovery behavior, and the safe limitation around removing an
+association.
+
 Applications can be selected by exact bundle ID, exact application path, or an
 unambiguous application name. JSON responses use API version `1`. Exit codes are
 `0` for success, `2` for usage errors, `3` for no match, `4` for ambiguous
@@ -154,6 +169,7 @@ MCP, agent policies, profiles, and drift detection is documented in the
 - **serde / serde_json**: Versioned machine-readable output
 - **toml**: Strict declarative configuration parsing
 - **sha2**: Deterministic reviewed-plan digests
+- **time**: Portable RFC 3339 snapshot timestamps
 
 ## Releases
 

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -72,6 +72,8 @@ Acceptance criteria:
 
 ## Phase 3: Snapshots, history, and rollback
 
+Status: implemented for v2.7.0
+
 Capture associations before every multi-item apply and expose:
 
 ```text
@@ -134,8 +136,7 @@ pipeline across all association types.
 
 ## Near-term engineering sequence
 
-1. Release Phase 2 and validate declarative apply across representative macOS
+1. Release Phase 3 and validate snapshot recovery across representative macOS
    application sets.
-2. Build snapshots and rollback before exposing any autonomous or continuously
-   running mode.
-3. Add MCP and skills only on top of the tested CLI/library semantics.
+2. Expose the stable read, plan, apply, and rollback core through MCP.
+3. Add agent skills and policy controls before any autonomous mode.

--- a/docs/snapshots-and-rollback.md
+++ b/docs/snapshots-and-rollback.md
@@ -1,0 +1,80 @@
+# Snapshots and rollback
+
+Dutis v2.7 stores local, versioned snapshots before declarative changes and
+uses the same plan, apply, and verification pipeline for rollback.
+
+## Storage
+
+Snapshots are JSON files stored at:
+
+```text
+~/Library/Application Support/dutis/snapshots/<snapshot-id>.json
+```
+
+Set `DUTIS_STATE_DIR` to use another state directory, which is useful for CI,
+isolated agent runs, or backups. Files are written atomically with owner-only
+permissions on Unix. They contain extension associations, bundle identifiers,
+application paths reported by `duti`, timestamps, and plan digests. They do not
+contain tokens or credentials.
+
+## Create and inspect
+
+Capture every extension declared by installed applications:
+
+```bash
+dutis snapshot create
+```
+
+Limit capture to extensions in a declarative configuration:
+
+```bash
+dutis snapshot create --config dutis.toml --json
+```
+
+List snapshots in newest-first order:
+
+```bash
+dutis history
+dutis history --json
+```
+
+Every declarative `apply` that has changes creates a `before_apply` safety
+snapshot before invoking `duti`. A rollback with changes creates a
+`before_rollback` snapshot, allowing the rollback itself to be reversed.
+Converged no-op plans do not create redundant snapshots.
+
+## Roll back
+
+Always review the rollback plan first:
+
+```bash
+dutis rollback <snapshot-id> --dry-run
+dutis rollback <snapshot-id> --dry-run --json
+```
+
+Apply and verify it explicitly:
+
+```bash
+dutis rollback <snapshot-id> --yes --json
+```
+
+Rollback resolves every recorded bundle identifier against currently installed
+applications, reads current state, builds a deterministic plan, applies each
+change, and verifies it. Missing or ambiguous applications block the entire
+rollback before mutation. Runtime failures retain the pre-rollback safety
+snapshot and return per-entry results.
+
+## Known safe limitation
+
+`duti` can set an association but does not provide a safe command to remove one.
+If a snapshot records that an extension had no default and it now has one,
+Dutis marks that entry unresolved and refuses the whole rollback. It never
+claims to restore an absent association or performs a broad Launch Services
+reset. The snapshot remains available for inspection and future tooling.
+
+## Snapshot schema
+
+Snapshot `schema_version` is currently `1`. Unknown versions are rejected.
+Snapshot identifiers accept only ASCII letters, numbers, and hyphens, preventing
+path traversal. Corrupt snapshot files cause history or rollback to fail loudly
+instead of being silently ignored.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,12 @@ pub enum CliCommand {
     Diff(ConfigArgs),
     /// Apply and verify a previously reviewed declarative plan
     Apply(ApplyArgs),
+    /// Create a local snapshot of current associations
+    Snapshot(SnapshotArgs),
+    /// List locally stored snapshots
+    History(OutputArgs),
+    /// Restore associations from a local snapshot
+    Rollback(RollbackArgs),
     /// Check whether dutis and its runtime dependency are ready
     Doctor(OutputArgs),
 }
@@ -86,6 +92,43 @@ pub struct ApplyArgs {
     #[arg(long)]
     pub dry_run: bool,
     /// Confirm a non-interactive system change
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct SnapshotArgs {
+    #[command(subcommand)]
+    pub command: SnapshotCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SnapshotCommand {
+    /// Capture current associations without changing the system
+    Create(SnapshotCreateArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct SnapshotCreateArgs {
+    /// Limit the snapshot to extensions in this configuration
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct RollbackArgs {
+    /// Snapshot identifier shown by the history command
+    pub snapshot_id: String,
+    /// Build and display the rollback plan without changing the system
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Confirm a non-interactive rollback
     #[arg(long)]
     pub yes: bool,
     /// Emit stable machine-readable JSON
@@ -154,5 +197,29 @@ mod tests {
                 .is_ok()
         );
         assert!(Cli::try_parse_from(["dutis", "apply", "dutis.toml", "--dry-run"]).is_ok());
+    }
+
+    #[test]
+    fn parses_snapshot_history_and_rollback_commands() {
+        let cli = Cli::try_parse_from([
+            "dutis",
+            "snapshot",
+            "create",
+            "--config",
+            "dutis.toml",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Snapshot(SnapshotArgs {
+                command: SnapshotCommand::Create(SnapshotCreateArgs { json: true, .. })
+            }))
+        ));
+        assert!(Cli::try_parse_from(["dutis", "history", "--json"]).is_ok());
+        assert!(
+            Cli::try_parse_from(["dutis", "rollback", "snapshot-id", "--dry-run", "--json"])
+                .is_ok()
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ pub mod application;
 pub mod config;
 pub mod planner;
 pub mod plist_parser;
+pub mod snapshot;
 pub mod system;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use cli::{ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, OutputArgs, SetArgs};
+use cli::{
+    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, OutputArgs, RollbackArgs, SetArgs,
+    SnapshotArgs, SnapshotCommand, SnapshotCreateArgs,
+};
 use colored::*;
 use dutis::application::{
     find_apps_for_extension, find_fuzzy_matches, normalize_extension, resolve_app, Application,
@@ -8,13 +11,18 @@ use dutis::application::{
 };
 use dutis::config::DutisConfig;
 use dutis::planner::{
-    apply_plan, build_plan, ApplyReport, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
+    build_plan, ApplyReport, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
+};
+use dutis::snapshot::{
+    apply_plan_with_snapshot, build_rollback_plan, capture_associations, SnapshotReason,
+    SnapshotStore, SnapshotSummary,
 };
 use dutis::system;
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::BTreeSet;
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 mod cli;
@@ -133,6 +141,25 @@ struct DiffResult<'a> {
     entries: Vec<&'a PlanEntry>,
 }
 
+#[derive(Serialize)]
+struct SnapshotCreated {
+    snapshot: SnapshotSummary,
+    path: PathBuf,
+}
+
+#[derive(Serialize)]
+struct MutationResult {
+    safety_snapshot_id: Option<String>,
+    #[serde(flatten)]
+    report: ApplyReport,
+}
+
+#[derive(Serialize)]
+struct RollbackPreview<'a> {
+    snapshot_id: &'a str,
+    plan: &'a AssociationPlan,
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     let command_name = cli
@@ -177,6 +204,9 @@ fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
         Some(CliCommand::Plan(args)) => run_plan(args),
         Some(CliCommand::Diff(args)) => run_diff(args),
         Some(CliCommand::Apply(args)) => run_apply(args),
+        Some(CliCommand::Snapshot(args)) => run_snapshot(args),
+        Some(CliCommand::History(args)) => run_history(args),
+        Some(CliCommand::Rollback(args)) => run_rollback(args),
         Some(CliCommand::Doctor(args)) => run_doctor(args),
     }
 }
@@ -190,6 +220,9 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Plan(_) => "plan",
         CliCommand::Diff(_) => "diff",
         CliCommand::Apply(_) => "apply",
+        CliCommand::Snapshot(_) => "snapshot",
+        CliCommand::History(_) => "history",
+        CliCommand::Rollback(_) => "rollback",
         CliCommand::Doctor(_) => "doctor",
     }
 }
@@ -201,6 +234,11 @@ fn command_uses_json(command: &CliCommand) -> bool {
         CliCommand::Set(args) => args.json,
         CliCommand::Plan(args) | CliCommand::Diff(args) => args.json,
         CliCommand::Apply(args) => args.json,
+        CliCommand::Snapshot(args) => match &args.command {
+            SnapshotCommand::Create(args) => args.json,
+        },
+        CliCommand::History(args) => args.json,
+        CliCommand::Rollback(args) => args.json,
     }
 }
 
@@ -462,17 +500,17 @@ fn run_apply(args: ApplyArgs) -> Result<(), CliError> {
         ));
     }
 
-    let report = apply_plan(&plan, system::set_default_app);
-    if report.failed > 0 {
-        let details = serde_json::to_value(&report)
+    let result = execute_plan_with_snapshot(&plan, SnapshotReason::BeforeApply)?;
+    if result.report.failed > 0 {
+        let details = serde_json::to_value(&result)
             .map_err(|error| CliError::operation(format!("failed to serialize report: {error}")))?;
         if !args.json {
-            print_apply_report(&report);
+            print_mutation_result(&result);
         }
         return Err(CliError::partial_failure(
             format!(
                 "{} association(s) failed; {} applied and {} skipped",
-                report.failed, report.applied, report.skipped
+                result.report.failed, result.report.applied, result.report.skipped
             ),
             details,
         ));
@@ -482,12 +520,201 @@ fn run_apply(args: ApplyArgs) -> Result<(), CliError> {
         write_json(&JsonEnvelope {
             api_version: API_VERSION,
             command: "apply",
-            data: report,
+            data: result,
         })?;
     } else {
-        print_apply_report(&report);
+        print_mutation_result(&result);
     }
     Ok(())
+}
+
+fn run_snapshot(args: SnapshotArgs) -> Result<(), CliError> {
+    match args.command {
+        SnapshotCommand::Create(args) => run_snapshot_create(args),
+    }
+}
+
+fn run_snapshot_create(args: SnapshotCreateArgs) -> Result<(), CliError> {
+    let extensions = if let Some(path) = args.config {
+        DutisConfig::load(&path)
+            .map_err(|error| CliError::usage(format!("{error:#}")))?
+            .associations
+            .into_keys()
+            .collect::<BTreeSet<_>>()
+    } else {
+        let catalog = scan_catalog()?;
+        report_metadata_failures(catalog.metadata_failures);
+        catalog
+            .applications
+            .into_iter()
+            .flat_map(|application| application.extensions)
+            .collect::<BTreeSet<_>>()
+    };
+
+    system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
+    let associations =
+        capture_associations(extensions, system::query_default_app).map_err(|error| {
+            CliError::operation(format!("failed to capture associations: {error:#}"))
+        })?;
+    let store = snapshot_store()?;
+    let snapshot = store
+        .create(SnapshotReason::Manual, None, associations)
+        .map_err(|error| CliError::operation(format!("failed to store snapshot: {error:#}")))?;
+    let path = store
+        .snapshot_path(&snapshot.id)
+        .map_err(|error| CliError::operation(format!("{error:#}")))?;
+    let created = SnapshotCreated {
+        snapshot: SnapshotSummary::from(&snapshot),
+        path,
+    };
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "snapshot",
+            data: created,
+        })?;
+    } else {
+        println!("Snapshot: {}", created.snapshot.id);
+        println!("Associations: {}", created.snapshot.associations);
+        println!("Stored at: {}", created.path.display());
+    }
+    Ok(())
+}
+
+fn run_history(args: OutputArgs) -> Result<(), CliError> {
+    let store = snapshot_store()?;
+    let history = store.history().map_err(|error| {
+        CliError::operation(format!("failed to read snapshot history: {error:#}"))
+    })?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "history",
+            data: history,
+        })?;
+    } else if history.is_empty() {
+        println!("No snapshots found in {}", store.root().display());
+    } else {
+        for snapshot in history {
+            println!(
+                "{}\t{}\t{:?}\t{} association(s)",
+                snapshot.id, snapshot.created_at, snapshot.reason, snapshot.associations
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_rollback(args: RollbackArgs) -> Result<(), CliError> {
+    if !args.dry_run && !args.yes {
+        return Err(CliError::usage(
+            "refusing to roll back without --yes; use --dry-run to preview",
+        ));
+    }
+
+    let store = snapshot_store()?;
+    let snapshot_path = store
+        .snapshot_path(&args.snapshot_id)
+        .map_err(|error| CliError::usage(format!("{error:#}")))?;
+    if !snapshot_path.is_file() {
+        return Err(CliError::not_found(format!(
+            "snapshot '{}' was not found",
+            args.snapshot_id
+        )));
+    }
+    let snapshot = store
+        .load(&args.snapshot_id)
+        .map_err(|error| CliError::operation(format!("failed to load snapshot: {error:#}")))?;
+    let catalog = scan_catalog()?;
+    report_metadata_failures(catalog.metadata_failures);
+    system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
+    let plan = build_rollback_plan(&snapshot, &catalog.applications, system::query_default_app)
+        .map_err(|error| {
+            CliError::operation(format!("failed to build rollback plan: {error:#}"))
+        })?;
+
+    if args.dry_run {
+        if args.json {
+            write_json(&JsonEnvelope {
+                api_version: API_VERSION,
+                command: "rollback",
+                data: RollbackPreview {
+                    snapshot_id: &snapshot.id,
+                    plan: &plan,
+                },
+            })?;
+        } else {
+            println!("Rollback snapshot: {}\n", snapshot.id);
+            print_plan(&plan, false);
+        }
+        return Ok(());
+    }
+
+    if plan.has_unresolved() {
+        let details = serde_json::to_value(RollbackPreview {
+            snapshot_id: &snapshot.id,
+            plan: &plan,
+        })
+        .map_err(|error| CliError::operation(format!("failed to serialize plan: {error}")))?;
+        if !args.json {
+            print_plan(&plan, false);
+        }
+        return Err(CliError::not_found(format!(
+            "rollback contains {} unresolved association(s); no changes were made",
+            plan.summary.unresolved
+        ))
+        .with_details(details));
+    }
+
+    let result = execute_plan_with_snapshot(&plan, SnapshotReason::BeforeRollback)?;
+    if result.report.failed > 0 {
+        let details = serde_json::to_value(&result)
+            .map_err(|error| CliError::operation(format!("failed to serialize report: {error}")))?;
+        if !args.json {
+            print_mutation_result(&result);
+        }
+        return Err(CliError::partial_failure(
+            format!(
+                "rollback failed for {} association(s); safety snapshot retained",
+                result.report.failed
+            ),
+            details,
+        ));
+    }
+
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "rollback",
+            data: result,
+        })?;
+    } else {
+        print_mutation_result(&result);
+    }
+    Ok(())
+}
+
+fn execute_plan_with_snapshot(
+    plan: &AssociationPlan,
+    reason: SnapshotReason,
+) -> Result<MutationResult, CliError> {
+    let store = snapshot_store()?;
+    let protected = apply_plan_with_snapshot(&store, plan, reason, system::set_default_app)
+        .map_err(|error| {
+            CliError::operation(format!(
+                "failed to store safety snapshot; no changes were made: {error:#}"
+            ))
+        })?;
+    Ok(MutationResult {
+        safety_snapshot_id: protected.safety_snapshot.map(|snapshot| snapshot.id),
+        report: protected.report,
+    })
+}
+
+fn snapshot_store() -> Result<SnapshotStore, CliError> {
+    SnapshotStore::from_environment().map_err(|error| {
+        CliError::operation(format!("failed to resolve snapshot storage: {error:#}"))
+    })
 }
 
 fn build_declarative_plan(path: &Path) -> Result<AssociationPlan, CliError> {
@@ -540,13 +767,16 @@ fn print_plan(plan: &AssociationPlan, changes_only: bool) {
     println!("Plan digest: {}", plan.digest);
 }
 
-fn print_apply_report(report: &ApplyReport) {
-    for result in &report.results {
+fn print_mutation_result(result: &MutationResult) {
+    if let Some(snapshot_id) = &result.safety_snapshot_id {
+        println!("Safety snapshot: {snapshot_id}\n");
+    }
+    for entry in &result.report.results {
         println!(
             "{:?} .{}{}",
-            result.status,
-            result.extension,
-            result
+            entry.status,
+            entry.extension,
+            entry
                 .error
                 .as_ref()
                 .map(|error| format!(": {error}"))
@@ -555,7 +785,7 @@ fn print_apply_report(report: &ApplyReport) {
     }
     println!(
         "\nApplied: {}, skipped: {}, failed: {}",
-        report.applied, report.skipped, report.failed
+        result.report.applied, result.report.skipped, result.report.failed
     );
 }
 

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -24,7 +24,7 @@ pub struct PlannedApplication {
 }
 
 impl PlannedApplication {
-    fn from_application(application: &Application) -> Option<Self> {
+    pub fn from_application(application: &Application) -> Option<Self> {
         Some(Self {
             name: application.name.clone(),
             path: application.path.clone(),
@@ -152,11 +152,15 @@ where
         entries.push(entry);
     }
 
+    assemble_plan(config.version, entries)
+}
+
+pub fn assemble_plan(config_version: u32, entries: Vec<PlanEntry>) -> Result<AssociationPlan> {
     let summary = summarize(&entries);
-    let digest = calculate_digest(config.version, &entries)?;
+    let digest = calculate_digest(config_version, &entries)?;
     Ok(AssociationPlan {
         schema_version: PLAN_SCHEMA_VERSION,
-        config_version: config.version,
+        config_version,
         digest,
         summary,
         entries,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,579 @@
+use crate::application::{normalize_extension, resolve_app, Application};
+use crate::planner::{
+    apply_plan, assemble_plan, ApplyReport, AssociationPlan, PlanAction, PlanEntry,
+    PlannedApplication,
+};
+use crate::system::DefaultApplication;
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fs::{self, OpenOptions};
+use std::io::{BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+pub const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotReason {
+    Manual,
+    BeforeApply,
+    BeforeRollback,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SnapshotAssociation {
+    pub extension: String,
+    pub default: Option<DefaultApplication>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Snapshot {
+    pub schema_version: u32,
+    pub id: String,
+    pub created_at: String,
+    pub reason: SnapshotReason,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_plan_digest: Option<String>,
+    pub associations: Vec<SnapshotAssociation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct SnapshotSummary {
+    pub id: String,
+    pub created_at: String,
+    pub reason: SnapshotReason,
+    pub source_plan_digest: Option<String>,
+    pub associations: usize,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ProtectedApply {
+    pub safety_snapshot: Option<Snapshot>,
+    pub report: ApplyReport,
+}
+
+impl From<&Snapshot> for SnapshotSummary {
+    fn from(snapshot: &Snapshot) -> Self {
+        Self {
+            id: snapshot.id.clone(),
+            created_at: snapshot.created_at.clone(),
+            reason: snapshot.reason,
+            source_plan_digest: snapshot.source_plan_digest.clone(),
+            associations: snapshot.associations.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SnapshotStore {
+    root: PathBuf,
+}
+
+impl SnapshotStore {
+    pub fn from_environment() -> Result<Self> {
+        if let Some(path) = std::env::var_os("DUTIS_STATE_DIR").filter(|value| !value.is_empty()) {
+            return Ok(Self::new(path));
+        }
+        let home = std::env::var_os("HOME")
+            .ok_or_else(|| anyhow!("HOME is not set; set DUTIS_STATE_DIR explicitly"))?;
+        Ok(Self::new(
+            PathBuf::from(home).join("Library/Application Support/dutis"),
+        ))
+    }
+
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn create(
+        &self,
+        reason: SnapshotReason,
+        source_plan_digest: Option<String>,
+        associations: Vec<SnapshotAssociation>,
+    ) -> Result<Snapshot> {
+        let associations = normalize_associations(associations)?;
+        let now = OffsetDateTime::now_utc();
+        let created_at = now.format(&Rfc3339)?;
+        let hash_material = serde_json::to_vec(&(
+            SNAPSHOT_SCHEMA_VERSION,
+            &created_at,
+            reason,
+            &source_plan_digest,
+            &associations,
+        ))?;
+        let hash = Sha256::digest(hash_material);
+        let hash_prefix = hash
+            .iter()
+            .take(6)
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        let id = format!("{}-{hash_prefix}", now.unix_timestamp_nanos());
+        let snapshot = Snapshot {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            id,
+            created_at,
+            reason,
+            source_plan_digest,
+            associations,
+        };
+
+        let directory = self.snapshots_directory();
+        fs::create_dir_all(&directory)
+            .with_context(|| format!("failed to create {}", directory.display()))?;
+        let destination = self.snapshot_path(&snapshot.id)?;
+        let temporary = directory.join(format!(".{}.{}.tmp", snapshot.id, std::process::id()));
+
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options
+            .open(&temporary)
+            .with_context(|| format!("failed to create {}", temporary.display()))?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, &snapshot)?;
+        writer.write_all(b"\n")?;
+        writer.flush()?;
+        writer.get_ref().sync_all()?;
+        fs::rename(&temporary, &destination).with_context(|| {
+            format!(
+                "failed to atomically store snapshot {}",
+                destination.display()
+            )
+        })?;
+        Ok(snapshot)
+    }
+
+    pub fn load(&self, id: &str) -> Result<Snapshot> {
+        let path = self.snapshot_path(id)?;
+        let file = fs::File::open(&path)
+            .with_context(|| format!("failed to open snapshot {}", path.display()))?;
+        let snapshot: Snapshot = serde_json::from_reader(BufReader::new(file))
+            .with_context(|| format!("failed to parse snapshot {}", path.display()))?;
+        validate_snapshot(&snapshot, Some(id))?;
+        Ok(snapshot)
+    }
+
+    pub fn history(&self) -> Result<Vec<SnapshotSummary>> {
+        let directory = self.snapshots_directory();
+        if !directory.exists() {
+            return Ok(Vec::new());
+        }
+        let mut snapshots = Vec::new();
+        for entry in fs::read_dir(&directory)
+            .with_context(|| format!("failed to read {}", directory.display()))?
+        {
+            let path = entry?.path();
+            if path.extension().is_none_or(|extension| extension != "json") {
+                continue;
+            }
+            let file = fs::File::open(&path)?;
+            let snapshot: Snapshot = serde_json::from_reader(BufReader::new(file))
+                .with_context(|| format!("failed to parse snapshot {}", path.display()))?;
+            validate_snapshot(&snapshot, None)?;
+            snapshots.push(SnapshotSummary::from(&snapshot));
+        }
+        snapshots.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        Ok(snapshots)
+    }
+
+    pub fn snapshot_path(&self, id: &str) -> Result<PathBuf> {
+        validate_snapshot_id(id)?;
+        Ok(self.snapshots_directory().join(format!("{id}.json")))
+    }
+
+    fn snapshots_directory(&self) -> PathBuf {
+        self.root.join("snapshots")
+    }
+}
+
+pub fn capture_associations<F, I>(extensions: I, mut query: F) -> Result<Vec<SnapshotAssociation>>
+where
+    I: IntoIterator,
+    I::Item: AsRef<str>,
+    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+{
+    let mut normalized = BTreeSet::new();
+    for extension in extensions {
+        normalized.insert(normalize_extension(extension.as_ref())?);
+    }
+    normalized
+        .into_iter()
+        .map(|extension| {
+            let default = query(&extension)?;
+            Ok(SnapshotAssociation { extension, default })
+        })
+        .collect()
+}
+
+pub fn associations_from_plan(plan: &AssociationPlan) -> Vec<SnapshotAssociation> {
+    plan.entries
+        .iter()
+        .map(|entry| SnapshotAssociation {
+            extension: entry.extension.clone(),
+            default: entry.current.clone(),
+        })
+        .collect()
+}
+
+pub fn apply_plan_with_snapshot<F>(
+    store: &SnapshotStore,
+    plan: &AssociationPlan,
+    reason: SnapshotReason,
+    apply: F,
+) -> Result<ProtectedApply>
+where
+    F: FnMut(&str, &str) -> Result<()>,
+{
+    let safety_snapshot = if plan.summary.changes > 0 {
+        Some(store.create(
+            reason,
+            Some(plan.digest.clone()),
+            associations_from_plan(plan),
+        )?)
+    } else {
+        None
+    };
+    let report = apply_plan(plan, apply);
+    Ok(ProtectedApply {
+        safety_snapshot,
+        report,
+    })
+}
+
+pub fn build_rollback_plan<F>(
+    snapshot: &Snapshot,
+    applications: &[Application],
+    mut query_default: F,
+) -> Result<AssociationPlan>
+where
+    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+{
+    validate_snapshot(snapshot, None)?;
+    let mut entries = Vec::with_capacity(snapshot.associations.len());
+    for association in &snapshot.associations {
+        let current = query_default(&association.extension)?;
+        let entry = match &association.default {
+            None if current.is_none() => PlanEntry {
+                extension: association.extension.clone(),
+                selector: "<no default>".to_owned(),
+                current,
+                target: None,
+                action: PlanAction::Unchanged,
+                reason: None,
+            },
+            None => PlanEntry {
+                extension: association.extension.clone(),
+                selector: "<no default>".to_owned(),
+                current,
+                target: None,
+                action: PlanAction::Unresolved,
+                reason: Some(
+                    "snapshot recorded no default; duti cannot safely remove an association"
+                        .to_owned(),
+                ),
+            },
+            Some(previous) => {
+                let matches = resolve_app(applications, &previous.bundle_id);
+                match matches.as_slice() {
+                    [application] => {
+                        let action = if current.as_ref().map(|app| app.bundle_id.as_str())
+                            == Some(previous.bundle_id.as_str())
+                        {
+                            PlanAction::Unchanged
+                        } else {
+                            PlanAction::Change
+                        };
+                        PlanEntry {
+                            extension: association.extension.clone(),
+                            selector: previous.bundle_id.clone(),
+                            current,
+                            target: PlannedApplication::from_application(application),
+                            action,
+                            reason: None,
+                        }
+                    }
+                    [] => PlanEntry {
+                        extension: association.extension.clone(),
+                        selector: previous.bundle_id.clone(),
+                        current,
+                        target: None,
+                        action: PlanAction::Unresolved,
+                        reason: Some(format!(
+                            "snapshot application '{}' is not installed",
+                            previous.bundle_id
+                        )),
+                    },
+                    matches => PlanEntry {
+                        extension: association.extension.clone(),
+                        selector: previous.bundle_id.clone(),
+                        current,
+                        target: None,
+                        action: PlanAction::Unresolved,
+                        reason: Some(format!(
+                            "snapshot bundle ID is ambiguous: {}",
+                            matches
+                                .iter()
+                                .map(|app| app.path.display().to_string())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )),
+                    },
+                }
+            }
+        };
+        entries.push(entry);
+    }
+    assemble_plan(snapshot.schema_version, entries)
+}
+
+fn normalize_associations(
+    associations: Vec<SnapshotAssociation>,
+) -> Result<Vec<SnapshotAssociation>> {
+    let mut normalized = associations
+        .into_iter()
+        .map(|association| {
+            Ok(SnapshotAssociation {
+                extension: normalize_extension(&association.extension)?,
+                default: association.default,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    normalized.sort_by(|left, right| left.extension.cmp(&right.extension));
+    if normalized
+        .windows(2)
+        .any(|pair| pair[0].extension == pair[1].extension)
+    {
+        bail!("snapshot contains duplicate extensions");
+    }
+    Ok(normalized)
+}
+
+fn validate_snapshot(snapshot: &Snapshot, expected_id: Option<&str>) -> Result<()> {
+    if snapshot.schema_version != SNAPSHOT_SCHEMA_VERSION {
+        bail!(
+            "unsupported snapshot schema version {}; expected {}",
+            snapshot.schema_version,
+            SNAPSHOT_SCHEMA_VERSION
+        );
+    }
+    validate_snapshot_id(&snapshot.id)?;
+    if expected_id.is_some_and(|id| id != snapshot.id) {
+        bail!("snapshot ID does not match its filename");
+    }
+    normalize_associations(snapshot.associations.clone())?;
+    Ok(())
+}
+
+fn validate_snapshot_id(id: &str) -> Result<()> {
+    if id.is_empty()
+        || !id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        bail!("invalid snapshot ID '{id}'");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temporary_store() -> SnapshotStore {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        SnapshotStore::new(
+            std::env::temp_dir().join(format!("dutis-snapshots-{}-{unique}", std::process::id())),
+        )
+    }
+
+    fn default(extension: &str, bundle_id: &str) -> DefaultApplication {
+        DefaultApplication {
+            extension: extension.to_owned(),
+            name: None,
+            path: None,
+            bundle_id: bundle_id.to_owned(),
+        }
+    }
+
+    fn application(bundle_id: &str) -> Application {
+        Application {
+            name: "Editor".to_owned(),
+            path: PathBuf::from("/Applications/Editor.app"),
+            bundle_id: Some(bundle_id.to_owned()),
+            extensions: vec!["md".to_owned()],
+        }
+    }
+
+    #[test]
+    fn atomically_stores_loads_and_lists_snapshots() {
+        let store = temporary_store();
+        let snapshot = store
+            .create(
+                SnapshotReason::Manual,
+                None,
+                vec![SnapshotAssociation {
+                    extension: ".MD".to_owned(),
+                    default: Some(default("md", "com.example.Editor")),
+                }],
+            )
+            .unwrap();
+        assert!(store.snapshot_path(&snapshot.id).unwrap().is_file());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(store.snapshot_path(&snapshot.id).unwrap())
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+        assert_eq!(store.load(&snapshot.id).unwrap(), snapshot);
+        let history = store.history().unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].id, snapshot.id);
+        fs::remove_dir_all(store.root()).unwrap();
+    }
+
+    #[test]
+    fn rejects_path_traversal_snapshot_ids() {
+        let store = temporary_store();
+        assert!(store.load("../../secret").is_err());
+    }
+
+    #[test]
+    fn captures_extensions_in_normalized_stable_order() {
+        let associations = capture_associations(["TXT", ".md", "txt"], |extension| {
+            Ok(Some(default(extension, "com.example.Editor")))
+        })
+        .unwrap();
+        assert_eq!(
+            associations
+                .iter()
+                .map(|association| association.extension.as_str())
+                .collect::<Vec<_>>(),
+            vec!["md", "txt"]
+        );
+    }
+
+    #[test]
+    fn builds_verified_rollback_plan() {
+        let store = temporary_store();
+        let snapshot = store
+            .create(
+                SnapshotReason::BeforeApply,
+                Some("source-plan".to_owned()),
+                vec![SnapshotAssociation {
+                    extension: "md".to_owned(),
+                    default: Some(default("md", "com.example.Editor")),
+                }],
+            )
+            .unwrap();
+        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |ext| {
+            Ok(Some(default(ext, "com.example.Other")))
+        })
+        .unwrap();
+        assert_eq!(plan.summary.changes, 1);
+        assert_eq!(plan.entries[0].action, PlanAction::Change);
+        fs::remove_dir_all(store.root()).unwrap();
+    }
+
+    #[test]
+    fn refuses_to_fake_restoring_an_absent_default() {
+        let store = temporary_store();
+        let snapshot = store
+            .create(
+                SnapshotReason::Manual,
+                None,
+                vec![SnapshotAssociation {
+                    extension: "md".to_owned(),
+                    default: None,
+                }],
+            )
+            .unwrap();
+        let plan = build_rollback_plan(&snapshot, &[], |ext| {
+            Ok(Some(default(ext, "com.example.Current")))
+        })
+        .unwrap();
+        assert_eq!(plan.summary.unresolved, 1);
+        assert!(plan.has_unresolved());
+        fs::remove_dir_all(store.root()).unwrap();
+    }
+
+    #[test]
+    fn failed_apply_retains_its_pre_change_snapshot() {
+        let store = temporary_store();
+        let snapshot = store
+            .create(
+                SnapshotReason::Manual,
+                None,
+                vec![SnapshotAssociation {
+                    extension: "md".to_owned(),
+                    default: Some(default("md", "com.example.Editor")),
+                }],
+            )
+            .unwrap();
+        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |ext| {
+            Ok(Some(default(ext, "com.example.Other")))
+        })
+        .unwrap();
+        let protected =
+            apply_plan_with_snapshot(&store, &plan, SnapshotReason::BeforeRollback, |_, _| {
+                anyhow::bail!("simulated failure")
+            })
+            .unwrap();
+        assert_eq!(protected.report.failed, 1);
+        let safety = protected.safety_snapshot.unwrap();
+        assert_eq!(
+            store.load(&safety.id).unwrap().associations[0]
+                .default
+                .as_ref()
+                .unwrap()
+                .bundle_id,
+            "com.example.Other"
+        );
+        fs::remove_dir_all(store.root()).unwrap();
+    }
+
+    #[test]
+    fn snapshot_storage_failure_prevents_mutation() {
+        let store = temporary_store();
+        fs::write(store.root(), "not a directory").unwrap();
+        let snapshot = Snapshot {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            id: "source-snapshot".to_owned(),
+            created_at: "2026-08-22T00:00:00Z".to_owned(),
+            reason: SnapshotReason::Manual,
+            source_plan_digest: None,
+            associations: vec![SnapshotAssociation {
+                extension: "md".to_owned(),
+                default: Some(default("md", "com.example.Editor")),
+            }],
+        };
+        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |ext| {
+            Ok(Some(default(ext, "com.example.Other")))
+        })
+        .unwrap();
+        let result =
+            apply_plan_with_snapshot(&store, &plan, SnapshotReason::BeforeRollback, |_, _| {
+                panic!("mutation ran without a safety snapshot")
+            });
+        assert!(result.is_err());
+        fs::remove_file(store.root()).unwrap();
+    }
+}

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, bail, Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::io;
 use std::process::Command;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DefaultApplication {
     pub extension: String,
     pub name: Option<String>,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn dutis() -> Command {
     Command::new(env!("CARGO_BIN_EXE_dutis"))
@@ -60,4 +61,37 @@ fn apply_requires_a_reviewed_digest_before_reading_configuration() {
         .as_str()
         .unwrap()
         .contains("--plan-digest"));
+}
+
+#[test]
+fn rollback_requires_confirmation_before_reading_snapshot_storage() {
+    let output = dutis()
+        .args(["rollback", "missing-snapshot", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stderr.is_empty());
+
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "rollback");
+    assert_eq!(response["error"]["kind"], "usage");
+}
+
+#[test]
+fn history_is_empty_for_an_isolated_state_directory() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let state =
+        std::env::temp_dir().join(format!("dutis-cli-history-{}-{unique}", std::process::id()));
+    let output = dutis()
+        .env("DUTIS_STATE_DIR", state)
+        .args(["history", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "history");
+    assert_eq!(response["data"].as_array().unwrap().len(), 0);
 }


### PR DESCRIPTION
Implements Roadmap Phase 3 for v2.7.0: versioned local snapshots, newest-first history, pre-mutation safety snapshots, verified rollback, stable JSON CLI output, documentation, and failure-path coverage. Validation: cargo fmt, clippy with warnings denied, 38 tests, release build, cargo package, and isolated CLI smoke tests.