### PR TITLE
feat: add policy controls and mutation audit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,10 @@ jobs:
             target/x86_64-apple-darwin/release/dutis \
             -output dist/package/dutis
           chmod +x dist/package/dutis
+          cp -R skills dist/package/skills
+          cp dutis.policy.example.toml dist/package/dutis.policy.example.toml
           lipo -info dist/package/dutis
-          tar -C dist/package -czf "dist/${archive}" dutis
+          tar -C dist/package -czf "dist/${archive}" dutis skills dutis.policy.example.toml
           cd dist
           shasum -a 256 "${archive}" > "${archive}.sha256"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A comprehensive Rust application for viewing file extensions supported by macOS 
 - 📋 **Declarative Configuration**: Plan, diff, apply, and verify a versioned TOML policy
 - ↩️ **Snapshots and Rollback**: Persist pre-change state and restore it through the verified plan pipeline
 - 🔌 **Local MCP Server**: Give agents read-only discovery and planning tools with separately gated writes
+- 🛡️ **Policy and Audit**: Enforce local allowlists and approvals with durable, verified mutation records
 
 ## Installation
 
@@ -140,11 +141,26 @@ fresh plan digest and the server-side `DUTIS_MCP_APPROVAL_TOKEN`. See the
 [MCP server guide](docs/mcp-server.md) for client configuration, tool schemas,
 and the audit contract.
 
+Inspect policy decisions and persistent mutation records:
+
+```bash
+dutis policy show --json
+dutis policy check dutis.toml --json
+dutis audit --json
+```
+
+All write paths enforce the same local policy before mutation and record the
+requester, reviewed plan, result, and verification. See the
+[policy and audit guide](docs/policy-and-audit.md). A reusable agent workflow is
+included at [`skills/dutis/SKILL.md`](skills/dutis/SKILL.md).
+Homebrew installs it under `$(brew --prefix dutis)/share/dutis/skills/dutis`.
+
 Applications can be selected by exact bundle ID, exact application path, or an
 unambiguous application name. JSON responses use API version `1`. Exit codes are
 `0` for success, `2` for usage errors, `3` for no match, `4` for ambiguous
 selectors, `5` for an unavailable dependency, and `6` for operation failure.
 Declarative apply also uses `7` for a stale plan and `8` for partial failure.
+Policy denial uses exit code `9`.
 
 The product and engineering sequence for declarative configuration, rollback,
 MCP, agent policies, profiles, and drift detection is documented in the

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -107,6 +107,8 @@ Acceptance criteria:
 
 ## Phase 5: Agent skill and policy layer
 
+Status: implemented for v2.9.0
+
 Ship a Dutis skill for common workflows and add local policy controls such as
 allowed extensions, allowed applications, protected associations, and required
 approval modes. Record who requested each change and which verified plan was
@@ -138,7 +140,8 @@ pipeline across all association types.
 
 ## Near-term engineering sequence
 
-1. Release Phase 4 and validate read-only MCP discovery across representative
-   agent clients.
-2. Add agent skills and local policy controls before any autonomous mode.
-3. Persist mutation audit records as part of the policy layer.
+1. Release Phase 5 and validate policy behavior across CLI, interactive, and
+   MCP mutation paths.
+2. Add explainable, opt-in profiles and recommendations.
+3. Design notification-first drift detection on top of the audited policy
+   layer.

--- a/docs/declarative-configuration.md
+++ b/docs/declarative-configuration.md
@@ -55,6 +55,7 @@ Apply a reviewed plan by copying its digest:
 ```bash
 dutis apply dutis.toml \
   --plan-digest <digest-from-plan> \
+  --requester <human-or-agent-id> \
   --yes \
   --json
 ```
@@ -68,6 +69,11 @@ for one association does not hide other results: Dutis continues, returns every
 per-entry result, and exits with code `8` when any item fails. Entries already
 in the desired state are skipped, so reapplying a converged configuration is a
 no-op.
+
+Before the first mutation, Dutis evaluates the plan against the effective local
+policy and creates a persistent pending audit record. Policy denial uses exit
+code `9` and no association is changed. See
+[policy and mutation audit](policy-and-audit.md).
 
 ## Versioning and migration
 
@@ -90,3 +96,4 @@ no-op.
 | `6` | State inspection or operation failed |
 | `7` | Reviewed plan is stale |
 | `8` | One or more associations failed to apply or verify |
+| `9` | Local mutation policy denied the plan or approval |

--- a/docs/homebrew-installation.md
+++ b/docs/homebrew-installation.md
@@ -6,6 +6,22 @@
 brew install tsonglew/tap/dutis
 ```
 
+The formula also installs the bundled agent skill under:
+
+```text
+$(brew --prefix dutis)/share/dutis/skills/dutis
+```
+
+The policy example is installed at
+`$(brew --prefix dutis)/share/dutis/dutis.policy.example.toml`.
+
+To make it discoverable by Codex, link it into your personal skills directory:
+
+```bash
+mkdir -p ~/.codex/skills
+ln -s "$(brew --prefix dutis)/share/dutis/skills/dutis" ~/.codex/skills/dutis
+```
+
 ## What This Does
 
 When you install `dutis` via Homebrew:

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -34,6 +34,9 @@ The server advertises these read tools:
 - `dutis_diff`: parse inline versioned TOML and return a deterministic plan.
 - `dutis_history`: list local safety snapshots.
 - `dutis_rollback_plan`: preview a snapshot rollback and return its digest.
+- `dutis_policy`: inspect the effective mutation policy.
+- `dutis_policy_check`: evaluate an inline TOML plan against policy.
+- `dutis_audit`: inspect persistent mutation audit records.
 
 `dutis_diff` accepts `config_toml` rather than a filesystem path. This keeps the
 MCP surface independent from unrestricted file access and makes the exact input
@@ -73,6 +76,11 @@ Every write call must include both the approval token and the digest returned by
 a fresh `dutis_diff` or `dutis_rollback_plan` call. Dutis rebuilds the plan from
 current system state. A changed digest, unresolved selector, missing token, or
 disabled write mode rejects the request before invoking `duti`.
+
+Write calls also require a non-empty `requester`. The identity, full plan,
+policy digest, safety snapshot, result, and verification are stored in the
+persistent audit record described in the
+[policy and audit guide](policy-and-audit.md).
 
 Do not commit approval tokens to a repository or pass them as command-line
 arguments. Rotate a token if it has been disclosed.

--- a/docs/policy-and-audit.md
+++ b/docs/policy-and-audit.md
@@ -1,0 +1,110 @@
+# Policy and mutation audit
+
+Dutis v2.9 evaluates every mutation against a local policy and creates a
+persistent audit record before any `duti -s` command can run. This applies to
+interactive changes, `set`, declarative `apply`, `rollback`, and MCP writes.
+
+## Policy location
+
+The default policy path is:
+
+```text
+~/Library/Application Support/dutis/policy.toml
+```
+
+Set `DUTIS_POLICY_FILE` to use another file. If the file does not exist, Dutis
+uses a built-in policy with `approval_mode = "explicit"` and no allowlists.
+Inspect the effective policy without exposing its token hash:
+
+```bash
+dutis policy show
+dutis policy show --json
+```
+
+## Policy schema
+
+Start from [`dutis.policy.example.toml`](../dutis.policy.example.toml):
+
+```toml
+version = 1
+approval_mode = "explicit"
+allowed_extensions = ["md", "txt"]
+allowed_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
+
+[protected_associations]
+pdf = "com.apple.Preview"
+```
+
+- `allowed_extensions` limits changed extensions. Omit it to allow any
+  extension; use an empty list to deny all extensions.
+- `allowed_applications` limits target bundle identifiers with the same
+  omitted-versus-empty behavior.
+- `protected_associations` permits an extension only when the target is the
+  configured bundle identifier. This allows restoration to the protected value
+  while denying changes away from it.
+- Unknown fields, invalid extensions, duplicate normalized values, and unknown
+  versions fail closed.
+
+Check a configuration against the current system state and policy without
+changing anything:
+
+```bash
+dutis policy check dutis.toml --json
+```
+
+## Approval modes
+
+`approval_mode` accepts:
+
+- `explicit`: require the existing interactive confirmation or CLI `--yes`.
+- `token`: require a token whose SHA-256 digest matches
+  `approval_token_sha256`.
+- `deny`: disable every mutation while keeping inspection available.
+
+Generate a token digest locally and place only the digest in the policy:
+
+```bash
+printf %s 'your-random-secret' | shasum -a 256
+```
+
+For CLI writes, provide the secret through `DUTIS_APPROVAL_TOKEN`. MCP writes
+use the `approval_token` field already required by the write tool; the same
+secret can satisfy both the MCP server gate and a token policy. Never commit or
+log the plaintext token.
+
+## Request identity
+
+Use `--requester` for non-interactive CLI writes:
+
+```bash
+dutis apply dutis.toml \
+  --plan-digest <reviewed-digest> \
+  --requester codex \
+  --yes
+```
+
+If omitted, CLI and interactive mode use `DUTIS_REQUESTER`, then the local
+`USER`, then `local-user`. MCP writes require a non-empty `requester` argument.
+
+## Persistent audit records
+
+Audit records are owner-only JSON files stored in:
+
+```text
+~/Library/Application Support/dutis/audit/<audit-id>.json
+```
+
+Use `DUTIS_STATE_DIR` to relocate both snapshots and audit storage. Inspect
+records newest first:
+
+```bash
+dutis audit
+dutis audit --json
+```
+
+Every record includes the requester, channel, operation, policy and plan
+digests, and full reviewed plan. Completed mutation records also include the
+safety snapshot ID, per-entry result, and verification summary. Dutis atomically
+writes a `pending` record before a mutation. If policy denies the request, it
+writes a `denied` record and never invokes the system mutation. If audit storage
+cannot be prepared, the mutation is refused.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,7 +4,8 @@ Merges into `master` trigger `.github/workflows/release.yml`. The workflow:
 
 1. Reads the version from `Cargo.toml` and creates the matching `vX.Y.Z` tag if it does not exist.
 2. Runs formatting, Clippy, and unit tests.
-3. Builds Intel and Apple Silicon binaries and combines them into one universal macOS binary.
+3. Builds Intel and Apple Silicon binaries, combines them into one universal
+   macOS binary, and packages the bundled Dutis agent skill.
 4. Publishes the archive and SHA-256 checksum to GitHub Releases.
 5. Updates `Formula/dutis.rb` in `tsonglew/homebrew-tap`.
 
@@ -39,4 +40,5 @@ After the workflow succeeds, verify installation in a clean environment:
 brew update
 brew install tsonglew/tap/dutis
 dutis --help
+test -f "$(brew --prefix dutis)/share/dutis/skills/dutis/SKILL.md"
 ```

--- a/dutis.policy.example.toml
+++ b/dutis.policy.example.toml
@@ -1,0 +1,10 @@
+version = 1
+approval_mode = "explicit"
+
+# Omit either allowlist to permit any value. An empty list permits none.
+allowed_extensions = ["md", "txt", "json"]
+allowed_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
+
+# A protected extension may only remain on, or be restored to, this bundle ID.
+[protected_associations]
+pdf = "com.apple.Preview"

--- a/scripts/render_homebrew_formula.rb
+++ b/scripts/render_homebrew_formula.rb
@@ -20,6 +20,8 @@ formula = <<~RUBY
 
     def install
       bin.install "dutis"
+      pkgshare.install "skills"
+      pkgshare.install "dutis.policy.example.toml"
     end
 
     test do

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: dutis
+description: Inspect, plan, safely change, or roll back macOS default file applications with Dutis through its CLI or MCP tools.
+---
+
+# Dutis
+
+Use Dutis for macOS filename-extension associations. Preserve its
+`inspect -> plan -> policy check -> approval -> apply -> verify` boundary.
+
+## Workflow
+
+1. Start read-only. Check readiness and the effective policy, then inspect the
+   requested extensions and installed handlers.
+2. Express multi-extension changes as versioned TOML. Build a fresh plan and
+   run the policy check. Treat unresolved selectors or policy violations as a
+   stop condition.
+3. Show the user the exact changed extensions, target bundle IDs, plan digest,
+   and any policy constraints. Run dry-run before requesting approval.
+4. Ask for explicit approval immediately before a write. Never infer approval
+   from an earlier inspection request.
+5. Apply only the reviewed digest, include a meaningful requester identity,
+   and report the resulting safety snapshot and audit IDs.
+6. Verify with `dutis get`, then use `dutis audit` when the user needs the full
+   local record.
+
+For CLI workflows, prefer `dutis plan`, `dutis policy check`, and
+`dutis apply --dry-run` before the confirmed `dutis apply` command with
+`--yes`, `--plan-digest`, and `--requester`. For rollback, preview with
+`dutis rollback <id> --dry-run` before the confirmed command.
+
+For MCP workflows, use `dutis_diff` and `dutis_policy_check` before
+`dutis_apply`, or `dutis_rollback_plan` before `dutis_rollback`. Mutation tools
+must be advertised by the server and require a fresh digest, an approval token,
+and `requester`. Never invent, persist, echo, or request disclosure of a secret
+token; use only a token supplied through the authorized workflow.
+
+Do not bypass Dutis with raw `duti` mutation commands. Do not weaken or rewrite
+the local policy unless the user explicitly asks to change that policy.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,10 @@ pub enum CliCommand {
     History(OutputArgs),
     /// Restore associations from a local snapshot
     Rollback(RollbackArgs),
+    /// Inspect the effective local mutation policy
+    Policy(PolicyArgs),
+    /// List persistent local mutation audit records
+    Audit(OutputArgs),
     /// Run the local Model Context Protocol server over stdio
     Mcp(McpArgs),
     /// Check whether dutis and its runtime dependency are ready
@@ -72,6 +76,9 @@ pub struct SetArgs {
     /// Emit stable machine-readable JSON
     #[arg(long)]
     pub json: bool,
+    /// Identity recorded in the local mutation audit
+    #[arg(long)]
+    pub requester: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -99,6 +106,9 @@ pub struct ApplyArgs {
     /// Emit stable machine-readable JSON
     #[arg(long)]
     pub json: bool,
+    /// Identity recorded in the local mutation audit
+    #[arg(long)]
+    pub requester: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -133,6 +143,32 @@ pub struct RollbackArgs {
     /// Confirm a non-interactive rollback
     #[arg(long)]
     pub yes: bool,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+    /// Identity recorded in the local mutation audit
+    #[arg(long)]
+    pub requester: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct PolicyArgs {
+    #[command(subcommand)]
+    pub command: PolicyCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PolicyCommand {
+    /// Show the effective policy and its source
+    Show(OutputArgs),
+    /// Check a declarative plan against the effective policy
+    Check(PolicyCheckArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct PolicyCheckArgs {
+    /// Path to a versioned dutis TOML configuration
+    pub config: PathBuf,
     /// Emit stable machine-readable JSON
     #[arg(long)]
     pub json: bool,
@@ -246,5 +282,12 @@ mod tests {
             cli.command,
             Some(CliCommand::Mcp(McpArgs { allow_writes: true }))
         ));
+    }
+
+    #[test]
+    fn parses_policy_and_audit_commands() {
+        assert!(Cli::try_parse_from(["dutis", "policy", "show", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["dutis", "policy", "check", "dutis.toml", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["dutis", "audit", "--json"]).is_ok());
     }
 }

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -1,0 +1,949 @@
+use crate::application::normalize_extension;
+use crate::planner::{ApplyReport, AssociationPlan, PlanAction};
+use crate::snapshot::{apply_plan_with_snapshot, SnapshotReason, SnapshotStore};
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+pub const POLICY_VERSION: u32 = 1;
+pub const AUDIT_SCHEMA_VERSION: u32 = 1;
+const POLICY_FILE_ENV: &str = "DUTIS_POLICY_FILE";
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalMode {
+    #[default]
+    Explicit,
+    Token,
+    Deny,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct Policy {
+    pub version: u32,
+    pub approval_mode: ApprovalMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_extensions: Option<BTreeSet<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_applications: Option<BTreeSet<String>>,
+    pub protected_associations: BTreeMap<String, String>,
+    #[serde(skip_serializing)]
+    approval_token_sha256: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawPolicy {
+    version: u32,
+    #[serde(default)]
+    approval_mode: ApprovalMode,
+    allowed_extensions: Option<Vec<String>>,
+    allowed_applications: Option<Vec<String>>,
+    #[serde(default)]
+    protected_associations: BTreeMap<String, String>,
+    approval_token_sha256: Option<String>,
+}
+
+impl Default for Policy {
+    fn default() -> Self {
+        Self {
+            version: POLICY_VERSION,
+            approval_mode: ApprovalMode::Explicit,
+            allowed_extensions: None,
+            allowed_applications: None,
+            protected_associations: BTreeMap::new(),
+            approval_token_sha256: None,
+        }
+    }
+}
+
+impl Policy {
+    pub fn parse(contents: &str) -> Result<Self> {
+        let raw: RawPolicy = toml::from_str(contents).context("failed to parse policy TOML")?;
+        if raw.version != POLICY_VERSION {
+            bail!(
+                "unsupported policy version {}; expected {}",
+                raw.version,
+                POLICY_VERSION
+            );
+        }
+        let allowed_extensions = raw
+            .allowed_extensions
+            .map(normalize_extension_set)
+            .transpose()?;
+        let allowed_applications = raw
+            .allowed_applications
+            .map(|values| normalize_nonempty_set(values, "allowed application"))
+            .transpose()?;
+        let mut protected_associations = BTreeMap::new();
+        for (input_extension, input_bundle_id) in raw.protected_associations {
+            let extension = normalize_extension(&input_extension)?;
+            let bundle_id = input_bundle_id.trim();
+            if bundle_id.is_empty() {
+                bail!("protected application for .{extension} cannot be empty");
+            }
+            if protected_associations
+                .insert(extension.clone(), bundle_id.to_owned())
+                .is_some()
+            {
+                bail!("duplicate protected extension .{extension}");
+            }
+        }
+        if raw.approval_mode == ApprovalMode::Token {
+            let digest = raw.approval_token_sha256.as_deref().ok_or_else(|| {
+                anyhow!("approval_token_sha256 is required when approval_mode is 'token'")
+            })?;
+            if digest.len() != 64
+                || !digest
+                    .chars()
+                    .all(|character| character.is_ascii_hexdigit())
+            {
+                bail!("approval_token_sha256 must be a 64-character SHA-256 hex digest");
+            }
+        }
+        Ok(Self {
+            version: raw.version,
+            approval_mode: raw.approval_mode,
+            allowed_extensions,
+            allowed_applications,
+            protected_associations,
+            approval_token_sha256: raw
+                .approval_token_sha256
+                .map(|digest| digest.to_ascii_lowercase()),
+        })
+    }
+
+    pub fn assess(&self, plan: &AssociationPlan) -> PolicyAssessment {
+        let mut violations = Vec::new();
+        if self.approval_mode == ApprovalMode::Deny {
+            violations.push("policy denies all mutations".to_owned());
+        }
+        if plan.has_unresolved() {
+            violations.push(format!(
+                "plan contains {} unresolved association(s)",
+                plan.summary.unresolved
+            ));
+        }
+        for entry in plan
+            .entries
+            .iter()
+            .filter(|entry| entry.action == PlanAction::Change)
+        {
+            if self
+                .allowed_extensions
+                .as_ref()
+                .is_some_and(|allowed| !allowed.contains(&entry.extension))
+            {
+                violations.push(format!("extension .{} is not allowed", entry.extension));
+            }
+            let target_bundle_id = entry
+                .target
+                .as_ref()
+                .map(|target| target.bundle_id.as_str());
+            if self.allowed_applications.as_ref().is_some_and(|allowed| {
+                target_bundle_id.is_none_or(|bundle_id| !allowed.contains(bundle_id))
+            }) {
+                violations.push(format!(
+                    "target application for .{} is not allowed",
+                    entry.extension
+                ));
+            }
+            if let Some(required) = self.protected_associations.get(&entry.extension) {
+                if target_bundle_id != Some(required.as_str()) {
+                    violations.push(format!(
+                        "protected association .{} must remain assigned to {}",
+                        entry.extension, required
+                    ));
+                }
+            }
+        }
+        PolicyAssessment {
+            allowed: violations.is_empty() && self.approval_mode != ApprovalMode::Deny,
+            approval_mode: self.approval_mode,
+            violations,
+        }
+    }
+
+    fn authorize(&self, plan: &AssociationPlan, request: &MutationRequest) -> PolicyAssessment {
+        let mut assessment = self.assess(plan);
+        if request.requester.trim().is_empty() {
+            assessment
+                .violations
+                .push("requester must be a non-empty identifier".to_owned());
+        }
+        match self.approval_mode {
+            ApprovalMode::Explicit if !request.explicit_approval => assessment
+                .violations
+                .push("explicit approval is required".to_owned()),
+            ApprovalMode::Token => {
+                let authorized = self
+                    .approval_token_sha256
+                    .as_deref()
+                    .zip(request.approval_token.as_deref())
+                    .is_some_and(|(expected, provided)| token_digest_matches(expected, provided));
+                if !authorized {
+                    assessment
+                        .violations
+                        .push("policy approval token is missing or invalid".to_owned());
+                }
+            }
+            ApprovalMode::Deny => {}
+            ApprovalMode::Explicit => {}
+        }
+        assessment.allowed = assessment.violations.is_empty();
+        assessment
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct PolicyAssessment {
+    pub allowed: bool,
+    pub approval_mode: ApprovalMode,
+    pub violations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct LoadedPolicy {
+    pub path: PathBuf,
+    pub exists: bool,
+    pub digest: String,
+    pub policy: Policy,
+}
+
+impl LoadedPolicy {
+    pub fn from_environment() -> Result<Self> {
+        let path = if let Some(path) =
+            std::env::var_os(POLICY_FILE_ENV).filter(|value| !value.is_empty())
+        {
+            PathBuf::from(path)
+        } else {
+            SnapshotStore::from_environment()?
+                .root()
+                .join("policy.toml")
+        };
+        Self::load(path)
+    }
+
+    pub fn load(path: PathBuf) -> Result<Self> {
+        let (policy, exists) = if path.exists() {
+            let contents = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read policy {}", path.display()))?;
+            (
+                Policy::parse(&contents)
+                    .with_context(|| format!("invalid policy {}", path.display()))?,
+                true,
+            )
+        } else {
+            (Policy::default(), false)
+        };
+        let digest = policy_digest(&policy)?;
+        Ok(Self {
+            path,
+            exists,
+            digest,
+            policy,
+        })
+    }
+
+    pub fn summary(&self) -> PolicySummary {
+        PolicySummary {
+            path: self.path.clone(),
+            exists: self.exists,
+            digest: self.digest.clone(),
+            version: self.policy.version,
+            approval_mode: self.policy.approval_mode,
+            approval_token_configured: self.policy.approval_token_sha256.is_some(),
+            allowed_extensions: self.policy.allowed_extensions.clone(),
+            allowed_applications: self.policy.allowed_applications.clone(),
+            protected_associations: self.policy.protected_associations.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct PolicySummary {
+    pub path: PathBuf,
+    pub exists: bool,
+    pub digest: String,
+    pub version: u32,
+    pub approval_mode: ApprovalMode,
+    pub approval_token_configured: bool,
+    pub allowed_extensions: Option<BTreeSet<String>>,
+    pub allowed_applications: Option<BTreeSet<String>>,
+    pub protected_associations: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationChannel {
+    Cli,
+    Interactive,
+    Mcp,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationOperation {
+    Set,
+    Apply,
+    Rollback,
+}
+
+#[derive(Debug, Clone)]
+pub struct MutationRequest {
+    pub requester: String,
+    pub channel: MutationChannel,
+    pub operation: MutationOperation,
+    pub explicit_approval: bool,
+    pub approval_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditOutcome {
+    Pending,
+    Succeeded,
+    PartialFailure,
+    Denied,
+    FailedBeforeMutation,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct VerificationSummary {
+    pub succeeded: bool,
+    pub applied: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct MutationAuditRecord {
+    pub schema_version: u32,
+    pub id: String,
+    pub timestamp: String,
+    pub requester: String,
+    pub channel: MutationChannel,
+    pub operation: MutationOperation,
+    pub policy_digest: String,
+    pub approval_mode: ApprovalMode,
+    pub plan_digest: String,
+    pub plan: AssociationPlan,
+    pub outcome: AuditOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub safety_snapshot_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<ApplyReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification: Option<VerificationSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuditStore {
+    root: PathBuf,
+}
+
+impl AuditStore {
+    pub fn from_environment() -> Result<Self> {
+        Ok(Self::new(
+            SnapshotStore::from_environment()?.root().join("audit"),
+        ))
+    }
+
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn save(&self, record: &MutationAuditRecord) -> Result<PathBuf> {
+        validate_record_id(&record.id)?;
+        fs::create_dir_all(&self.root)
+            .with_context(|| format!("failed to create {}", self.root.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&self.root, fs::Permissions::from_mode(0o700))?;
+        }
+        let destination = self.root.join(format!("{}.json", record.id));
+        let temporary = self.root.join(format!(
+            ".{}.{}.{}.tmp",
+            record.id,
+            std::process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options
+            .open(&temporary)
+            .with_context(|| format!("failed to create {}", temporary.display()))?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, record)?;
+        writer.write_all(b"\n")?;
+        writer.flush()?;
+        writer.get_ref().sync_all()?;
+        fs::rename(&temporary, &destination)
+            .with_context(|| format!("failed to store audit record {}", destination.display()))?;
+        Ok(destination)
+    }
+
+    pub fn history(&self) -> Result<Vec<MutationAuditRecord>> {
+        if !self.root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut records = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let path = entry?.path();
+            if path.extension().is_none_or(|extension| extension != "json") {
+                continue;
+            }
+            let record: MutationAuditRecord =
+                serde_json::from_reader(BufReader::new(fs::File::open(&path)?))
+                    .with_context(|| format!("failed to parse audit record {}", path.display()))?;
+            let filename_id = path.file_stem().and_then(|value| value.to_str());
+            validate_audit_record(&record, filename_id)?;
+            records.push(record);
+        }
+        records.sort_by(|left: &MutationAuditRecord, right| right.id.cmp(&left.id));
+        Ok(records)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct GovernedMutation {
+    pub audit_id: String,
+    pub safety_snapshot_id: Option<String>,
+    #[serde(flatten)]
+    pub report: ApplyReport,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GovernanceErrorKind {
+    PolicyDenied,
+    AuditFailed,
+    SnapshotFailed,
+}
+
+#[derive(Debug)]
+pub struct GovernanceError {
+    kind: GovernanceErrorKind,
+    message: String,
+    audit_id: Option<String>,
+    violations: Vec<String>,
+}
+
+impl GovernanceError {
+    pub fn kind(&self) -> GovernanceErrorKind {
+        self.kind
+    }
+
+    pub fn audit_id(&self) -> Option<&str> {
+        self.audit_id.as_deref()
+    }
+
+    pub fn violations(&self) -> &[String] {
+        &self.violations
+    }
+}
+
+impl fmt::Display for GovernanceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for GovernanceError {}
+
+pub fn execute_governed_plan<F>(
+    plan: &AssociationPlan,
+    reason: SnapshotReason,
+    request: &MutationRequest,
+    apply: F,
+) -> std::result::Result<GovernedMutation, GovernanceError>
+where
+    F: FnMut(&str, &str) -> Result<()>,
+{
+    let policy = LoadedPolicy::from_environment().map_err(|error| GovernanceError {
+        kind: GovernanceErrorKind::PolicyDenied,
+        message: format!("failed to load mutation policy: {error:#}"),
+        audit_id: None,
+        violations: vec![format!("policy could not be loaded: {error:#}")],
+    })?;
+    let audit_store = AuditStore::from_environment().map_err(|error| GovernanceError {
+        kind: GovernanceErrorKind::AuditFailed,
+        message: format!("failed to resolve audit storage: {error:#}"),
+        audit_id: None,
+        violations: Vec::new(),
+    })?;
+    let snapshot_store = SnapshotStore::from_environment().map_err(|error| GovernanceError {
+        kind: GovernanceErrorKind::SnapshotFailed,
+        message: format!("failed to resolve snapshot storage: {error:#}"),
+        audit_id: None,
+        violations: Vec::new(),
+    })?;
+    execute_governed_plan_with(
+        &policy,
+        &audit_store,
+        &snapshot_store,
+        plan,
+        reason,
+        request,
+        apply,
+    )
+}
+
+fn execute_governed_plan_with<F>(
+    loaded_policy: &LoadedPolicy,
+    audit_store: &AuditStore,
+    snapshot_store: &SnapshotStore,
+    plan: &AssociationPlan,
+    reason: SnapshotReason,
+    request: &MutationRequest,
+    apply: F,
+) -> std::result::Result<GovernedMutation, GovernanceError>
+where
+    F: FnMut(&str, &str) -> Result<()>,
+{
+    let assessment = loaded_policy.policy.authorize(plan, request);
+    let mut record = new_audit_record(loaded_policy, plan, request);
+    if !assessment.allowed {
+        record.outcome = AuditOutcome::Denied;
+        record.error = Some(assessment.violations.join("; "));
+        audit_store.save(&record).map_err(|error| GovernanceError {
+            kind: GovernanceErrorKind::AuditFailed,
+            message: format!("policy denied mutation and audit storage failed: {error:#}"),
+            audit_id: Some(record.id.clone()),
+            violations: assessment.violations.clone(),
+        })?;
+        return Err(GovernanceError {
+            kind: GovernanceErrorKind::PolicyDenied,
+            message: format!(
+                "policy denied mutation: {}",
+                assessment.violations.join("; ")
+            ),
+            audit_id: Some(record.id),
+            violations: assessment.violations,
+        });
+    }
+
+    audit_store.save(&record).map_err(|error| GovernanceError {
+        kind: GovernanceErrorKind::AuditFailed,
+        message: format!("failed to create pending audit record; no changes were made: {error:#}"),
+        audit_id: Some(record.id.clone()),
+        violations: Vec::new(),
+    })?;
+
+    let protected = match apply_plan_with_snapshot(snapshot_store, plan, reason, apply) {
+        Ok(protected) => protected,
+        Err(error) => {
+            record.outcome = AuditOutcome::FailedBeforeMutation;
+            record.error = Some(format!("{error:#}"));
+            let _ = audit_store.save(&record);
+            return Err(GovernanceError {
+                kind: GovernanceErrorKind::SnapshotFailed,
+                message: format!(
+                    "failed to store safety snapshot; no changes were made: {error:#}"
+                ),
+                audit_id: Some(record.id),
+                violations: Vec::new(),
+            });
+        }
+    };
+    let verification = VerificationSummary {
+        succeeded: protected.report.failed == 0,
+        applied: protected.report.applied,
+        skipped: protected.report.skipped,
+        failed: protected.report.failed,
+    };
+    record.outcome = if verification.succeeded {
+        AuditOutcome::Succeeded
+    } else {
+        AuditOutcome::PartialFailure
+    };
+    record.safety_snapshot_id = protected
+        .safety_snapshot
+        .as_ref()
+        .map(|snapshot| snapshot.id.clone());
+    record.result = Some(protected.report.clone());
+    record.verification = Some(verification);
+    audit_store.save(&record).map_err(|error| GovernanceError {
+        kind: GovernanceErrorKind::AuditFailed,
+        message: format!(
+            "mutation completed but final audit record could not be stored; pending record {} remains: {error:#}",
+            record.id
+        ),
+        audit_id: Some(record.id.clone()),
+        violations: Vec::new(),
+    })?;
+
+    Ok(GovernedMutation {
+        audit_id: record.id,
+        safety_snapshot_id: record.safety_snapshot_id,
+        report: protected.report,
+    })
+}
+
+fn new_audit_record(
+    policy: &LoadedPolicy,
+    plan: &AssociationPlan,
+    request: &MutationRequest,
+) -> MutationAuditRecord {
+    let now = OffsetDateTime::now_utc();
+    let timestamp = now
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    let hash = Sha256::digest(
+        format!(
+            "{}:{}:{}:{:?}",
+            now.unix_timestamp_nanos(),
+            request.requester,
+            plan.digest,
+            request.operation
+        )
+        .as_bytes(),
+    );
+    let suffix = hash
+        .iter()
+        .take(6)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    MutationAuditRecord {
+        schema_version: AUDIT_SCHEMA_VERSION,
+        id: format!("{}-{suffix}", now.unix_timestamp_nanos()),
+        timestamp,
+        requester: request.requester.trim().to_owned(),
+        channel: request.channel,
+        operation: request.operation,
+        policy_digest: policy.digest.clone(),
+        approval_mode: policy.policy.approval_mode,
+        plan_digest: plan.digest.clone(),
+        plan: plan.clone(),
+        outcome: AuditOutcome::Pending,
+        safety_snapshot_id: None,
+        result: None,
+        verification: None,
+        error: None,
+    }
+}
+
+fn policy_digest(policy: &Policy) -> Result<String> {
+    let material = serde_json::to_vec(&(
+        policy,
+        policy.approval_token_sha256.as_deref().unwrap_or(""),
+    ))?;
+    Ok(Sha256::digest(material)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
+}
+
+fn token_digest_matches(expected: &str, provided: &str) -> bool {
+    let actual = Sha256::digest(provided.as_bytes());
+    let actual = actual
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    expected
+        .as_bytes()
+        .iter()
+        .zip(actual.as_bytes())
+        .fold(0_u8, |difference, (left, right)| {
+            difference | (left ^ right)
+        })
+        == 0
+}
+
+fn normalize_extension_set(values: Vec<String>) -> Result<BTreeSet<String>> {
+    let mut normalized = BTreeSet::new();
+    for value in values {
+        let extension = normalize_extension(&value)?;
+        if !normalized.insert(extension.clone()) {
+            bail!("duplicate allowed extension .{extension}");
+        }
+    }
+    Ok(normalized)
+}
+
+fn normalize_nonempty_set(values: Vec<String>, label: &str) -> Result<BTreeSet<String>> {
+    let mut normalized = BTreeSet::new();
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() {
+            bail!("{label} cannot be empty");
+        }
+        if !normalized.insert(value.to_owned()) {
+            bail!("duplicate {label} '{value}'");
+        }
+    }
+    Ok(normalized)
+}
+
+fn validate_record_id(id: &str) -> Result<()> {
+    if id.is_empty()
+        || !id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        bail!("invalid audit record ID '{id}'");
+    }
+    Ok(())
+}
+
+fn validate_audit_record(record: &MutationAuditRecord, expected_id: Option<&str>) -> Result<()> {
+    if record.schema_version != AUDIT_SCHEMA_VERSION {
+        bail!(
+            "unsupported audit schema version {}; expected {}",
+            record.schema_version,
+            AUDIT_SCHEMA_VERSION
+        );
+    }
+    validate_record_id(&record.id)?;
+    if expected_id.is_some_and(|id| id != record.id) {
+        bail!("audit record ID does not match its filename");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::planner::{assemble_plan, PlanEntry, PlannedApplication};
+    use crate::system::DefaultApplication;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_root(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("dutis-{label}-{}-{unique}", std::process::id()))
+    }
+
+    fn plan(extension: &str, target: &str) -> AssociationPlan {
+        assemble_plan(
+            1,
+            vec![PlanEntry {
+                extension: extension.to_owned(),
+                selector: target.to_owned(),
+                current: Some(DefaultApplication {
+                    extension: extension.to_owned(),
+                    name: None,
+                    path: None,
+                    bundle_id: "com.example.Old".to_owned(),
+                }),
+                target: Some(PlannedApplication {
+                    name: "Target".to_owned(),
+                    path: PathBuf::from("/Applications/Target.app"),
+                    bundle_id: target.to_owned(),
+                }),
+                action: PlanAction::Change,
+                reason: None,
+            }],
+        )
+        .unwrap()
+    }
+
+    fn loaded(policy: Policy, root: &Path) -> LoadedPolicy {
+        LoadedPolicy {
+            path: root.join("policy.toml"),
+            exists: true,
+            digest: policy_digest(&policy).unwrap(),
+            policy,
+        }
+    }
+
+    fn request(token: Option<&str>) -> MutationRequest {
+        MutationRequest {
+            requester: "test-agent".to_owned(),
+            channel: MutationChannel::Mcp,
+            operation: MutationOperation::Apply,
+            explicit_approval: true,
+            approval_token: token.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn parses_and_normalizes_policy() {
+        let policy = Policy::parse(
+            r#"
+                version = 1
+                approval_mode = "explicit"
+                allowed_extensions = [".MD", "txt"]
+                allowed_applications = ["com.example.Editor"]
+
+                [protected_associations]
+                ".PDF" = "com.apple.Preview"
+            "#,
+        )
+        .unwrap();
+        assert!(policy.allowed_extensions.unwrap().contains("md"));
+        assert_eq!(policy.protected_associations["pdf"], "com.apple.Preview");
+    }
+
+    #[test]
+    fn policy_denies_disallowed_targets_before_mutation() {
+        let root = temp_root("policy-denial");
+        let policy = Policy::parse(
+            r#"
+                version = 1
+                allowed_extensions = ["md"]
+                allowed_applications = ["com.example.Allowed"]
+            "#,
+        )
+        .unwrap();
+        let audit_store = AuditStore::new(root.join("audit"));
+        let snapshot_store = SnapshotStore::new(root.join("state"));
+        let result = execute_governed_plan_with(
+            &loaded(policy, &root),
+            &audit_store,
+            &snapshot_store,
+            &plan("md", "com.example.Denied"),
+            SnapshotReason::BeforeApply,
+            &request(None),
+            |_, _| panic!("policy denial reached mutation"),
+        );
+        assert_eq!(
+            result.unwrap_err().kind(),
+            GovernanceErrorKind::PolicyDenied
+        );
+        let records = audit_store.history().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].outcome, AuditOutcome::Denied);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn token_policy_requires_the_matching_digest() {
+        let digest = Sha256::digest(b"correct-token")
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        let policy = Policy::parse(&format!(
+            "version = 1\napproval_mode = 'token'\napproval_token_sha256 = '{digest}'\n"
+        ))
+        .unwrap();
+        let assessment =
+            policy.authorize(&plan("md", "com.example.Editor"), &request(Some("wrong")));
+        assert!(!assessment.allowed);
+        let assessment = policy.authorize(
+            &plan("md", "com.example.Editor"),
+            &request(Some("correct-token")),
+        );
+        assert!(assessment.allowed);
+    }
+
+    #[test]
+    fn protected_association_allows_restoration_but_denies_replacement() {
+        let policy =
+            Policy::parse("version = 1\n[protected_associations]\nmd = 'com.example.Protected'\n")
+                .unwrap();
+        assert!(policy.assess(&plan("md", "com.example.Protected")).allowed);
+        let denied = policy.assess(&plan("md", "com.example.Other"));
+        assert!(!denied.allowed);
+        assert!(denied.violations[0].contains("must remain assigned"));
+    }
+
+    #[test]
+    fn successful_mutation_persists_plan_result_and_verification() {
+        let root = temp_root("audit-success");
+        let policy = Policy::default();
+        let audit_store = AuditStore::new(root.join("audit"));
+        let snapshot_store = SnapshotStore::new(root.join("state"));
+        let result = execute_governed_plan_with(
+            &loaded(policy, &root),
+            &audit_store,
+            &snapshot_store,
+            &plan("md", "com.example.Editor"),
+            SnapshotReason::BeforeApply,
+            &request(None),
+            |_, _| Ok(()),
+        )
+        .unwrap();
+        assert_eq!(result.report.applied, 1);
+        let records = audit_store.history().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].requester, "test-agent");
+        assert_eq!(records[0].outcome, AuditOutcome::Succeeded);
+        assert_eq!(records[0].result.as_ref().unwrap().applied, 1);
+        assert!(records[0].verification.as_ref().unwrap().succeeded);
+        assert!(records[0].safety_snapshot_id.is_some());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let record_path = audit_store.root().join(format!("{}.json", result.audit_id));
+            assert_eq!(
+                fs::metadata(record_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+            assert_eq!(
+                fs::metadata(audit_store.root())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn repository_policy_example_uses_the_current_schema() {
+        let policy = Policy::parse(include_str!("../dutis.policy.example.toml")).unwrap();
+        assert_eq!(policy.version, POLICY_VERSION);
+        assert!(!policy.protected_associations.is_empty());
+    }
+
+    #[test]
+    fn partial_failure_is_persisted_with_failed_verification() {
+        let root = temp_root("audit-partial");
+        let audit_store = AuditStore::new(root.join("audit"));
+        let result = execute_governed_plan_with(
+            &loaded(Policy::default(), &root),
+            &audit_store,
+            &SnapshotStore::new(root.join("state")),
+            &plan("md", "com.example.Editor"),
+            SnapshotReason::BeforeApply,
+            &request(None),
+            |_, _| bail!("simulated verification failure"),
+        )
+        .unwrap();
+        assert_eq!(result.report.failed, 1);
+        let record = audit_store.history().unwrap().pop().unwrap();
+        assert_eq!(record.outcome, AuditOutcome::PartialFailure);
+        assert!(!record.verification.unwrap().succeeded);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn audit_storage_failure_prevents_mutation() {
+        let root = temp_root("audit-failure");
+        fs::write(&root, "not a directory").unwrap();
+        let result = execute_governed_plan_with(
+            &loaded(Policy::default(), Path::new("/policy")),
+            &AuditStore::new(root.clone()),
+            &SnapshotStore::new(temp_root("unused-snapshot")),
+            &plan("md", "com.example.Editor"),
+            SnapshotReason::BeforeApply,
+            &request(None),
+            |_, _| panic!("mutation ran without an audit record"),
+        );
+        assert_eq!(result.unwrap_err().kind(), GovernanceErrorKind::AuditFailed);
+        fs::remove_file(root).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app_scanner;
 pub mod application;
 pub mod config;
+pub mod governance;
 pub mod mcp;
 pub mod planner;
 pub mod plist_parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{
-    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, McpArgs, OutputArgs, RollbackArgs,
-    SetArgs, SnapshotArgs, SnapshotCommand, SnapshotCreateArgs,
+    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, McpArgs, OutputArgs, PolicyArgs,
+    PolicyCheckArgs, PolicyCommand, RollbackArgs, SetArgs, SnapshotArgs, SnapshotCommand,
+    SnapshotCreateArgs,
 };
 use colored::*;
 use dutis::application::{
@@ -10,12 +11,16 @@ use dutis::application::{
     ApplicationCatalog,
 };
 use dutis::config::DutisConfig;
+use dutis::governance::{
+    execute_governed_plan, AuditStore, GovernanceErrorKind, GovernedMutation, LoadedPolicy,
+    MutationChannel, MutationOperation, MutationRequest, PolicyAssessment,
+};
 use dutis::planner::{
-    build_plan, ApplyReport, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
+    assemble_plan, build_plan, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
+    PlannedApplication,
 };
 use dutis::snapshot::{
-    apply_plan_with_snapshot, build_rollback_plan, capture_associations, SnapshotReason,
-    SnapshotStore, SnapshotSummary,
+    build_rollback_plan, capture_associations, SnapshotReason, SnapshotStore, SnapshotSummary,
 };
 use dutis::system;
 use serde::Serialize;
@@ -64,6 +69,10 @@ impl CliError {
 
     fn partial_failure(message: impl Into<String>, details: Value) -> Self {
         Self::new(8, "partial_failure", message).with_details(details)
+    }
+
+    fn policy_denied(message: impl Into<String>, details: Value) -> Self {
+        Self::new(9, "policy_denied", message).with_details(details)
     }
 
     fn new(code: u8, kind: &'static str, message: impl Into<String>) -> Self {
@@ -123,6 +132,10 @@ struct SetResult<'a> {
     extension: &'a str,
     application: &'a Application,
     command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    audit_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    safety_snapshot_id: Option<&'a str>,
 }
 
 #[derive(Serialize)]
@@ -148,15 +161,15 @@ struct SnapshotCreated {
 }
 
 #[derive(Serialize)]
-struct MutationResult {
-    safety_snapshot_id: Option<String>,
-    #[serde(flatten)]
-    report: ApplyReport,
+struct RollbackPreview<'a> {
+    snapshot_id: &'a str,
+    plan: &'a AssociationPlan,
 }
 
 #[derive(Serialize)]
-struct RollbackPreview<'a> {
-    snapshot_id: &'a str,
+struct PolicyCheckResult<'a> {
+    policy: dutis::governance::PolicySummary,
+    assessment: PolicyAssessment,
     plan: &'a AssociationPlan,
 }
 
@@ -207,6 +220,8 @@ fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
         Some(CliCommand::Snapshot(args)) => run_snapshot(args),
         Some(CliCommand::History(args)) => run_history(args),
         Some(CliCommand::Rollback(args)) => run_rollback(args),
+        Some(CliCommand::Policy(args)) => run_policy(args),
+        Some(CliCommand::Audit(args)) => run_audit(args),
         Some(CliCommand::Mcp(args)) => run_mcp(args),
         Some(CliCommand::Doctor(args)) => run_doctor(args),
     }
@@ -224,6 +239,8 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Snapshot(_) => "snapshot",
         CliCommand::History(_) => "history",
         CliCommand::Rollback(_) => "rollback",
+        CliCommand::Policy(_) => "policy",
+        CliCommand::Audit(_) => "audit",
         CliCommand::Mcp(_) => "mcp",
         CliCommand::Doctor(_) => "doctor",
     }
@@ -241,6 +258,11 @@ fn command_uses_json(command: &CliCommand) -> bool {
         },
         CliCommand::History(args) => args.json,
         CliCommand::Rollback(args) => args.json,
+        CliCommand::Policy(args) => match &args.command {
+            PolicyCommand::Show(args) => args.json,
+            PolicyCommand::Check(args) => args.json,
+        },
+        CliCommand::Audit(args) => args.json,
         CliCommand::Mcp(_) => false,
     }
 }
@@ -250,6 +272,110 @@ fn run_mcp(args: McpArgs) -> Result<(), CliError> {
         .map_err(|error| CliError::usage(format!("{error:#}")))?;
     dutis::mcp::serve_stdio(options)
         .map_err(|error| CliError::operation(format!("MCP server failed: {error:#}")))
+}
+
+fn run_policy(args: PolicyArgs) -> Result<(), CliError> {
+    match args.command {
+        PolicyCommand::Show(args) => run_policy_show(args),
+        PolicyCommand::Check(args) => run_policy_check(args),
+    }
+}
+
+fn run_policy_show(args: OutputArgs) -> Result<(), CliError> {
+    let policy = LoadedPolicy::from_environment()
+        .map_err(|error| CliError::usage(format!("failed to load policy: {error:#}")))?;
+    let summary = policy.summary();
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "policy",
+            data: summary,
+        })?;
+    } else {
+        println!("Policy: {}", summary.path.display());
+        println!(
+            "Source: {}",
+            if summary.exists {
+                "configured"
+            } else {
+                "built-in default"
+            }
+        );
+        println!("Digest: {}", summary.digest);
+        println!("Approval mode: {:?}", summary.approval_mode);
+        println!(
+            "Approval token configured: {}",
+            summary.approval_token_configured
+        );
+    }
+    Ok(())
+}
+
+fn run_policy_check(args: PolicyCheckArgs) -> Result<(), CliError> {
+    let plan = build_declarative_plan(&args.config)?;
+    let policy = LoadedPolicy::from_environment()
+        .map_err(|error| CliError::usage(format!("failed to load policy: {error:#}")))?;
+    let result = PolicyCheckResult {
+        policy: policy.summary(),
+        assessment: policy.policy.assess(&plan),
+        plan: &plan,
+    };
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "policy",
+            data: result,
+        })?;
+    } else {
+        println!(
+            "Policy decision: {}",
+            if result.assessment.allowed {
+                "allowed"
+            } else {
+                "denied"
+            }
+        );
+        for violation in &result.assessment.violations {
+            println!("DENY: {violation}");
+        }
+        println!();
+        print_plan(&plan, false);
+    }
+    Ok(())
+}
+
+fn run_audit(args: OutputArgs) -> Result<(), CliError> {
+    let store = AuditStore::from_environment().map_err(|error| {
+        CliError::operation(format!("failed to resolve audit storage: {error:#}"))
+    })?;
+    let records = store
+        .history()
+        .map_err(|error| CliError::operation(format!("failed to read audit history: {error:#}")))?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "audit",
+            data: records,
+        })?;
+    } else if records.is_empty() {
+        println!(
+            "No mutation audit records found in {}",
+            store.root().display()
+        );
+    } else {
+        for record in records {
+            println!(
+                "{}\t{}\t{:?}\t{:?}\t{}\t{:?}",
+                record.id,
+                record.timestamp,
+                record.channel,
+                record.operation,
+                record.requester,
+                record.outcome
+            );
+        }
+    }
+    Ok(())
 }
 
 fn run_list(args: OutputArgs) -> Result<(), CliError> {
@@ -382,16 +508,47 @@ fn run_set(args: SetArgs) -> Result<(), CliError> {
         "all".to_owned(),
     ];
 
-    let status = apply_or_preview(
-        args.dry_run,
-        &extension,
-        bundle_id,
-        |extension, bundle_id| {
-            system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
-            system::set_default_app(extension, bundle_id)
-                .map_err(|error| CliError::operation(format!("{error:#}")))
-        },
-    )?;
+    let mutation = if args.dry_run {
+        None
+    } else {
+        system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
+        let current = system::query_default_app(&extension)
+            .map_err(|error| CliError::operation(format!("{error:#}")))?;
+        let action = if current.as_ref().map(|value| value.bundle_id.as_str()) == Some(bundle_id) {
+            PlanAction::Unchanged
+        } else {
+            PlanAction::Change
+        };
+        let plan = assemble_plan(
+            dutis::config::CONFIG_VERSION,
+            vec![PlanEntry {
+                extension: extension.clone(),
+                selector: args.app_selector.clone(),
+                current,
+                target: PlannedApplication::from_application(app),
+                action,
+                reason: None,
+            }],
+        )
+        .map_err(|error| CliError::operation(format!("failed to build set plan: {error:#}")))?;
+        let request = cli_mutation_request(args.requester.as_deref(), MutationOperation::Set);
+        let result = execute_governed_cli_plan(&plan, SnapshotReason::BeforeApply, &request)?;
+        if result.report.failed > 0 {
+            let details = serde_json::to_value(&result).map_err(|error| {
+                CliError::operation(format!("failed to serialize report: {error}"))
+            })?;
+            return Err(CliError::partial_failure(
+                "the association failed to apply or verify",
+                details,
+            ));
+        }
+        Some(result)
+    };
+    let status = match mutation.as_ref() {
+        None => "planned",
+        Some(result) if result.report.applied > 0 => "applied",
+        Some(_) => "unchanged",
+    };
 
     if args.json {
         write_json(&JsonEnvelope {
@@ -402,6 +559,10 @@ fn run_set(args: SetArgs) -> Result<(), CliError> {
                 extension: &extension,
                 application: app,
                 command,
+                audit_id: mutation.as_ref().map(|result| result.audit_id.as_str()),
+                safety_snapshot_id: mutation
+                    .as_ref()
+                    .and_then(|result| result.safety_snapshot_id.as_deref()),
             },
         })?;
     } else if args.dry_run {
@@ -410,11 +571,15 @@ fn run_set(args: SetArgs) -> Result<(), CliError> {
             app.name
         );
         println!("Command: {}", shell_display(&command));
-    } else {
+    } else if let Some(result) = mutation {
         println!(
             "Set .{extension} to {} ({bundle_id}) and verified it",
             app.name
         );
+        println!("Audit record: {}", result.audit_id);
+        if let Some(snapshot_id) = result.safety_snapshot_id {
+            println!("Safety snapshot: {snapshot_id}");
+        }
     }
     Ok(())
 }
@@ -510,7 +675,8 @@ fn run_apply(args: ApplyArgs) -> Result<(), CliError> {
         ));
     }
 
-    let result = execute_plan_with_snapshot(&plan, SnapshotReason::BeforeApply)?;
+    let request = cli_mutation_request(args.requester.as_deref(), MutationOperation::Apply);
+    let result = execute_governed_cli_plan(&plan, SnapshotReason::BeforeApply, &request)?;
     if result.report.failed > 0 {
         let details = serde_json::to_value(&result)
             .map_err(|error| CliError::operation(format!("failed to serialize report: {error}")))?;
@@ -676,7 +842,8 @@ fn run_rollback(args: RollbackArgs) -> Result<(), CliError> {
         .with_details(details));
     }
 
-    let result = execute_plan_with_snapshot(&plan, SnapshotReason::BeforeRollback)?;
+    let request = cli_mutation_request(args.requester.as_deref(), MutationOperation::Rollback);
+    let result = execute_governed_cli_plan(&plan, SnapshotReason::BeforeRollback, &request)?;
     if result.report.failed > 0 {
         let details = serde_json::to_value(&result)
             .map_err(|error| CliError::operation(format!("failed to serialize report: {error}")))?;
@@ -704,21 +871,53 @@ fn run_rollback(args: RollbackArgs) -> Result<(), CliError> {
     Ok(())
 }
 
-fn execute_plan_with_snapshot(
+fn execute_governed_cli_plan(
     plan: &AssociationPlan,
     reason: SnapshotReason,
-) -> Result<MutationResult, CliError> {
-    let store = snapshot_store()?;
-    let protected = apply_plan_with_snapshot(&store, plan, reason, system::set_default_app)
-        .map_err(|error| {
-            CliError::operation(format!(
-                "failed to store safety snapshot; no changes were made: {error:#}"
-            ))
-        })?;
-    Ok(MutationResult {
-        safety_snapshot_id: protected.safety_snapshot.map(|snapshot| snapshot.id),
-        report: protected.report,
-    })
+    request: &MutationRequest,
+) -> Result<GovernedMutation, CliError> {
+    execute_governed_plan(plan, reason, request, system::set_default_app)
+        .map_err(governance_cli_error)
+}
+
+fn governance_cli_error(error: dutis::governance::GovernanceError) -> CliError {
+    let details = serde_json::json!({
+        "audit_id": error.audit_id(),
+        "violations": error.violations(),
+    });
+    if error.kind() == GovernanceErrorKind::PolicyDenied {
+        CliError::policy_denied(error.to_string(), details)
+    } else {
+        CliError::operation(error.to_string()).with_details(details)
+    }
+}
+
+fn cli_mutation_request(
+    requested_identity: Option<&str>,
+    operation: MutationOperation,
+) -> MutationRequest {
+    let requester = requested_identity
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .or_else(|| {
+            std::env::var("DUTIS_REQUESTER")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| {
+            std::env::var("USER")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or_else(|| "local-user".to_owned());
+    MutationRequest {
+        requester,
+        channel: MutationChannel::Cli,
+        operation,
+        explicit_approval: true,
+        approval_token: std::env::var("DUTIS_APPROVAL_TOKEN").ok(),
+    }
 }
 
 fn snapshot_store() -> Result<SnapshotStore, CliError> {
@@ -777,7 +976,8 @@ fn print_plan(plan: &AssociationPlan, changes_only: bool) {
     println!("Plan digest: {}", plan.digest);
 }
 
-fn print_mutation_result(result: &MutationResult) {
+fn print_mutation_result(result: &GovernedMutation) {
+    println!("Audit record: {}", result.audit_id);
     if let Some(snapshot_id) = &result.safety_snapshot_id {
         println!("Safety snapshot: {snapshot_id}\n");
     }
@@ -797,22 +997,6 @@ fn print_mutation_result(result: &MutationResult) {
         "\nApplied: {}, skipped: {}, failed: {}",
         result.report.applied, result.report.skipped, result.report.failed
     );
-}
-
-fn apply_or_preview<F>(
-    dry_run: bool,
-    extension: &str,
-    bundle_id: &str,
-    apply: F,
-) -> Result<&'static str, CliError>
-where
-    F: FnOnce(&str, &str) -> Result<(), CliError>,
-{
-    if dry_run {
-        return Ok("planned");
-    }
-    apply(extension, bundle_id)?;
-    Ok("applied")
 }
 
 fn run_doctor(args: OutputArgs) -> Result<(), CliError> {
@@ -1050,13 +1234,45 @@ fn set_default_and_report(extension: &str, app: &Application) {
         .bundle_id
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("{} has no readable bundle identifier", app.path.display()))
-        .and_then(|bundle_id| system::set_default_app(extension, bundle_id));
+        .and_then(|bundle_id| {
+            system::duti_version()?;
+            let current = system::query_default_app(extension)?;
+            let action =
+                if current.as_ref().map(|value| value.bundle_id.as_str()) == Some(bundle_id) {
+                    PlanAction::Unchanged
+                } else {
+                    PlanAction::Change
+                };
+            let plan = assemble_plan(
+                dutis::config::CONFIG_VERSION,
+                vec![PlanEntry {
+                    extension: extension.to_owned(),
+                    selector: bundle_id.to_owned(),
+                    current,
+                    target: PlannedApplication::from_application(app),
+                    action,
+                    reason: None,
+                }],
+            )?;
+            let mut request = cli_mutation_request(None, MutationOperation::Set);
+            request.channel = MutationChannel::Interactive;
+            execute_governed_plan(
+                &plan,
+                SnapshotReason::BeforeApply,
+                &request,
+                system::set_default_app,
+            )
+            .map_err(anyhow::Error::from)
+        });
     match result {
-        Ok(()) => println!(
-            "✅ Successfully set {} as the default application for .{} files!",
-            app.name.bright_green(),
-            extension.yellow()
-        ),
+        Ok(result) => {
+            println!(
+                "✅ Successfully set {} as the default application for .{} files!",
+                app.name.bright_green(),
+                extension.yellow()
+            );
+            println!("Audit record: {}", result.audit_id);
+        }
         Err(error) => println!("❌ Failed to set default application: {error:#}"),
     }
 }
@@ -1160,14 +1376,5 @@ mod tests {
         assert_eq!(json["api_version"], "1");
         assert_eq!(json["command"], "test");
         assert_eq!(json["data"][0], "ok");
-    }
-
-    #[test]
-    fn dry_run_never_calls_mutating_operation() {
-        let status = apply_or_preview(true, "md", "com.example.Editor", |_, _| {
-            panic!("dry-run attempted a mutation")
-        })
-        .unwrap();
-        assert_eq!(status, "planned");
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,9 +1,11 @@
 use crate::application::{find_apps_for_extension, normalize_extension, ApplicationCatalog};
 use crate::config::DutisConfig;
-use crate::planner::{build_plan, AssociationPlan};
-use crate::snapshot::{
-    apply_plan_with_snapshot, build_rollback_plan, SnapshotReason, SnapshotStore,
+use crate::governance::{
+    execute_governed_plan, AuditStore, GovernanceError, GovernanceErrorKind, LoadedPolicy,
+    MutationChannel, MutationOperation, MutationRequest,
 };
+use crate::planner::{build_plan, AssociationPlan};
+use crate::snapshot::{build_rollback_plan, SnapshotReason, SnapshotStore};
 use crate::system;
 use anyhow::{anyhow, Context, Result};
 use serde::Serialize;
@@ -71,21 +73,22 @@ pub struct McpAuditEvent {
     pub error_kind: Option<String>,
 }
 
-#[derive(Serialize)]
-struct MutationResult {
-    safety_snapshot_id: Option<String>,
-    #[serde(flatten)]
-    report: crate::planner::ApplyReport,
-}
-
 trait McpBackend {
     fn list(&mut self) -> Result<Value>;
     fn query(&mut self, extension: &str) -> Result<Value>;
     fn get(&mut self, extension: &str) -> Result<Value>;
     fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan>;
-    fn apply(&mut self, plan: &AssociationPlan, reason: SnapshotReason) -> Result<Value>;
+    fn apply(
+        &mut self,
+        plan: &AssociationPlan,
+        reason: SnapshotReason,
+        request: &MutationRequest,
+    ) -> Result<Value>;
     fn history(&mut self) -> Result<Value>;
     fn rollback_plan(&mut self, snapshot_id: &str) -> Result<AssociationPlan>;
+    fn policy(&mut self) -> Result<Value>;
+    fn policy_check(&mut self, plan: &AssociationPlan) -> Result<Value>;
+    fn audit(&mut self) -> Result<Value>;
 }
 
 struct SystemBackend;
@@ -120,14 +123,15 @@ impl McpBackend for SystemBackend {
         build_plan(config, &catalog.applications, system::query_default_app)
     }
 
-    fn apply(&mut self, plan: &AssociationPlan, reason: SnapshotReason) -> Result<Value> {
-        let store = SnapshotStore::from_environment()?;
-        let protected = apply_plan_with_snapshot(&store, plan, reason, system::set_default_app)?;
-        serde_json::to_value(MutationResult {
-            safety_snapshot_id: protected.safety_snapshot.map(|snapshot| snapshot.id),
-            report: protected.report,
-        })
-        .context("failed to serialize mutation result")
+    fn apply(
+        &mut self,
+        plan: &AssociationPlan,
+        reason: SnapshotReason,
+        request: &MutationRequest,
+    ) -> Result<Value> {
+        let result = execute_governed_plan(plan, reason, request, system::set_default_app)
+            .map_err(anyhow::Error::from)?;
+        serde_json::to_value(result).context("failed to serialize mutation result")
     }
 
     fn history(&mut self) -> Result<Value> {
@@ -141,6 +145,25 @@ impl McpBackend for SystemBackend {
         system::duti_version()?;
         let catalog = ApplicationCatalog::scan()?;
         build_rollback_plan(&snapshot, &catalog.applications, system::query_default_app)
+    }
+
+    fn policy(&mut self) -> Result<Value> {
+        let policy = LoadedPolicy::from_environment()?;
+        serde_json::to_value(policy.summary()).context("failed to serialize mutation policy")
+    }
+
+    fn policy_check(&mut self, plan: &AssociationPlan) -> Result<Value> {
+        let policy = LoadedPolicy::from_environment()?;
+        Ok(json!({
+            "policy": policy.summary(),
+            "assessment": policy.policy.assess(plan),
+            "plan": plan,
+        }))
+    }
+
+    fn audit(&mut self) -> Result<Value> {
+        let records = AuditStore::from_environment()?.history()?;
+        serde_json::to_value(records).context("failed to serialize mutation audit history")
     }
 }
 
@@ -282,6 +305,13 @@ impl<B: McpBackend> McpServer<B> {
                 serde_json::to_value(plan).map_err(|error| operation_error(error.into()))
             }
             "dutis_history" => self.backend.history().map_err(operation_error),
+            "dutis_policy" => self.backend.policy().map_err(operation_error),
+            "dutis_policy_check" => {
+                let config = parse_config(arguments)?;
+                let plan = self.backend.plan(&config).map_err(operation_error)?;
+                self.backend.policy_check(&plan).map_err(operation_error)
+            }
+            "dutis_audit" => self.backend.audit().map_err(operation_error),
             "dutis_rollback_plan" => {
                 let snapshot_id = argument_string(arguments, "snapshot_id")?;
                 let plan = self
@@ -291,19 +321,28 @@ impl<B: McpBackend> McpServer<B> {
                 serde_json::to_value(plan).map_err(|error| operation_error(error.into()))
             }
             "dutis_apply" => {
-                self.authorize_write(arguments)?;
+                let approval_token = self.authorize_write(arguments)?;
+                let requester = argument_string(arguments, "requester")?;
                 let config = parse_config(arguments)?;
                 let expected_digest = argument_string(arguments, "plan_digest")?;
                 let plan = self.backend.plan(&config).map_err(operation_error)?;
                 validate_mutation_plan(&plan, expected_digest)?;
+                let request = MutationRequest {
+                    requester: requester.to_owned(),
+                    channel: MutationChannel::Mcp,
+                    operation: MutationOperation::Apply,
+                    explicit_approval: true,
+                    approval_token: Some(approval_token),
+                };
                 let result = self
                     .backend
-                    .apply(&plan, SnapshotReason::BeforeApply)
+                    .apply(&plan, SnapshotReason::BeforeApply, &request)
                     .map_err(operation_error)?;
                 validate_apply_result(result)
             }
             "dutis_rollback" => {
-                self.authorize_write(arguments)?;
+                let approval_token = self.authorize_write(arguments)?;
+                let requester = argument_string(arguments, "requester")?;
                 let snapshot_id = argument_string(arguments, "snapshot_id")?;
                 let expected_digest = argument_string(arguments, "plan_digest")?;
                 let plan = self
@@ -311,9 +350,16 @@ impl<B: McpBackend> McpServer<B> {
                     .rollback_plan(snapshot_id)
                     .map_err(operation_error)?;
                 validate_mutation_plan(&plan, expected_digest)?;
+                let request = MutationRequest {
+                    requester: requester.to_owned(),
+                    channel: MutationChannel::Mcp,
+                    operation: MutationOperation::Rollback,
+                    explicit_approval: true,
+                    approval_token: Some(approval_token),
+                };
                 let result = self
                     .backend
-                    .apply(&plan, SnapshotReason::BeforeRollback)
+                    .apply(&plan, SnapshotReason::BeforeRollback, &request)
                     .map_err(operation_error)?;
                 validate_apply_result(result)
             }
@@ -327,7 +373,7 @@ impl<B: McpBackend> McpServer<B> {
     fn authorize_write(
         &self,
         arguments: &Map<String, Value>,
-    ) -> std::result::Result<(), ToolError> {
+    ) -> std::result::Result<String, ToolError> {
         if !self.options.allow_writes {
             return Err(ToolError::new(
                 "write_disabled",
@@ -346,7 +392,7 @@ impl<B: McpBackend> McpServer<B> {
                 "approval token does not match",
             ));
         }
-        Ok(())
+        Ok(provided.to_owned())
     }
 }
 
@@ -418,6 +464,17 @@ fn parse_config(arguments: &Map<String, Value>) -> std::result::Result<DutisConf
 }
 
 fn operation_error(error: anyhow::Error) -> ToolError {
+    if let Some(governance) = error.downcast_ref::<GovernanceError>() {
+        let kind = match governance.kind() {
+            GovernanceErrorKind::PolicyDenied => "policy_denied",
+            GovernanceErrorKind::AuditFailed => "audit_failed",
+            GovernanceErrorKind::SnapshotFailed => "snapshot_failed",
+        };
+        return ToolError::new(kind, governance.to_string()).with_details(json!({
+            "audit_id": governance.audit_id(),
+            "violations": governance.violations(),
+        }));
+    }
     ToolError::new("operation_failed", format!("{error:#}"))
 }
 
@@ -554,13 +611,31 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
         tool_definition(
             "dutis_history",
             "List locally stored safety snapshots in newest-first order.",
-            empty_schema,
+            empty_schema.clone(),
             read_annotations.clone(),
         ),
         tool_definition(
             "dutis_rollback_plan",
             "Build a deterministic rollback plan and digest without changing the system.",
             snapshot_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_policy",
+            "Inspect the effective local mutation policy without exposing token hashes.",
+            empty_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_policy_check",
+            "Build a plan and evaluate it against the effective local mutation policy.",
+            config_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_audit",
+            "List persistent local mutation audit records in newest-first order.",
+            empty_schema,
             read_annotations,
         ),
     ];
@@ -579,9 +654,10 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
                 "properties": {
                     "config_toml": {"type": "string", "minLength": 1},
                     "plan_digest": {"type": "string", "minLength": 1},
-                    "approval_token": {"type": "string", "minLength": 1}
+                    "approval_token": {"type": "string", "minLength": 1},
+                    "requester": {"type": "string", "minLength": 1}
                 },
-                "required": ["config_toml", "plan_digest", "approval_token"],
+                "required": ["config_toml", "plan_digest", "approval_token", "requester"],
                 "additionalProperties": false,
             }),
             write_annotations.clone(),
@@ -594,9 +670,10 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
                 "properties": {
                     "snapshot_id": {"type": "string", "minLength": 1},
                     "plan_digest": {"type": "string", "minLength": 1},
-                    "approval_token": {"type": "string", "minLength": 1}
+                    "approval_token": {"type": "string", "minLength": 1},
+                    "requester": {"type": "string", "minLength": 1}
                 },
-                "required": ["snapshot_id", "plan_digest", "approval_token"],
+                "required": ["snapshot_id", "plan_digest", "approval_token", "requester"],
                 "additionalProperties": false,
             }),
             write_annotations,
@@ -675,7 +752,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::planner::{ApplyReport, PlanSummary};
+    use crate::planner::PlanSummary;
 
     struct FakeBackend {
         plan: AssociationPlan,
@@ -719,19 +796,22 @@ mod tests {
             Ok(self.plan.clone())
         }
 
-        fn apply(&mut self, plan: &AssociationPlan, _reason: SnapshotReason) -> Result<Value> {
+        fn apply(
+            &mut self,
+            plan: &AssociationPlan,
+            _reason: SnapshotReason,
+            _request: &MutationRequest,
+        ) -> Result<Value> {
             self.apply_calls += 1;
-            serde_json::to_value(MutationResult {
-                safety_snapshot_id: None,
-                report: ApplyReport {
-                    plan_digest: plan.digest.clone(),
-                    applied: 0,
-                    skipped: 0,
-                    failed: 0,
-                    results: Vec::new(),
-                },
-            })
-            .map_err(Into::into)
+            Ok(json!({
+                "audit_id": "test-audit",
+                "safety_snapshot_id": null,
+                "plan_digest": plan.digest,
+                "applied": 0,
+                "skipped": 0,
+                "failed": 0,
+                "results": []
+            }))
         }
 
         fn history(&mut self) -> Result<Value> {
@@ -740,6 +820,21 @@ mod tests {
 
         fn rollback_plan(&mut self, _snapshot_id: &str) -> Result<AssociationPlan> {
             Ok(self.plan.clone())
+        }
+
+        fn policy(&mut self) -> Result<Value> {
+            Ok(json!({"approval_mode": "explicit"}))
+        }
+
+        fn policy_check(&mut self, plan: &AssociationPlan) -> Result<Value> {
+            Ok(json!({
+                "assessment": {"allowed": true, "approval_mode": "explicit", "violations": []},
+                "plan": plan
+            }))
+        }
+
+        fn audit(&mut self) -> Result<Value> {
+            Ok(json!([]))
         }
     }
 
@@ -774,6 +869,8 @@ mod tests {
             .map(|tool| tool["name"].as_str().unwrap())
             .collect::<Vec<_>>();
         assert!(names.contains(&"dutis_diff"));
+        assert!(names.contains(&"dutis_policy_check"));
+        assert!(names.contains(&"dutis_audit"));
         assert!(!names.contains(&"dutis_apply"));
         assert!(!names.contains(&"dutis_rollback"));
     }
@@ -796,6 +893,16 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(names.contains(&"dutis_apply"));
         assert!(names.contains(&"dutis_rollback"));
+        let apply = response["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tool| tool["name"] == "dutis_apply")
+            .unwrap();
+        assert!(apply["inputSchema"]["required"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("requester")));
     }
 
     #[test]
@@ -821,7 +928,8 @@ mod tests {
                 "arguments": {
                     "config_toml": config_toml(),
                     "plan_digest": "reviewed-digest",
-                    "approval_token": "a-secure-test-token"
+                    "approval_token": "a-secure-test-token",
+                    "requester": "test-agent"
                 }
             }),
         ));
@@ -851,7 +959,8 @@ mod tests {
                 "arguments": {
                     "config_toml": config_toml(),
                     "plan_digest": "reviewed-digest",
-                    "approval_token": "wrong-token"
+                    "approval_token": "wrong-token",
+                    "requester": "test-agent"
                 }
             }),
         ));
@@ -869,7 +978,8 @@ mod tests {
                 "arguments": {
                     "config_toml": config_toml(),
                     "plan_digest": "old-digest",
-                    "approval_token": "a-secure-test-token"
+                    "approval_token": "a-secure-test-token",
+                    "requester": "test-agent"
                 }
             }),
         ));
@@ -894,7 +1004,8 @@ mod tests {
                 "arguments": {
                     "config_toml": config_toml(),
                     "plan_digest": "reviewed-digest",
-                    "approval_token": "a-secure-test-token"
+                    "approval_token": "a-secure-test-token",
+                    "requester": "test-agent"
                 }
             }),
         ));

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -2,13 +2,13 @@ use crate::application::{resolve_app, Application};
 use crate::config::DutisConfig;
 use crate::system::DefaultApplication;
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 
 pub const PLAN_SCHEMA_VERSION: u32 = 1;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanAction {
     Change,
@@ -16,7 +16,7 @@ pub enum PlanAction {
     Unresolved,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PlannedApplication {
     pub name: String,
     pub path: PathBuf,
@@ -33,7 +33,7 @@ impl PlannedApplication {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PlanEntry {
     pub extension: String,
     pub selector: String,
@@ -44,7 +44,7 @@ pub struct PlanEntry {
     pub reason: Option<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PlanSummary {
     pub total: usize,
     pub changes: usize,
@@ -52,7 +52,7 @@ pub struct PlanSummary {
     pub unresolved: usize,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AssociationPlan {
     pub schema_version: u32,
     pub config_version: u32,
@@ -67,7 +67,7 @@ impl AssociationPlan {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApplyStatus {
     Applied,
@@ -75,7 +75,7 @@ pub enum ApplyStatus {
     Failed,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ApplyEntryResult {
     pub extension: String,
     pub bundle_id: Option<String>,
@@ -84,7 +84,7 @@ pub struct ApplyEntryResult {
     pub error: Option<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ApplyReport {
     pub plan_digest: String,
     pub applied: usize,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::fs;
 use std::io::Write;
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -119,7 +120,8 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\"}}\n",
         "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
         "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n",
-        "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_history\",\"arguments\":{}}}\n"
+        "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_history\",\"arguments\":{}}}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_policy\",\"arguments\":{}}}\n"
     );
     child
         .stdin
@@ -135,16 +137,27 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         .lines()
         .map(|line| serde_json::from_str::<Value>(line).unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(responses.len(), 3);
+    assert_eq!(responses.len(), 4);
     assert_eq!(responses[0]["result"]["protocolVersion"], "2024-11-05");
     let tools = responses[1]["result"]["tools"].as_array().unwrap();
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_diff"));
+    assert!(tools.iter().any(|tool| tool["name"] == "dutis_policy"));
     assert!(!tools.iter().any(|tool| tool["name"] == "dutis_apply"));
+    assert_eq!(
+        responses[3]["result"]["structuredContent"]["data"]["approval_mode"],
+        "explicit"
+    );
 
-    let audit: Value = serde_json::from_slice(&output.stderr).unwrap();
-    assert_eq!(audit["schema_version"], 1);
-    assert_eq!(audit["tool"], "dutis_history");
-    assert_eq!(audit["access"], "read");
+    let audit = String::from_utf8(output.stderr)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(audit.len(), 2);
+    assert_eq!(audit[0]["schema_version"], 1);
+    assert_eq!(audit[0]["tool"], "dutis_history");
+    assert_eq!(audit[1]["tool"], "dutis_policy");
+    assert!(audit.iter().all(|event| event["access"] == "read"));
 }
 
 #[test]
@@ -159,4 +172,47 @@ fn mcp_write_mode_requires_a_server_side_approval_token() {
     assert!(String::from_utf8(output.stderr)
         .unwrap()
         .contains("DUTIS_MCP_APPROVAL_TOKEN"));
+}
+
+#[test]
+fn policy_show_redacts_token_hash_and_audit_starts_empty() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let state = std::env::temp_dir().join(format!(
+        "dutis-policy-integration-{}-{unique}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&state).unwrap();
+    let policy_path = state.join("policy.toml");
+    let secret_hash = "a".repeat(64);
+    fs::write(
+        &policy_path,
+        format!("version = 1\napproval_mode = 'token'\napproval_token_sha256 = '{secret_hash}'\n"),
+    )
+    .unwrap();
+
+    let policy_output = dutis()
+        .env("DUTIS_STATE_DIR", &state)
+        .args(["policy", "show", "--json"])
+        .output()
+        .unwrap();
+    assert!(policy_output.status.success());
+    let policy: Value = serde_json::from_slice(&policy_output.stdout).unwrap();
+    assert_eq!(policy["data"]["approval_mode"], "token");
+    assert_eq!(policy["data"]["approval_token_configured"], true);
+    assert!(!String::from_utf8(policy_output.stdout)
+        .unwrap()
+        .contains(&secret_hash));
+
+    let audit_output = dutis()
+        .env("DUTIS_STATE_DIR", &state)
+        .args(["audit", "--json"])
+        .output()
+        .unwrap();
+    assert!(audit_output.status.success());
+    let audit: Value = serde_json::from_slice(&audit_output.stdout).unwrap();
+    assert_eq!(audit["data"].as_array().unwrap().len(), 0);
+    fs::remove_dir_all(state).unwrap();
 }


### PR DESCRIPTION
Implements Roadmap Phase 5 for v2.9.0. Adds versioned local policy controls for allowed extensions, allowed applications, protected associations, and explicit/token/deny approval modes. Every CLI, interactive, and MCP mutation now passes through one governed execution path that creates a pending owner-only audit record before mutation and records the reviewed plan, requester, snapshot, result, and verification. Adds policy and audit CLI/MCP tools, a validated Dutis agent skill, documentation, and Homebrew/release packaging for the skill and policy example. Validation: formatting, Clippy with warnings denied, 58 tests, release build, cargo package, policy-denial smoke test with no system mutation, official skill validation, and Homebrew formula rendering.