### PR TITLE
feat: add local MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A comprehensive Rust application for viewing file extensions supported by macOS 
 - 🤖 **Agent-ready CLI**: Stable JSON output, dry runs, deterministic selectors, and explicit exit codes
 - 📋 **Declarative Configuration**: Plan, diff, apply, and verify a versioned TOML policy
 - ↩️ **Snapshots and Rollback**: Persist pre-change state and restore it through the verified plan pipeline
+- 🔌 **Local MCP Server**: Give agents read-only discovery and planning tools with separately gated writes
 
 ## Installation
 
@@ -127,6 +128,17 @@ Real declarative applies and rollbacks automatically store a safety snapshot
 before the first mutation. See [snapshots and rollback](docs/snapshots-and-rollback.md)
 for storage, recovery behavior, and the safe limitation around removing an
 association.
+
+Run the local MCP server in its default read-only mode:
+
+```bash
+dutis mcp
+```
+
+Mutation tools are registered only with `--allow-writes` and require both a
+fresh plan digest and the server-side `DUTIS_MCP_APPROVAL_TOKEN`. See the
+[MCP server guide](docs/mcp-server.md) for client configuration, tool schemas,
+and the audit contract.
 
 Applications can be selected by exact bundle ID, exact application path, or an
 unambiguous application name. JSON responses use API version `1`. Exit codes are

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -91,6 +91,8 @@ Acceptance criteria:
 
 ## Phase 4: MCP server and agent tools
 
+Status: implemented for v2.8.0
+
 Expose the core library through a local MCP server. Keep read tools (`list`,
 `query`, `get`, `diff`) separate from mutation tools (`apply`, `rollback`). Write
 tools accept a plan digest and explicit approval token rather than free-form
@@ -136,7 +138,7 @@ pipeline across all association types.
 
 ## Near-term engineering sequence
 
-1. Release Phase 3 and validate snapshot recovery across representative macOS
-   application sets.
-2. Expose the stable read, plan, apply, and rollback core through MCP.
-3. Add agent skills and policy controls before any autonomous mode.
+1. Release Phase 4 and validate read-only MCP discovery across representative
+   agent clients.
+2. Add agent skills and local policy controls before any autonomous mode.
+3. Persist mutation audit records as part of the policy layer.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,101 @@
+# MCP server
+
+Dutis v2.8 exposes its inspected, planned, snapshotted, and verified association
+workflow as a local Model Context Protocol server. The server uses JSON-RPC 2.0
+over stdio, so protocol messages are written only to stdout. Stable JSON audit
+events are written to stderr.
+
+## Start in read-only mode
+
+Read-only is the default:
+
+```bash
+dutis mcp
+```
+
+A typical MCP client configuration is:
+
+```json
+{
+  "mcpServers": {
+    "dutis": {
+      "command": "dutis",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+The server advertises these read tools:
+
+- `dutis_list`: discover installed applications and declared extensions.
+- `dutis_query`: find installed handlers for one extension.
+- `dutis_get`: inspect the current default handler.
+- `dutis_diff`: parse inline versioned TOML and return a deterministic plan.
+- `dutis_history`: list local safety snapshots.
+- `dutis_rollback_plan`: preview a snapshot rollback and return its digest.
+
+`dutis_diff` accepts `config_toml` rather than a filesystem path. This keeps the
+MCP surface independent from unrestricted file access and makes the exact input
+part of the reviewed tool call.
+
+## Enable writes explicitly
+
+Mutation tools are absent from `tools/list` unless the server starts with write
+capabilities enabled. Use a secret of at least 16 characters:
+
+```bash
+DUTIS_MCP_APPROVAL_TOKEN='replace-with-a-random-secret' dutis mcp --allow-writes
+```
+
+For an MCP client, place the token in the server process environment:
+
+```json
+{
+  "mcpServers": {
+    "dutis": {
+      "command": "dutis",
+      "args": ["mcp", "--allow-writes"],
+      "env": {
+        "DUTIS_MCP_APPROVAL_TOKEN": "replace-with-a-random-secret"
+      }
+    }
+  }
+}
+```
+
+Write mode adds:
+
+- `dutis_apply`: rebuild, apply, snapshot, and verify an inline TOML policy.
+- `dutis_rollback`: rebuild, apply, snapshot, and verify a rollback.
+
+Every write call must include both the approval token and the digest returned by
+a fresh `dutis_diff` or `dutis_rollback_plan` call. Dutis rebuilds the plan from
+current system state. A changed digest, unresolved selector, missing token, or
+disabled write mode rejects the request before invoking `duti`.
+
+Do not commit approval tokens to a repository or pass them as command-line
+arguments. Rotate a token if it has been disclosed.
+
+## Protocol and audit contract
+
+The server supports MCP protocol versions `2024-11-05`, `2025-03-26`, and
+`2025-06-18`. Tool results contain a text representation plus
+`structuredContent` with `api_version: "1"`. Tool failures set `isError: true`
+and return a stable error `kind` and message.
+
+Each tool call emits one JSON audit event to stderr:
+
+```json
+{
+  "schema_version": 1,
+  "timestamp": "2026-08-22T00:00:00Z",
+  "request_id": 7,
+  "tool": "dutis_apply",
+  "access": "write",
+  "outcome": "success"
+}
+```
+
+Audit events never include tool arguments or approval tokens. Snapshot storage
+continues to use `DUTIS_STATE_DIR` when set.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,8 @@ pub enum CliCommand {
     History(OutputArgs),
     /// Restore associations from a local snapshot
     Rollback(RollbackArgs),
+    /// Run the local Model Context Protocol server over stdio
+    Mcp(McpArgs),
     /// Check whether dutis and its runtime dependency are ready
     Doctor(OutputArgs),
 }
@@ -136,6 +138,13 @@ pub struct RollbackArgs {
     pub json: bool,
 }
 
+#[derive(Debug, Args)]
+pub struct McpArgs {
+    /// Register mutation tools; also requires DUTIS_MCP_APPROVAL_TOKEN
+    #[arg(long)]
+    pub allow_writes: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,5 +230,21 @@ mod tests {
             Cli::try_parse_from(["dutis", "rollback", "snapshot-id", "--dry-run", "--json"])
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn parses_read_only_and_write_enabled_mcp_server() {
+        let cli = Cli::try_parse_from(["dutis", "mcp"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Mcp(McpArgs {
+                allow_writes: false
+            }))
+        ));
+        let cli = Cli::try_parse_from(["dutis", "mcp", "--allow-writes"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Mcp(McpArgs { allow_writes: true }))
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app_scanner;
 pub mod application;
 pub mod config;
+pub mod mcp;
 pub mod planner;
 pub mod plist_parser;
 pub mod snapshot;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{
-    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, OutputArgs, RollbackArgs, SetArgs,
-    SnapshotArgs, SnapshotCommand, SnapshotCreateArgs,
+    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, McpArgs, OutputArgs, RollbackArgs,
+    SetArgs, SnapshotArgs, SnapshotCommand, SnapshotCreateArgs,
 };
 use colored::*;
 use dutis::application::{
@@ -207,6 +207,7 @@ fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
         Some(CliCommand::Snapshot(args)) => run_snapshot(args),
         Some(CliCommand::History(args)) => run_history(args),
         Some(CliCommand::Rollback(args)) => run_rollback(args),
+        Some(CliCommand::Mcp(args)) => run_mcp(args),
         Some(CliCommand::Doctor(args)) => run_doctor(args),
     }
 }
@@ -223,6 +224,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Snapshot(_) => "snapshot",
         CliCommand::History(_) => "history",
         CliCommand::Rollback(_) => "rollback",
+        CliCommand::Mcp(_) => "mcp",
         CliCommand::Doctor(_) => "doctor",
     }
 }
@@ -239,7 +241,15 @@ fn command_uses_json(command: &CliCommand) -> bool {
         },
         CliCommand::History(args) => args.json,
         CliCommand::Rollback(args) => args.json,
+        CliCommand::Mcp(_) => false,
     }
+}
+
+fn run_mcp(args: McpArgs) -> Result<(), CliError> {
+    let options = dutis::mcp::McpOptions::from_environment(args.allow_writes)
+        .map_err(|error| CliError::usage(format!("{error:#}")))?;
+    dutis::mcp::serve_stdio(options)
+        .map_err(|error| CliError::operation(format!("MCP server failed: {error:#}")))
 }
 
 fn run_list(args: OutputArgs) -> Result<(), CliError> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,929 @@
+use crate::application::{find_apps_for_extension, normalize_extension, ApplicationCatalog};
+use crate::config::DutisConfig;
+use crate::planner::{build_plan, AssociationPlan};
+use crate::snapshot::{
+    apply_plan_with_snapshot, build_rollback_plan, SnapshotReason, SnapshotStore,
+};
+use crate::system;
+use anyhow::{anyhow, Context, Result};
+use serde::Serialize;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use std::io::{BufRead, Write};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+pub const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
+pub const MCP_AUDIT_SCHEMA_VERSION: u32 = 1;
+const TOOL_API_VERSION: &str = "1";
+const APPROVAL_TOKEN_ENV: &str = "DUTIS_MCP_APPROVAL_TOKEN";
+const MAX_CONFIG_BYTES: usize = 1_048_576;
+
+pub struct McpOptions {
+    allow_writes: bool,
+    approval_token: Option<String>,
+}
+
+impl McpOptions {
+    pub fn read_only() -> Self {
+        Self {
+            allow_writes: false,
+            approval_token: None,
+        }
+    }
+
+    pub fn from_environment(allow_writes: bool) -> Result<Self> {
+        if !allow_writes {
+            return Ok(Self::read_only());
+        }
+        let token = std::env::var(APPROVAL_TOKEN_ENV).with_context(|| {
+            format!("{APPROVAL_TOKEN_ENV} must be set when --allow-writes is enabled")
+        })?;
+        if token.len() < 16 {
+            return Err(anyhow!(
+                "{APPROVAL_TOKEN_ENV} must contain at least 16 characters"
+            ));
+        }
+        Ok(Self {
+            allow_writes: true,
+            approval_token: Some(token),
+        })
+    }
+
+    #[cfg(test)]
+    fn with_writes(token: &str) -> Self {
+        Self {
+            allow_writes: true,
+            approval_token: Some(token.to_owned()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct McpAuditEvent {
+    pub schema_version: u32,
+    pub timestamp: String,
+    pub request_id: Value,
+    pub tool: String,
+    pub access: &'static str,
+    pub outcome: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_kind: Option<String>,
+}
+
+#[derive(Serialize)]
+struct MutationResult {
+    safety_snapshot_id: Option<String>,
+    #[serde(flatten)]
+    report: crate::planner::ApplyReport,
+}
+
+trait McpBackend {
+    fn list(&mut self) -> Result<Value>;
+    fn query(&mut self, extension: &str) -> Result<Value>;
+    fn get(&mut self, extension: &str) -> Result<Value>;
+    fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan>;
+    fn apply(&mut self, plan: &AssociationPlan, reason: SnapshotReason) -> Result<Value>;
+    fn history(&mut self) -> Result<Value>;
+    fn rollback_plan(&mut self, snapshot_id: &str) -> Result<AssociationPlan>;
+}
+
+struct SystemBackend;
+
+impl McpBackend for SystemBackend {
+    fn list(&mut self) -> Result<Value> {
+        let catalog = ApplicationCatalog::scan()?;
+        Ok(json!({
+            "applications": catalog.applications,
+            "metadata_failures": catalog.metadata_failures,
+        }))
+    }
+
+    fn query(&mut self, extension: &str) -> Result<Value> {
+        let catalog = ApplicationCatalog::scan()?;
+        let applications = find_apps_for_extension(&catalog.applications, extension);
+        Ok(json!({
+            "extension": extension,
+            "applications": applications,
+            "metadata_failures": catalog.metadata_failures,
+        }))
+    }
+
+    fn get(&mut self, extension: &str) -> Result<Value> {
+        let default = system::get_default_app(extension)?;
+        Ok(json!({"extension": extension, "default": default}))
+    }
+
+    fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan> {
+        system::duti_version()?;
+        let catalog = ApplicationCatalog::scan()?;
+        build_plan(config, &catalog.applications, system::query_default_app)
+    }
+
+    fn apply(&mut self, plan: &AssociationPlan, reason: SnapshotReason) -> Result<Value> {
+        let store = SnapshotStore::from_environment()?;
+        let protected = apply_plan_with_snapshot(&store, plan, reason, system::set_default_app)?;
+        serde_json::to_value(MutationResult {
+            safety_snapshot_id: protected.safety_snapshot.map(|snapshot| snapshot.id),
+            report: protected.report,
+        })
+        .context("failed to serialize mutation result")
+    }
+
+    fn history(&mut self) -> Result<Value> {
+        let history = SnapshotStore::from_environment()?.history()?;
+        serde_json::to_value(history).context("failed to serialize snapshot history")
+    }
+
+    fn rollback_plan(&mut self, snapshot_id: &str) -> Result<AssociationPlan> {
+        let store = SnapshotStore::from_environment()?;
+        let snapshot = store.load(snapshot_id)?;
+        system::duti_version()?;
+        let catalog = ApplicationCatalog::scan()?;
+        build_rollback_plan(&snapshot, &catalog.applications, system::query_default_app)
+    }
+}
+
+struct ToolError {
+    kind: &'static str,
+    message: String,
+    details: Option<Value>,
+}
+
+impl ToolError {
+    fn new(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    fn with_details(mut self, details: Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+}
+
+struct HandleOutcome {
+    response: Option<Value>,
+    audit: Option<McpAuditEvent>,
+}
+
+struct McpServer<B> {
+    backend: B,
+    options: McpOptions,
+}
+
+impl<B: McpBackend> McpServer<B> {
+    fn new(backend: B, options: McpOptions) -> Self {
+        Self { backend, options }
+    }
+
+    fn handle(&mut self, message: Value) -> HandleOutcome {
+        let Some(object) = message.as_object() else {
+            return response_only(json_rpc_error(Value::Null, -32600, "invalid request"));
+        };
+        let id = object.get("id").cloned();
+        let Some(method) = object.get("method").and_then(Value::as_str) else {
+            return response_only(json_rpc_error(
+                id.unwrap_or(Value::Null),
+                -32600,
+                "invalid request",
+            ));
+        };
+
+        if id.is_none() {
+            return HandleOutcome {
+                response: None,
+                audit: None,
+            };
+        }
+        let id = id.unwrap_or(Value::Null);
+        let params = object.get("params").cloned().unwrap_or_else(|| json!({}));
+
+        match method {
+            "initialize" => response_only(json_rpc_result(
+                id,
+                json!({
+                    "protocolVersion": negotiated_protocol_version(&params),
+                    "capabilities": {"tools": {"listChanged": false}},
+                    "serverInfo": {
+                        "name": "dutis",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    },
+                    "instructions": "Inspect and plan first. Mutation tools require server-side write enablement, a fresh plan digest, and an approval token."
+                }),
+            )),
+            "ping" => response_only(json_rpc_result(id, json!({}))),
+            "tools/list" => response_only(json_rpc_result(
+                id,
+                json!({"tools": tool_definitions(self.options.allow_writes)}),
+            )),
+            "tools/call" => self.call_tool(id, params),
+            _ => response_only(json_rpc_error(id, -32601, "method not found")),
+        }
+    }
+
+    fn call_tool(&mut self, id: Value, params: Value) -> HandleOutcome {
+        let Some(name) = params.get("name").and_then(Value::as_str) else {
+            return response_only(json_rpc_error(id, -32602, "tool name is required"));
+        };
+        let arguments = params
+            .get("arguments")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        let access = if is_write_tool(name) { "write" } else { "read" };
+        let result = self.dispatch_tool(name, &arguments);
+        let (tool_result, outcome, error_kind) = match result {
+            Ok(data) => (tool_success(data), "success", None),
+            Err(error) => {
+                let kind = error.kind.to_owned();
+                (tool_error(error), "error", Some(kind))
+            }
+        };
+        HandleOutcome {
+            response: Some(json_rpc_result(id.clone(), tool_result)),
+            audit: Some(McpAuditEvent {
+                schema_version: MCP_AUDIT_SCHEMA_VERSION,
+                timestamp: timestamp(),
+                request_id: id,
+                tool: name.to_owned(),
+                access,
+                outcome,
+                error_kind,
+            }),
+        }
+    }
+
+    fn dispatch_tool(
+        &mut self,
+        name: &str,
+        arguments: &Map<String, Value>,
+    ) -> std::result::Result<Value, ToolError> {
+        match name {
+            "dutis_list" => self.backend.list().map_err(operation_error),
+            "dutis_query" => {
+                let extension = argument_string(arguments, "extension")?;
+                let extension = normalize_extension(extension)
+                    .map_err(|error| ToolError::new("invalid_arguments", error.to_string()))?;
+                self.backend.query(&extension).map_err(operation_error)
+            }
+            "dutis_get" => {
+                let extension = argument_string(arguments, "extension")?;
+                let extension = normalize_extension(extension)
+                    .map_err(|error| ToolError::new("invalid_arguments", error.to_string()))?;
+                self.backend.get(&extension).map_err(operation_error)
+            }
+            "dutis_diff" => {
+                let config = parse_config(arguments)?;
+                let plan = self.backend.plan(&config).map_err(operation_error)?;
+                serde_json::to_value(plan).map_err(|error| operation_error(error.into()))
+            }
+            "dutis_history" => self.backend.history().map_err(operation_error),
+            "dutis_rollback_plan" => {
+                let snapshot_id = argument_string(arguments, "snapshot_id")?;
+                let plan = self
+                    .backend
+                    .rollback_plan(snapshot_id)
+                    .map_err(operation_error)?;
+                serde_json::to_value(plan).map_err(|error| operation_error(error.into()))
+            }
+            "dutis_apply" => {
+                self.authorize_write(arguments)?;
+                let config = parse_config(arguments)?;
+                let expected_digest = argument_string(arguments, "plan_digest")?;
+                let plan = self.backend.plan(&config).map_err(operation_error)?;
+                validate_mutation_plan(&plan, expected_digest)?;
+                let result = self
+                    .backend
+                    .apply(&plan, SnapshotReason::BeforeApply)
+                    .map_err(operation_error)?;
+                validate_apply_result(result)
+            }
+            "dutis_rollback" => {
+                self.authorize_write(arguments)?;
+                let snapshot_id = argument_string(arguments, "snapshot_id")?;
+                let expected_digest = argument_string(arguments, "plan_digest")?;
+                let plan = self
+                    .backend
+                    .rollback_plan(snapshot_id)
+                    .map_err(operation_error)?;
+                validate_mutation_plan(&plan, expected_digest)?;
+                let result = self
+                    .backend
+                    .apply(&plan, SnapshotReason::BeforeRollback)
+                    .map_err(operation_error)?;
+                validate_apply_result(result)
+            }
+            _ => Err(ToolError::new(
+                "tool_not_found",
+                format!("unknown tool '{name}'"),
+            )),
+        }
+    }
+
+    fn authorize_write(
+        &self,
+        arguments: &Map<String, Value>,
+    ) -> std::result::Result<(), ToolError> {
+        if !self.options.allow_writes {
+            return Err(ToolError::new(
+                "write_disabled",
+                "mutation tools are disabled; restart with --allow-writes",
+            ));
+        }
+        let provided = argument_string(arguments, "approval_token")?;
+        let expected = self
+            .options
+            .approval_token
+            .as_deref()
+            .ok_or_else(|| ToolError::new("write_disabled", "approval token is unavailable"))?;
+        if !tokens_match(expected, provided) {
+            return Err(ToolError::new(
+                "approval_denied",
+                "approval token does not match",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_mutation_plan(
+    plan: &AssociationPlan,
+    expected_digest: &str,
+) -> std::result::Result<(), ToolError> {
+    if plan.digest != expected_digest {
+        return Err(ToolError::new(
+            "stale_plan",
+            "current plan digest differs from the reviewed digest",
+        )
+        .with_details(json!({
+            "expected_plan_digest": expected_digest,
+            "current_plan": plan,
+        })));
+    }
+    if plan.has_unresolved() {
+        return Err(ToolError::new(
+            "unresolved_plan",
+            format!(
+                "plan contains {} unresolved association(s); no changes were made",
+                plan.summary.unresolved
+            ),
+        )
+        .with_details(json!({"plan": plan})));
+    }
+    Ok(())
+}
+
+fn validate_apply_result(result: Value) -> std::result::Result<Value, ToolError> {
+    let failed = result.get("failed").and_then(Value::as_u64).unwrap_or(0);
+    if failed > 0 {
+        return Err(ToolError::new(
+            "partial_failure",
+            format!("{failed} association(s) failed; safety snapshot retained"),
+        )
+        .with_details(result));
+    }
+    Ok(result)
+}
+
+fn argument_string<'a>(
+    arguments: &'a Map<String, Value>,
+    name: &str,
+) -> std::result::Result<&'a str, ToolError> {
+    arguments
+        .get(name)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ToolError::new(
+                "invalid_arguments",
+                format!("'{name}' must be a non-empty string"),
+            )
+        })
+}
+
+fn parse_config(arguments: &Map<String, Value>) -> std::result::Result<DutisConfig, ToolError> {
+    let contents = argument_string(arguments, "config_toml")?;
+    if contents.len() > MAX_CONFIG_BYTES {
+        return Err(ToolError::new(
+            "invalid_arguments",
+            "'config_toml' exceeds the 1 MiB limit",
+        ));
+    }
+    DutisConfig::parse(contents)
+        .map_err(|error| ToolError::new("invalid_arguments", format!("{error:#}")))
+}
+
+fn operation_error(error: anyhow::Error) -> ToolError {
+    ToolError::new("operation_failed", format!("{error:#}"))
+}
+
+fn tokens_match(expected: &str, provided: &str) -> bool {
+    let expected = Sha256::digest(expected.as_bytes());
+    let provided = Sha256::digest(provided.as_bytes());
+    expected
+        .iter()
+        .zip(provided.iter())
+        .fold(0_u8, |difference, (left, right)| {
+            difference | (left ^ right)
+        })
+        == 0
+}
+
+fn timestamp() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn negotiated_protocol_version(params: &Value) -> &str {
+    match params.get("protocolVersion").and_then(Value::as_str) {
+        Some("2024-11-05") => "2024-11-05",
+        Some("2025-03-26") => "2025-03-26",
+        Some("2025-06-18") => "2025-06-18",
+        _ => MCP_PROTOCOL_VERSION,
+    }
+}
+
+fn response_only(response: Value) -> HandleOutcome {
+    HandleOutcome {
+        response: Some(response),
+        audit: None,
+    }
+}
+
+fn json_rpc_result(id: Value, result: Value) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+fn json_rpc_error(id: Value, code: i32, message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {"code": code, "message": message},
+    })
+}
+
+fn tool_success(data: Value) -> Value {
+    let envelope = json!({"api_version": TOOL_API_VERSION, "data": data});
+    let text = serde_json::to_string_pretty(&envelope)
+        .unwrap_or_else(|_| "{\"api_version\":\"1\"}".to_owned());
+    json!({
+        "content": [{"type": "text", "text": text}],
+        "structuredContent": envelope,
+        "isError": false,
+    })
+}
+
+fn tool_error(error: ToolError) -> Value {
+    let mut body = json!({
+        "kind": error.kind,
+        "message": error.message,
+    });
+    if let Some(details) = error.details {
+        body["details"] = details;
+    }
+    let envelope = json!({"api_version": TOOL_API_VERSION, "error": body});
+    let text = serde_json::to_string_pretty(&envelope)
+        .unwrap_or_else(|_| "{\"api_version\":\"1\"}".to_owned());
+    json!({
+        "content": [{"type": "text", "text": text}],
+        "structuredContent": envelope,
+        "isError": true,
+    })
+}
+
+fn is_write_tool(name: &str) -> bool {
+    matches!(name, "dutis_apply" | "dutis_rollback")
+}
+
+fn tool_definitions(allow_writes: bool) -> Vec<Value> {
+    let empty_schema = json!({"type": "object", "properties": {}, "additionalProperties": false});
+    let extension_schema = json!({
+        "type": "object",
+        "properties": {"extension": {"type": "string", "minLength": 1}},
+        "required": ["extension"],
+        "additionalProperties": false,
+    });
+    let config_schema = json!({
+        "type": "object",
+        "properties": {"config_toml": {"type": "string", "minLength": 1}},
+        "required": ["config_toml"],
+        "additionalProperties": false,
+    });
+    let snapshot_schema = json!({
+        "type": "object",
+        "properties": {"snapshot_id": {"type": "string", "minLength": 1}},
+        "required": ["snapshot_id"],
+        "additionalProperties": false,
+    });
+    let read_annotations = json!({
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false,
+    });
+    let mut tools = vec![
+        tool_definition(
+            "dutis_list",
+            "List installed macOS applications and their declared file extensions.",
+            empty_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_query",
+            "Find installed applications that declare support for an extension.",
+            extension_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_get",
+            "Read the current default application for an extension.",
+            extension_schema,
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_diff",
+            "Build a deterministic association plan and digest from TOML without changing the system.",
+            config_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_history",
+            "List locally stored safety snapshots in newest-first order.",
+            empty_schema,
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_rollback_plan",
+            "Build a deterministic rollback plan and digest without changing the system.",
+            snapshot_schema.clone(),
+            read_annotations,
+        ),
+    ];
+    if allow_writes {
+        let write_annotations = json!({
+            "readOnlyHint": false,
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": false,
+        });
+        tools.push(tool_definition(
+            "dutis_apply",
+            "Apply and verify a freshly reviewed TOML plan. Requires a matching digest and approval token.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "config_toml": {"type": "string", "minLength": 1},
+                    "plan_digest": {"type": "string", "minLength": 1},
+                    "approval_token": {"type": "string", "minLength": 1}
+                },
+                "required": ["config_toml", "plan_digest", "approval_token"],
+                "additionalProperties": false,
+            }),
+            write_annotations.clone(),
+        ));
+        tools.push(tool_definition(
+            "dutis_rollback",
+            "Apply and verify a freshly reviewed rollback plan. Requires a matching digest and approval token.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "snapshot_id": {"type": "string", "minLength": 1},
+                    "plan_digest": {"type": "string", "minLength": 1},
+                    "approval_token": {"type": "string", "minLength": 1}
+                },
+                "required": ["snapshot_id", "plan_digest", "approval_token"],
+                "additionalProperties": false,
+            }),
+            write_annotations,
+        ));
+    }
+    tools
+}
+
+fn tool_definition(
+    name: &str,
+    description: &str,
+    input_schema: Value,
+    annotations: Value,
+) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "inputSchema": input_schema,
+        "outputSchema": {
+            "type": "object",
+            "properties": {"api_version": {"const": TOOL_API_VERSION}},
+            "required": ["api_version"],
+            "additionalProperties": true
+        },
+        "annotations": annotations,
+    })
+}
+
+pub fn serve_stdio(options: McpOptions) -> Result<()> {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let stderr = std::io::stderr();
+    serve(
+        stdin.lock(),
+        stdout.lock(),
+        stderr.lock(),
+        McpServer::new(SystemBackend, options),
+    )
+}
+
+fn serve<R, W, E, B>(
+    reader: R,
+    mut writer: W,
+    mut audit_writer: E,
+    mut server: McpServer<B>,
+) -> Result<()>
+where
+    R: BufRead,
+    W: Write,
+    E: Write,
+    B: McpBackend,
+{
+    for line in reader.lines() {
+        let line = line.context("failed to read MCP input")?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let outcome = match serde_json::from_str::<Value>(&line) {
+            Ok(message) => server.handle(message),
+            Err(_) => response_only(json_rpc_error(Value::Null, -32700, "parse error")),
+        };
+        if let Some(audit) = outcome.audit {
+            serde_json::to_writer(&mut audit_writer, &audit)?;
+            audit_writer.write_all(b"\n")?;
+            audit_writer.flush()?;
+        }
+        if let Some(response) = outcome.response {
+            serde_json::to_writer(&mut writer, &response)?;
+            writer.write_all(b"\n")?;
+            writer.flush()?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::planner::{ApplyReport, PlanSummary};
+
+    struct FakeBackend {
+        plan: AssociationPlan,
+        apply_calls: usize,
+    }
+
+    impl FakeBackend {
+        fn new() -> Self {
+            Self {
+                plan: AssociationPlan {
+                    schema_version: 1,
+                    config_version: 1,
+                    digest: "reviewed-digest".to_owned(),
+                    summary: PlanSummary {
+                        total: 0,
+                        changes: 0,
+                        unchanged: 0,
+                        unresolved: 0,
+                    },
+                    entries: Vec::new(),
+                },
+                apply_calls: 0,
+            }
+        }
+    }
+
+    impl McpBackend for FakeBackend {
+        fn list(&mut self) -> Result<Value> {
+            Ok(json!({"applications": []}))
+        }
+
+        fn query(&mut self, extension: &str) -> Result<Value> {
+            Ok(json!({"extension": extension, "applications": []}))
+        }
+
+        fn get(&mut self, extension: &str) -> Result<Value> {
+            Ok(json!({"extension": extension, "default": null}))
+        }
+
+        fn plan(&mut self, _config: &DutisConfig) -> Result<AssociationPlan> {
+            Ok(self.plan.clone())
+        }
+
+        fn apply(&mut self, plan: &AssociationPlan, _reason: SnapshotReason) -> Result<Value> {
+            self.apply_calls += 1;
+            serde_json::to_value(MutationResult {
+                safety_snapshot_id: None,
+                report: ApplyReport {
+                    plan_digest: plan.digest.clone(),
+                    applied: 0,
+                    skipped: 0,
+                    failed: 0,
+                    results: Vec::new(),
+                },
+            })
+            .map_err(Into::into)
+        }
+
+        fn history(&mut self) -> Result<Value> {
+            Ok(json!([]))
+        }
+
+        fn rollback_plan(&mut self, _snapshot_id: &str) -> Result<AssociationPlan> {
+            Ok(self.plan.clone())
+        }
+    }
+
+    fn request(id: u64, method: &str, params: Value) -> Value {
+        json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params})
+    }
+
+    fn config_toml() -> &'static str {
+        "version = 1\n[associations]\nmd = 'com.example.Editor'\n"
+    }
+
+    #[test]
+    fn initializes_with_stable_protocol_metadata() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let outcome = server.handle(request(1, "initialize", json!({})));
+        let response = outcome.response.unwrap();
+        assert_eq!(response["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert_eq!(response["result"]["serverInfo"]["name"], "dutis");
+    }
+
+    #[test]
+    fn read_only_mode_does_not_advertise_write_tools() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let response = server
+            .handle(request(1, "tools/list", json!({})))
+            .response
+            .unwrap();
+        let names = response["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"dutis_diff"));
+        assert!(!names.contains(&"dutis_apply"));
+        assert!(!names.contains(&"dutis_rollback"));
+    }
+
+    #[test]
+    fn write_mode_advertises_mutations() {
+        let mut server = McpServer::new(
+            FakeBackend::new(),
+            McpOptions::with_writes("a-secure-test-token"),
+        );
+        let response = server
+            .handle(request(1, "tools/list", json!({})))
+            .response
+            .unwrap();
+        let names = response["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"dutis_apply"));
+        assert!(names.contains(&"dutis_rollback"));
+    }
+
+    #[test]
+    fn advertised_schemas_are_closed_and_versioned() {
+        for tool in tool_definitions(true) {
+            assert_eq!(tool["inputSchema"]["additionalProperties"], false);
+            assert_eq!(
+                tool["outputSchema"]["properties"]["api_version"]["const"],
+                "1"
+            );
+            assert_eq!(tool["outputSchema"]["required"], json!(["api_version"]));
+        }
+    }
+
+    #[test]
+    fn disabled_write_returns_a_stable_error_and_audit_event() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let outcome = server.handle(request(
+            9,
+            "tools/call",
+            json!({
+                "name": "dutis_apply",
+                "arguments": {
+                    "config_toml": config_toml(),
+                    "plan_digest": "reviewed-digest",
+                    "approval_token": "a-secure-test-token"
+                }
+            }),
+        ));
+        let response = outcome.response.unwrap();
+        assert_eq!(response["result"]["isError"], true);
+        assert_eq!(
+            response["result"]["structuredContent"]["error"]["kind"],
+            "write_disabled"
+        );
+        assert_eq!(server.backend.apply_calls, 0);
+        let audit = outcome.audit.unwrap();
+        assert_eq!(audit.outcome, "error");
+        assert_eq!(audit.error_kind.as_deref(), Some("write_disabled"));
+    }
+
+    #[test]
+    fn approval_and_digest_are_checked_before_mutation() {
+        let mut server = McpServer::new(
+            FakeBackend::new(),
+            McpOptions::with_writes("a-secure-test-token"),
+        );
+        let denied = server.handle(request(
+            1,
+            "tools/call",
+            json!({
+                "name": "dutis_apply",
+                "arguments": {
+                    "config_toml": config_toml(),
+                    "plan_digest": "reviewed-digest",
+                    "approval_token": "wrong-token"
+                }
+            }),
+        ));
+        assert_eq!(
+            denied.response.unwrap()["result"]["structuredContent"]["error"]["kind"],
+            "approval_denied"
+        );
+        assert_eq!(server.backend.apply_calls, 0);
+
+        let stale = server.handle(request(
+            2,
+            "tools/call",
+            json!({
+                "name": "dutis_apply",
+                "arguments": {
+                    "config_toml": config_toml(),
+                    "plan_digest": "old-digest",
+                    "approval_token": "a-secure-test-token"
+                }
+            }),
+        ));
+        assert_eq!(
+            stale.response.unwrap()["result"]["structuredContent"]["error"]["kind"],
+            "stale_plan"
+        );
+        assert_eq!(server.backend.apply_calls, 0);
+    }
+
+    #[test]
+    fn approved_fresh_plan_mutates_and_emits_audit_event() {
+        let mut server = McpServer::new(
+            FakeBackend::new(),
+            McpOptions::with_writes("a-secure-test-token"),
+        );
+        let outcome = server.handle(request(
+            7,
+            "tools/call",
+            json!({
+                "name": "dutis_apply",
+                "arguments": {
+                    "config_toml": config_toml(),
+                    "plan_digest": "reviewed-digest",
+                    "approval_token": "a-secure-test-token"
+                }
+            }),
+        ));
+        assert_eq!(server.backend.apply_calls, 1);
+        assert_eq!(outcome.response.unwrap()["result"]["isError"], false);
+        let audit = outcome.audit.unwrap();
+        assert_eq!(audit.schema_version, 1);
+        assert_eq!(audit.request_id, json!(7));
+        assert_eq!(audit.tool, "dutis_apply");
+        assert_eq!(audit.access, "write");
+        assert_eq!(audit.outcome, "success");
+    }
+
+    #[test]
+    fn stdio_transport_returns_parse_errors_and_ignores_notifications() {
+        let input = b"not-json\n{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n";
+        let mut output = Vec::new();
+        let mut audit = Vec::new();
+        serve(
+            &input[..],
+            &mut output,
+            &mut audit,
+            McpServer::new(FakeBackend::new(), McpOptions::read_only()),
+        )
+        .unwrap();
+        let lines = String::from_utf8(output).unwrap();
+        assert_eq!(lines.lines().count(), 1);
+        let response: Value = serde_json::from_str(lines.trim()).unwrap();
+        assert_eq!(response["error"]["code"], -32700);
+        assert!(audit.is_empty());
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
-use std::process::Command;
+use std::io::Write;
+use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn dutis() -> Command {
@@ -94,4 +95,68 @@ fn history_is_empty_for_an_isolated_state_directory() {
     let response: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(response["command"], "history");
     assert_eq!(response["data"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn mcp_stdio_initializes_and_advertises_read_only_tools() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let state = std::env::temp_dir().join(format!(
+        "dutis-mcp-integration-{}-{unique}",
+        std::process::id()
+    ));
+    let mut child = dutis()
+        .arg("mcp")
+        .env("DUTIS_STATE_DIR", state)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let input = concat!(
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\"}}\n",
+        "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_history\",\"arguments\":{}}}\n"
+    );
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+
+    let responses = String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(responses.len(), 3);
+    assert_eq!(responses[0]["result"]["protocolVersion"], "2024-11-05");
+    let tools = responses[1]["result"]["tools"].as_array().unwrap();
+    assert!(tools.iter().any(|tool| tool["name"] == "dutis_diff"));
+    assert!(!tools.iter().any(|tool| tool["name"] == "dutis_apply"));
+
+    let audit: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(audit["schema_version"], 1);
+    assert_eq!(audit["tool"], "dutis_history");
+    assert_eq!(audit["access"], "read");
+}
+
+#[test]
+fn mcp_write_mode_requires_a_server_side_approval_token() {
+    let output = dutis()
+        .env_remove("DUTIS_MCP_APPROVAL_TOKEN")
+        .args(["mcp", "--allow-writes"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8(output.stderr)
+        .unwrap()
+        .contains("DUTIS_MCP_APPROVAL_TOKEN"));
 }


### PR DESCRIPTION
Implements Roadmap Phase 4 for v2.8.0. Adds a local stdio MCP server with six read tools and separately gated apply/rollback tools. Write calls require server-side enablement, a matching approval token, and a freshly rebuilt plan digest; mutations retain Phase 3 snapshot and verification guarantees. Tool schemas, structured errors, protocol negotiation, and token-free JSON audit events are documented and tested. Validation: formatting, Clippy with warnings denied, 49 tests, release build, cargo package, and real stdio smoke testing.