### PR TITLE
feat: add profiles and explainable recommendations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.9.0"
+version = "2.10.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A comprehensive Rust application for viewing file extensions supported by macOS 
 - ↩️ **Snapshots and Rollback**: Persist pre-change state and restore it through the verified plan pipeline
 - 🔌 **Local MCP Server**: Give agents read-only discovery and planning tools with separately gated writes
 - 🛡️ **Policy and Audit**: Enforce local allowlists and approvals with durable, verified mutation records
+- 💡 **Explainable Profiles**: Generate evidence-backed developer, designer, media, or minimal proposals without changing the system
 
 ## Installation
 
@@ -148,6 +149,20 @@ dutis policy show --json
 dutis policy check dutis.toml --json
 dutis audit --json
 ```
+
+Explore built-in profiles and generate a read-only recommendation:
+
+```bash
+dutis profile list
+dutis profile show developer --json
+dutis recommend developer --json
+```
+
+Recommendations show ordered candidates, installed paths, declared extension
+support, the current handler, the proposed TOML, a deterministic plan digest,
+and the effective policy assessment. They never change system associations.
+Review [profiles and recommendations](docs/profiles-and-recommendations.md) for
+selection rules and the safe path from a proposal to an approved apply.
 
 All write paths enforce the same local policy before mutation and record the
 requester, reviewed plan, result, and verification. See the

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -122,9 +122,20 @@ Acceptance criteria:
 
 ## Phase 6: Profiles and recommendations
 
+Status: implemented for v2.10.0
+
 Add reusable profiles such as developer, designer, media, and minimal macOS,
 plus explainable recommendations based on installed applications and current
 associations. Recommendations remain proposals and include their evidence.
+
+Acceptance criteria:
+
+- Profiles can be inspected without `duti` or write permission.
+- Recommendations explain candidate priority, installation evidence, extension
+  support, current-handler retention, and unavailable choices.
+- Every proposal includes TOML, a deterministic plan digest, and the effective
+  policy assessment without changing system associations.
+- CLI and MCP expose the same read-only profile workflow.
 
 ## Phase 7: Drift detection
 
@@ -140,8 +151,7 @@ pipeline across all association types.
 
 ## Near-term engineering sequence
 
-1. Release Phase 5 and validate policy behavior across CLI, interactive, and
-   MCP mutation paths.
-2. Add explainable, opt-in profiles and recommendations.
-3. Design notification-first drift detection on top of the audited policy
+1. Release Phase 6 and validate profile evidence across common macOS setups.
+2. Design notification-first drift detection on top of the audited policy
    layer.
+3. Expand normalized planning to URL schemes, UTIs, and MIME types.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP server
 
-Dutis v2.8 exposes its inspected, planned, snapshotted, and verified association
+Dutis exposes its inspected, planned, snapshotted, and verified association
 workflow as a local Model Context Protocol server. The server uses JSON-RPC 2.0
 over stdio, so protocol messages are written only to stdout. Stable JSON audit
 events are written to stderr.
@@ -29,6 +29,9 @@ A typical MCP client configuration is:
 The server advertises these read tools:
 
 - `dutis_list`: discover installed applications and declared extensions.
+- `dutis_profiles`: list built-in profiles and ordered candidates.
+- `dutis_profile`: inspect one profile by its `profile` name.
+- `dutis_recommend`: generate an explainable proposal, plan digest, and policy assessment by `profile` name.
 - `dutis_query`: find installed handlers for one extension.
 - `dutis_get`: inspect the current default handler.
 - `dutis_diff`: parse inline versioned TOML and return a deterministic plan.
@@ -41,6 +44,11 @@ The server advertises these read tools:
 `dutis_diff` accepts `config_toml` rather than a filesystem path. This keeps the
 MCP surface independent from unrestricted file access and makes the exact input
 part of the reviewed tool call.
+
+Profile recommendations are also read-only. A recommendation is evidence, not
+approval: it does not register a mutation tool call or change an association.
+To use one, review its `proposed_toml`, rebuild it with `dutis_diff`, run
+`dutis_policy_check`, and follow the normal write approval flow.
 
 ## Enable writes explicitly
 

--- a/docs/profiles-and-recommendations.md
+++ b/docs/profiles-and-recommendations.md
@@ -1,0 +1,70 @@
+# Profiles and recommendations
+
+Dutis includes four built-in profiles for common macOS workflows:
+
+- `developer`: source code, scripts, structured data, and technical Markdown.
+- `designer`: raster images, SVG assets, design-oriented PDFs.
+- `media`: common audio and video formats.
+- `minimal`: built-in macOS applications with no third-party dependency.
+
+Profiles are ordered preferences, not hidden configuration. Inspect them
+without scanning applications or requiring `duti`:
+
+```bash
+dutis profile list
+dutis profile show developer
+dutis profile show developer --json
+```
+
+## Generate a proposal
+
+```bash
+dutis recommend developer
+dutis recommend developer --json
+```
+
+Recommendation scans installed applications and reads current handlers. It
+does not change Launch Services. For each extension, Dutis:
+
+1. Keeps the current handler when it is a profile candidate with exactly one
+   installed application, minimizing unnecessary changes.
+2. Otherwise selects the first candidate with exactly one installed path.
+3. Marks the extension unavailable when every candidate is missing or a bundle
+   ID resolves to multiple paths. Unavailable entries are excluded from the
+   proposed configuration and plan.
+
+Each result includes the candidate order, installed paths, whether the app
+declares support for the extension, the selected target, current handler, and
+a human-readable reason. The complete response also includes proposed TOML, a
+deterministic `AssociationPlan` and digest, and assessment against the current
+local policy.
+
+Declared extension support is evidence rather than the only selector. Some
+applications accept formats that are not present in all versions of their
+bundle metadata, so the ordered built-in profile remains the source of the
+preference while the evidence stays visible for review.
+
+## Review and apply
+
+A recommendation is never an approval. Save or copy the proposed TOML, inspect
+it, and use the normal governed workflow:
+
+```bash
+dutis plan dutis.toml --json
+dutis policy check dutis.toml --json
+dutis apply dutis.toml --dry-run
+dutis apply dutis.toml --plan-digest <reviewed-digest> --yes --requester <identity>
+```
+
+The apply command rebuilds the plan from current state, rejects a stale digest,
+enforces policy, creates a safety snapshot, records an audit entry, and verifies
+the resulting handlers.
+
+## MCP tools
+
+Read-only MCP servers advertise `dutis_profiles`, `dutis_profile`, and
+`dutis_recommend`. `dutis_recommend` accepts `{ "profile": "developer" }` and
+returns the same evidence, proposed configuration, plan, and policy assessment
+as the CLI. Agents must still use `dutis_diff` and `dutis_policy_check`, obtain
+explicit approval, and provide the freshly reviewed digest before calling a
+write tool.

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -12,16 +12,20 @@ Use Dutis for macOS filename-extension associations. Preserve its
 
 1. Start read-only. Check readiness and the effective policy, then inspect the
    requested extensions and installed handlers.
-2. Express multi-extension changes as versioned TOML. Build a fresh plan and
+2. If the user asks for a general setup or is unsure which application to use,
+   inspect `dutis_profiles` / `dutis_profile`, then use `dutis_recommend` (or
+   the equivalent CLI commands). Present candidate evidence and treat the
+   recommendation strictly as a proposal, never as approval.
+3. Express multi-extension changes as versioned TOML. Build a fresh plan and
    run the policy check. Treat unresolved selectors or policy violations as a
    stop condition.
-3. Show the user the exact changed extensions, target bundle IDs, plan digest,
+4. Show the user the exact changed extensions, target bundle IDs, plan digest,
    and any policy constraints. Run dry-run before requesting approval.
-4. Ask for explicit approval immediately before a write. Never infer approval
+5. Ask for explicit approval immediately before a write. Never infer approval
    from an earlier inspection request.
-5. Apply only the reviewed digest, include a meaningful requester identity,
+6. Apply only the reviewed digest, include a meaningful requester identity,
    and report the resulting safety snapshot and audit IDs.
-6. Verify with `dutis get`, then use `dutis audit` when the user needs the full
+7. Verify with `dutis get`, then use `dutis audit` when the user needs the full
    local record.
 
 For CLI workflows, prefer `dutis plan`, `dutis policy check`, and
@@ -34,6 +38,9 @@ For MCP workflows, use `dutis_diff` and `dutis_policy_check` before
 must be advertised by the server and require a fresh digest, an approval token,
 and `requester`. Never invent, persist, echo, or request disclosure of a secret
 token; use only a token supplied through the authorized workflow.
+
+Do not pass recommendation output directly to a write tool. Rebuild the plan
+from the reviewed proposed TOML so current state and policy are checked again.
 
 Do not bypass Dutis with raw `duti` mutation commands. Do not weaken or rewrite
 the local policy unless the user explicitly asks to change that policy.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,10 @@ pub enum CliCommand {
     Policy(PolicyArgs),
     /// List persistent local mutation audit records
     Audit(OutputArgs),
+    /// Inspect built-in association profiles
+    Profile(ProfileArgs),
+    /// Generate an explainable proposal from a built-in profile
+    Recommend(RecommendArgs),
     /// Run the local Model Context Protocol server over stdio
     Mcp(McpArgs),
     /// Check whether dutis and its runtime dependency are ready
@@ -175,6 +179,38 @@ pub struct PolicyCheckArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct ProfileArgs {
+    #[command(subcommand)]
+    pub command: ProfileCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ProfileCommand {
+    /// List available built-in profiles
+    List(OutputArgs),
+    /// Show one profile and its ordered candidate applications
+    Show(ProfileShowArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ProfileShowArgs {
+    /// Built-in profile name
+    pub name: String,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct RecommendArgs {
+    /// Built-in profile name
+    pub profile: String,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
 pub struct McpArgs {
     /// Register mutation tools; also requires DUTIS_MCP_APPROVAL_TOKEN
     #[arg(long)]
@@ -289,5 +325,12 @@ mod tests {
         assert!(Cli::try_parse_from(["dutis", "policy", "show", "--json"]).is_ok());
         assert!(Cli::try_parse_from(["dutis", "policy", "check", "dutis.toml", "--json"]).is_ok());
         assert!(Cli::try_parse_from(["dutis", "audit", "--json"]).is_ok());
+    }
+
+    #[test]
+    fn parses_profile_and_recommendation_commands() {
+        assert!(Cli::try_parse_from(["dutis", "profile", "list", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["dutis", "profile", "show", "developer", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["dutis", "recommend", "minimal", "--json"]).is_ok());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod governance;
 pub mod mcp;
 pub mod planner;
 pub mod plist_parser;
+pub mod profiles;
 pub mod snapshot;
 pub mod system;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{
     ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, McpArgs, OutputArgs, PolicyArgs,
-    PolicyCheckArgs, PolicyCommand, RollbackArgs, SetArgs, SnapshotArgs, SnapshotCommand,
-    SnapshotCreateArgs,
+    PolicyCheckArgs, PolicyCommand, ProfileArgs, ProfileCommand, ProfileShowArgs, RecommendArgs,
+    RollbackArgs, SetArgs, SnapshotArgs, SnapshotCommand, SnapshotCreateArgs,
 };
 use colored::*;
 use dutis::application::{
@@ -19,6 +19,7 @@ use dutis::planner::{
     assemble_plan, build_plan, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
     PlannedApplication,
 };
+use dutis::profiles::{find_profile, profiles, recommend_profile, ProfileRecommendation};
 use dutis::snapshot::{
     build_rollback_plan, capture_associations, SnapshotReason, SnapshotStore, SnapshotSummary,
 };
@@ -173,6 +174,14 @@ struct PolicyCheckResult<'a> {
     plan: &'a AssociationPlan,
 }
 
+#[derive(Serialize)]
+struct RecommendResult {
+    metadata_failures: usize,
+    recommendation: ProfileRecommendation,
+    policy: dutis::governance::PolicySummary,
+    assessment: PolicyAssessment,
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     let command_name = cli
@@ -222,6 +231,8 @@ fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
         Some(CliCommand::Rollback(args)) => run_rollback(args),
         Some(CliCommand::Policy(args)) => run_policy(args),
         Some(CliCommand::Audit(args)) => run_audit(args),
+        Some(CliCommand::Profile(args)) => run_profile(args),
+        Some(CliCommand::Recommend(args)) => run_recommend(args),
         Some(CliCommand::Mcp(args)) => run_mcp(args),
         Some(CliCommand::Doctor(args)) => run_doctor(args),
     }
@@ -241,6 +252,8 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Rollback(_) => "rollback",
         CliCommand::Policy(_) => "policy",
         CliCommand::Audit(_) => "audit",
+        CliCommand::Profile(_) => "profile",
+        CliCommand::Recommend(_) => "recommend",
         CliCommand::Mcp(_) => "mcp",
         CliCommand::Doctor(_) => "doctor",
     }
@@ -263,8 +276,143 @@ fn command_uses_json(command: &CliCommand) -> bool {
             PolicyCommand::Check(args) => args.json,
         },
         CliCommand::Audit(args) => args.json,
+        CliCommand::Profile(args) => match &args.command {
+            ProfileCommand::List(args) => args.json,
+            ProfileCommand::Show(args) => args.json,
+        },
+        CliCommand::Recommend(args) => args.json,
         CliCommand::Mcp(_) => false,
     }
+}
+
+fn run_profile(args: ProfileArgs) -> Result<(), CliError> {
+    match args.command {
+        ProfileCommand::List(args) => run_profile_list(args),
+        ProfileCommand::Show(args) => run_profile_show(args),
+    }
+}
+
+fn run_profile_list(args: OutputArgs) -> Result<(), CliError> {
+    let available = profiles();
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "profile",
+            data: available,
+        })?;
+    } else {
+        for profile in available {
+            println!("{}\t{}", profile.name, profile.description);
+        }
+    }
+    Ok(())
+}
+
+fn run_profile_show(args: ProfileShowArgs) -> Result<(), CliError> {
+    let profile = find_profile(&args.name)
+        .ok_or_else(|| CliError::not_found(format!("unknown profile '{}'", args.name)))?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "profile",
+            data: profile,
+        })?;
+    } else {
+        println!("{}: {}", profile.name, profile.description);
+        for association in profile.associations {
+            println!("\n.{}", association.extension);
+            for (index, candidate) in association.candidates.iter().enumerate() {
+                println!(
+                    "  {}. {} — {}",
+                    index + 1,
+                    candidate.bundle_id,
+                    candidate.rationale
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_recommend(args: RecommendArgs) -> Result<(), CliError> {
+    let profile = find_profile(&args.profile)
+        .ok_or_else(|| CliError::not_found(format!("unknown profile '{}'", args.profile)))?;
+    let catalog = scan_catalog()?;
+    report_metadata_failures(catalog.metadata_failures);
+    system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
+    let recommendation =
+        recommend_profile(&profile, &catalog.applications, system::query_default_app).map_err(
+            |error| CliError::operation(format!("failed to build recommendation: {error:#}")),
+        )?;
+    let policy = LoadedPolicy::from_environment()
+        .map_err(|error| CliError::usage(format!("failed to load policy: {error:#}")))?;
+    let result = RecommendResult {
+        metadata_failures: catalog.metadata_failures,
+        assessment: policy.policy.assess(&recommendation.plan),
+        policy: policy.summary(),
+        recommendation,
+    };
+
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "recommend",
+            data: result,
+        })?;
+    } else {
+        println!("Profile: {}", result.recommendation.profile);
+        println!("{}", result.recommendation.description);
+        for item in &result.recommendation.recommendations {
+            println!(
+                "\n{:?} .{}: {}",
+                item.action, item.extension, item.explanation
+            );
+            for candidate in &item.evidence {
+                let status = if candidate.selected {
+                    "selected"
+                } else {
+                    "candidate"
+                };
+                let paths = candidate
+                    .installed_paths
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                println!(
+                    "  {}. {} [{}; installed={}; declares_extension={}]{}",
+                    candidate.priority,
+                    candidate.bundle_id,
+                    status,
+                    candidate.installed_paths.len(),
+                    candidate.declares_extension,
+                    if paths.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" {paths}")
+                    }
+                );
+            }
+        }
+        println!(
+            "\nProposed configuration:\n{}",
+            result.recommendation.proposed_toml
+        );
+        println!("Plan digest: {}", result.recommendation.plan.digest);
+        println!(
+            "Policy decision: {}",
+            if result.assessment.allowed {
+                "allowed"
+            } else {
+                "denied"
+            }
+        );
+        for violation in &result.assessment.violations {
+            println!("DENY: {violation}");
+        }
+        println!("\nThis is a proposal only; no system associations were changed.");
+    }
+    Ok(())
 }
 
 fn run_mcp(args: McpArgs) -> Result<(), CliError> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -5,6 +5,7 @@ use crate::governance::{
     MutationChannel, MutationOperation, MutationRequest,
 };
 use crate::planner::{build_plan, AssociationPlan};
+use crate::profiles::{find_profile, profiles, recommend_profile};
 use crate::snapshot::{build_rollback_plan, SnapshotReason, SnapshotStore};
 use crate::system;
 use anyhow::{anyhow, Context, Result};
@@ -75,6 +76,9 @@ pub struct McpAuditEvent {
 
 trait McpBackend {
     fn list(&mut self) -> Result<Value>;
+    fn profiles(&mut self) -> Result<Value>;
+    fn profile(&mut self, name: &str) -> Result<Value>;
+    fn recommend(&mut self, name: &str) -> Result<Value>;
     fn query(&mut self, extension: &str) -> Result<Value>;
     fn get(&mut self, extension: &str) -> Result<Value>;
     fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan>;
@@ -99,6 +103,30 @@ impl McpBackend for SystemBackend {
         Ok(json!({
             "applications": catalog.applications,
             "metadata_failures": catalog.metadata_failures,
+        }))
+    }
+
+    fn profiles(&mut self) -> Result<Value> {
+        serde_json::to_value(profiles()).context("failed to serialize built-in profiles")
+    }
+
+    fn profile(&mut self, name: &str) -> Result<Value> {
+        let profile = find_profile(name).ok_or_else(|| anyhow!("unknown profile '{name}'"))?;
+        serde_json::to_value(profile).context("failed to serialize profile")
+    }
+
+    fn recommend(&mut self, name: &str) -> Result<Value> {
+        let profile = find_profile(name).ok_or_else(|| anyhow!("unknown profile '{name}'"))?;
+        let catalog = ApplicationCatalog::scan()?;
+        system::duti_version()?;
+        let recommendation =
+            recommend_profile(&profile, &catalog.applications, system::query_default_app)?;
+        let policy = LoadedPolicy::from_environment()?;
+        Ok(json!({
+            "metadata_failures": catalog.metadata_failures,
+            "assessment": policy.policy.assess(&recommendation.plan),
+            "policy": policy.summary(),
+            "recommendation": recommendation,
         }))
     }
 
@@ -287,6 +315,27 @@ impl<B: McpBackend> McpServer<B> {
     ) -> std::result::Result<Value, ToolError> {
         match name {
             "dutis_list" => self.backend.list().map_err(operation_error),
+            "dutis_profiles" => self.backend.profiles().map_err(operation_error),
+            "dutis_profile" => {
+                let profile = argument_string(arguments, "profile")?;
+                if find_profile(profile).is_none() {
+                    return Err(ToolError::new(
+                        "not_found",
+                        format!("unknown profile '{profile}'"),
+                    ));
+                }
+                self.backend.profile(profile).map_err(operation_error)
+            }
+            "dutis_recommend" => {
+                let profile = argument_string(arguments, "profile")?;
+                if find_profile(profile).is_none() {
+                    return Err(ToolError::new(
+                        "not_found",
+                        format!("unknown profile '{profile}'"),
+                    ));
+                }
+                self.backend.recommend(profile).map_err(operation_error)
+            }
             "dutis_query" => {
                 let extension = argument_string(arguments, "extension")?;
                 let extension = normalize_extension(extension)
@@ -577,6 +626,12 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
         "required": ["snapshot_id"],
         "additionalProperties": false,
     });
+    let profile_schema = json!({
+        "type": "object",
+        "properties": {"profile": {"type": "string", "minLength": 1}},
+        "required": ["profile"],
+        "additionalProperties": false,
+    });
     let read_annotations = json!({
         "readOnlyHint": true,
         "destructiveHint": false,
@@ -588,6 +643,24 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
             "dutis_list",
             "List installed macOS applications and their declared file extensions.",
             empty_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_profiles",
+            "List built-in association profiles and their ordered application candidates.",
+            empty_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_profile",
+            "Inspect one built-in association profile without changing the system.",
+            profile_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_recommend",
+            "Generate an explainable profile proposal, deterministic plan, and policy assessment without changing the system.",
+            profile_schema,
             read_annotations.clone(),
         ),
         tool_definition(
@@ -784,6 +857,18 @@ mod tests {
             Ok(json!({"applications": []}))
         }
 
+        fn profiles(&mut self) -> Result<Value> {
+            serde_json::to_value(profiles()).map_err(Into::into)
+        }
+
+        fn profile(&mut self, name: &str) -> Result<Value> {
+            serde_json::to_value(find_profile(name)).map_err(Into::into)
+        }
+
+        fn recommend(&mut self, name: &str) -> Result<Value> {
+            Ok(json!({"profile": name, "proposal_only": true}))
+        }
+
         fn query(&mut self, extension: &str) -> Result<Value> {
             Ok(json!({"extension": extension, "applications": []}))
         }
@@ -869,10 +954,49 @@ mod tests {
             .map(|tool| tool["name"].as_str().unwrap())
             .collect::<Vec<_>>();
         assert!(names.contains(&"dutis_diff"));
+        assert!(names.contains(&"dutis_profiles"));
+        assert!(names.contains(&"dutis_profile"));
+        assert!(names.contains(&"dutis_recommend"));
         assert!(names.contains(&"dutis_policy_check"));
         assert!(names.contains(&"dutis_audit"));
         assert!(!names.contains(&"dutis_apply"));
         assert!(!names.contains(&"dutis_rollback"));
+    }
+
+    #[test]
+    fn profile_tools_return_proposals_and_stable_not_found_errors() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let profile = server.handle(request(
+            1,
+            "tools/call",
+            json!({"name": "dutis_profile", "arguments": {"profile": "minimal"}}),
+        ));
+        assert_eq!(
+            profile.response.unwrap()["result"]["structuredContent"]["data"]["name"],
+            "minimal"
+        );
+
+        let recommendation = server.handle(request(
+            2,
+            "tools/call",
+            json!({"name": "dutis_recommend", "arguments": {"profile": "developer"}}),
+        ));
+        assert_eq!(
+            recommendation.response.unwrap()["result"]["structuredContent"]["data"]
+                ["proposal_only"],
+            true
+        );
+        assert_eq!(recommendation.audit.unwrap().access, "read");
+
+        let missing = server.handle(request(
+            3,
+            "tools/call",
+            json!({"name": "dutis_recommend", "arguments": {"profile": "unknown"}}),
+        ));
+        assert_eq!(
+            missing.response.unwrap()["result"]["structuredContent"]["error"]["kind"],
+            "not_found"
+        );
     }
 
     #[test]

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,0 +1,566 @@
+use crate::application::Application;
+use crate::config::{DutisConfig, CONFIG_VERSION};
+use crate::planner::{assemble_plan, AssociationPlan, PlanAction, PlanEntry, PlannedApplication};
+use crate::system::DefaultApplication;
+use anyhow::Result;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProfileDefinition {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub associations: Vec<ProfileAssociation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProfileAssociation {
+    pub extension: &'static str,
+    pub candidates: Vec<ProfileCandidate>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProfileCandidate {
+    pub bundle_id: &'static str,
+    pub rationale: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecommendationAction {
+    Change,
+    KeepCurrent,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct CandidateEvidence {
+    pub bundle_id: String,
+    pub priority: usize,
+    pub installed_paths: Vec<PathBuf>,
+    pub declares_extension: bool,
+    pub selected: bool,
+    pub rationale: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct AssociationRecommendation {
+    pub extension: String,
+    pub action: RecommendationAction,
+    pub current: Option<DefaultApplication>,
+    pub target: Option<PlannedApplication>,
+    pub explanation: String,
+    pub evidence: Vec<CandidateEvidence>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct RecommendationSummary {
+    pub total: usize,
+    pub available: usize,
+    pub changes: usize,
+    pub kept_current: usize,
+    pub unavailable: usize,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ProfileRecommendation {
+    pub profile: String,
+    pub description: String,
+    pub summary: RecommendationSummary,
+    pub recommendations: Vec<AssociationRecommendation>,
+    pub proposed_config: DutisConfig,
+    pub proposed_toml: String,
+    pub plan: AssociationPlan,
+}
+
+pub fn profiles() -> Vec<ProfileDefinition> {
+    vec![
+        developer_profile(),
+        designer_profile(),
+        media_profile(),
+        minimal_profile(),
+    ]
+}
+
+pub fn find_profile(name: &str) -> Option<ProfileDefinition> {
+    profiles()
+        .into_iter()
+        .find(|profile| profile.name.eq_ignore_ascii_case(name.trim()))
+}
+
+pub fn recommend_profile<F>(
+    profile: &ProfileDefinition,
+    applications: &[Application],
+    mut query_default: F,
+) -> Result<ProfileRecommendation>
+where
+    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+{
+    let mut proposed_associations = BTreeMap::new();
+    let mut plan_entries = Vec::new();
+    let mut recommendations = Vec::with_capacity(profile.associations.len());
+
+    for association in &profile.associations {
+        let current = query_default(association.extension)?;
+        let candidates = association
+            .candidates
+            .iter()
+            .enumerate()
+            .map(|(index, candidate)| {
+                let matches = applications
+                    .iter()
+                    .filter(|application| {
+                        application.bundle_id.as_deref() == Some(candidate.bundle_id)
+                    })
+                    .collect::<Vec<_>>();
+                CandidateEvidence {
+                    bundle_id: candidate.bundle_id.to_owned(),
+                    priority: index + 1,
+                    installed_paths: matches
+                        .iter()
+                        .map(|application| application.path.clone())
+                        .collect(),
+                    declares_extension: matches.iter().any(|application| {
+                        application
+                            .extensions
+                            .iter()
+                            .any(|extension| extension.eq_ignore_ascii_case(association.extension))
+                    }),
+                    selected: false,
+                    rationale: candidate.rationale.to_owned(),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let current_candidate = current.as_ref().and_then(|current| {
+            association
+                .candidates
+                .iter()
+                .position(|candidate| candidate.bundle_id == current.bundle_id)
+        });
+        let selected_index = current_candidate
+            .filter(|index| candidates[*index].installed_paths.len() == 1)
+            .or_else(|| {
+                candidates
+                    .iter()
+                    .position(|candidate| candidate.installed_paths.len() == 1)
+            });
+        let mut evidence = candidates;
+
+        let (action, target, explanation) = if let Some(index) = selected_index {
+            evidence[index].selected = true;
+            let selected = &association.candidates[index];
+            let application = applications
+                .iter()
+                .find(|application| {
+                    application.bundle_id.as_deref() == Some(selected.bundle_id)
+                        && application.path == evidence[index].installed_paths[0]
+                })
+                .expect("selected profile candidate has one installed application");
+            let target = PlannedApplication::from_application(application)
+                .expect("profile candidates have bundle identifiers");
+            let keep_current =
+                current.as_ref().map(|value| value.bundle_id.as_str()) == Some(selected.bundle_id);
+            let action = if keep_current {
+                RecommendationAction::KeepCurrent
+            } else {
+                RecommendationAction::Change
+            };
+            let explanation = if keep_current {
+                format!(
+                    "Keep {} because the current handler is compatible with the {} profile.",
+                    application.name, profile.name
+                )
+            } else {
+                format!(
+                    "Recommend {} because it is the highest-priority uniquely installed candidate for .{}: {}",
+                    application.name, association.extension, selected.rationale
+                )
+            };
+            proposed_associations.insert(
+                association.extension.to_owned(),
+                selected.bundle_id.to_owned(),
+            );
+            plan_entries.push(PlanEntry {
+                extension: association.extension.to_owned(),
+                selector: selected.bundle_id.to_owned(),
+                current: current.clone(),
+                target: Some(target.clone()),
+                action: if keep_current {
+                    PlanAction::Unchanged
+                } else {
+                    PlanAction::Change
+                },
+                reason: None,
+            });
+            (action, Some(target), explanation)
+        } else {
+            (
+                RecommendationAction::Unavailable,
+                None,
+                format!(
+                    "No uniquely installed candidate is available for .{}; no change is proposed.",
+                    association.extension
+                ),
+            )
+        };
+
+        recommendations.push(AssociationRecommendation {
+            extension: association.extension.to_owned(),
+            action,
+            current,
+            target,
+            explanation,
+            evidence,
+        });
+    }
+
+    let proposed_config = DutisConfig {
+        version: CONFIG_VERSION,
+        associations: proposed_associations,
+    };
+    let proposed_toml = toml::to_string_pretty(&proposed_config)?;
+    let plan = assemble_plan(CONFIG_VERSION, plan_entries)?;
+    let summary = RecommendationSummary {
+        total: recommendations.len(),
+        available: recommendations
+            .iter()
+            .filter(|recommendation| recommendation.target.is_some())
+            .count(),
+        changes: recommendations
+            .iter()
+            .filter(|recommendation| recommendation.action == RecommendationAction::Change)
+            .count(),
+        kept_current: recommendations
+            .iter()
+            .filter(|recommendation| recommendation.action == RecommendationAction::KeepCurrent)
+            .count(),
+        unavailable: recommendations
+            .iter()
+            .filter(|recommendation| recommendation.action == RecommendationAction::Unavailable)
+            .count(),
+    };
+
+    Ok(ProfileRecommendation {
+        profile: profile.name.to_owned(),
+        description: profile.description.to_owned(),
+        summary,
+        recommendations,
+        proposed_config,
+        proposed_toml,
+        plan,
+    })
+}
+
+fn developer_profile() -> ProfileDefinition {
+    ProfileDefinition {
+        name: "developer",
+        description: "Source code, structured data, scripts, and technical documentation.",
+        associations: vec![
+            developer_association("md"),
+            developer_association("json"),
+            developer_association("yaml"),
+            developer_association("yml"),
+            developer_association("toml"),
+            developer_association("rs"),
+            developer_association("py"),
+            developer_association("js"),
+            developer_association("ts"),
+            developer_association("sh"),
+        ],
+    }
+}
+
+fn developer_association(extension: &'static str) -> ProfileAssociation {
+    ProfileAssociation {
+        extension,
+        candidates: vec![
+            candidate(
+                "dev.zed.Zed",
+                "Fast native editor with strong project and language tooling.",
+            ),
+            candidate(
+                "com.microsoft.VSCode",
+                "Broad language and extension ecosystem for development files.",
+            ),
+            candidate(
+                "com.sublimetext.4",
+                "Fast general-purpose source and text editor.",
+            ),
+            candidate(
+                "com.apple.dt.Xcode",
+                "Apple development environment with source editing support.",
+            ),
+            candidate(
+                "com.apple.TextEdit",
+                "Built-in fallback for plain-text-compatible files.",
+            ),
+        ],
+    }
+}
+
+fn designer_profile() -> ProfileDefinition {
+    ProfileDefinition {
+        name: "designer",
+        description: "Images, vector assets, design documents, and PDFs.",
+        associations: vec![
+            image_association("png"),
+            image_association("jpg"),
+            image_association("jpeg"),
+            image_association("svg"),
+            ProfileAssociation {
+                extension: "pdf",
+                candidates: vec![
+                    candidate(
+                        "com.apple.Preview",
+                        "Built-in fast PDF viewing and annotation.",
+                    ),
+                    candidate(
+                        "com.adobe.Acrobat.Pro",
+                        "Advanced PDF editing and production workflows.",
+                    ),
+                ],
+            },
+        ],
+    }
+}
+
+fn image_association(extension: &'static str) -> ProfileAssociation {
+    ProfileAssociation {
+        extension,
+        candidates: vec![
+            candidate(
+                "com.pixelmatorteam.pixelmator.x",
+                "Native image editing workflow for design assets.",
+            ),
+            candidate(
+                "com.apple.Preview",
+                "Built-in lightweight image inspection.",
+            ),
+        ],
+    }
+}
+
+fn media_profile() -> ProfileDefinition {
+    ProfileDefinition {
+        name: "media",
+        description: "Audio and video playback with native and broad-codec options.",
+        associations: vec![
+            media_association("mp3"),
+            media_association("m4a"),
+            media_association("wav"),
+            media_association("flac"),
+            video_association("mp4"),
+            video_association("mov"),
+            video_association("mkv"),
+        ],
+    }
+}
+
+fn media_association(extension: &'static str) -> ProfileAssociation {
+    ProfileAssociation {
+        extension,
+        candidates: vec![
+            candidate(
+                "com.apple.Music",
+                "Built-in music library and audio playback.",
+            ),
+            candidate("org.videolan.vlc", "Broad codec support for audio files."),
+            candidate(
+                "com.colliderli.iina",
+                "Native macOS player with broad format support.",
+            ),
+        ],
+    }
+}
+
+fn video_association(extension: &'static str) -> ProfileAssociation {
+    ProfileAssociation {
+        extension,
+        candidates: vec![
+            candidate(
+                "com.colliderli.iina",
+                "Native macOS player with broad codec support.",
+            ),
+            candidate("org.videolan.vlc", "Broad codec support for video files."),
+            candidate(
+                "com.apple.QuickTimePlayerX",
+                "Built-in playback for common Apple-supported formats.",
+            ),
+        ],
+    }
+}
+
+fn minimal_profile() -> ProfileDefinition {
+    ProfileDefinition {
+        name: "minimal",
+        description: "Built-in macOS applications with no third-party dependency.",
+        associations: vec![
+            ProfileAssociation {
+                extension: "txt",
+                candidates: vec![candidate(
+                    "com.apple.TextEdit",
+                    "Built-in macOS plain-text editor.",
+                )],
+            },
+            ProfileAssociation {
+                extension: "rtf",
+                candidates: vec![candidate(
+                    "com.apple.TextEdit",
+                    "Built-in macOS rich-text editor.",
+                )],
+            },
+            ProfileAssociation {
+                extension: "pdf",
+                candidates: vec![candidate(
+                    "com.apple.Preview",
+                    "Built-in macOS document viewer.",
+                )],
+            },
+            ProfileAssociation {
+                extension: "png",
+                candidates: vec![candidate(
+                    "com.apple.Preview",
+                    "Built-in macOS image viewer.",
+                )],
+            },
+            ProfileAssociation {
+                extension: "jpg",
+                candidates: vec![candidate(
+                    "com.apple.Preview",
+                    "Built-in macOS image viewer.",
+                )],
+            },
+            ProfileAssociation {
+                extension: "mov",
+                candidates: vec![candidate(
+                    "com.apple.QuickTimePlayerX",
+                    "Built-in macOS media player.",
+                )],
+            },
+        ],
+    }
+}
+
+fn candidate(bundle_id: &'static str, rationale: &'static str) -> ProfileCandidate {
+    ProfileCandidate {
+        bundle_id,
+        rationale,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app(name: &str, bundle_id: &str, extensions: &[&str]) -> Application {
+        Application {
+            name: name.to_owned(),
+            path: PathBuf::from(format!("/Applications/{name}.app")),
+            bundle_id: Some(bundle_id.to_owned()),
+            extensions: extensions.iter().map(|value| (*value).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn exposes_the_four_builtin_profiles() {
+        assert_eq!(
+            profiles()
+                .iter()
+                .map(|profile| profile.name)
+                .collect::<Vec<_>>(),
+            vec!["developer", "designer", "media", "minimal"]
+        );
+        assert!(find_profile("DEVELOPER").is_some());
+        assert!(find_profile("unknown").is_none());
+    }
+
+    #[test]
+    fn keeps_a_compatible_current_handler_to_minimize_churn() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: vec![ProfileAssociation {
+                extension: "md",
+                candidates: vec![
+                    candidate("com.example.First", "first"),
+                    candidate("com.example.Current", "current"),
+                ],
+            }],
+        };
+        let applications = vec![
+            app("First", "com.example.First", &["md"]),
+            app("Current", "com.example.Current", &["md"]),
+        ];
+        let recommendation = recommend_profile(&profile, &applications, |extension| {
+            Ok(Some(DefaultApplication {
+                extension: extension.to_owned(),
+                name: Some("Current".to_owned()),
+                path: Some("/Applications/Current.app".to_owned()),
+                bundle_id: "com.example.Current".to_owned(),
+            }))
+        })
+        .unwrap();
+        assert_eq!(recommendation.summary.kept_current, 1);
+        assert_eq!(recommendation.summary.changes, 0);
+        assert_eq!(
+            recommendation.recommendations[0]
+                .target
+                .as_ref()
+                .unwrap()
+                .bundle_id,
+            "com.example.Current"
+        );
+    }
+
+    #[test]
+    fn selects_first_uniquely_installed_candidate_with_evidence() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: vec![ProfileAssociation {
+                extension: "md",
+                candidates: vec![
+                    candidate("com.example.Missing", "preferred"),
+                    candidate("com.example.Editor", "available"),
+                ],
+            }],
+        };
+        let recommendation = recommend_profile(
+            &profile,
+            &[app("Editor", "com.example.Editor", &["md"])],
+            |_| Ok(None),
+        )
+        .unwrap();
+        assert_eq!(recommendation.summary.changes, 1);
+        assert_eq!(recommendation.plan.summary.changes, 1);
+        assert_eq!(recommendation.recommendations[0].evidence[1].priority, 2);
+        assert!(recommendation.recommendations[0].evidence[1].selected);
+        assert!(recommendation.recommendations[0].evidence[1].declares_extension);
+        assert!(recommendation.proposed_toml.contains("com.example.Editor"));
+    }
+
+    #[test]
+    fn leaves_ambiguous_or_missing_candidates_out_of_the_plan() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: vec![ProfileAssociation {
+                extension: "md",
+                candidates: vec![candidate("com.example.Editor", "candidate")],
+            }],
+        };
+        let applications = vec![
+            app("Editor", "com.example.Editor", &["md"]),
+            Application {
+                path: PathBuf::from("/Applications/Other/Editor.app"),
+                ..app("Editor", "com.example.Editor", &["md"])
+            },
+        ];
+        let recommendation = recommend_profile(&profile, &applications, |_| Ok(None)).unwrap();
+        assert_eq!(recommendation.summary.unavailable, 1);
+        assert_eq!(recommendation.plan.summary.total, 0);
+        assert!(recommendation.proposed_config.associations.is_empty());
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -99,6 +99,46 @@ fn history_is_empty_for_an_isolated_state_directory() {
 }
 
 #[test]
+fn profile_list_and_show_are_available_without_duti() {
+    let list = dutis()
+        .env("PATH", "")
+        .args(["profile", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let response: Value = serde_json::from_slice(&list.stdout).unwrap();
+    let names = response["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|profile| profile["name"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["developer", "designer", "media", "minimal"]);
+
+    let show = dutis()
+        .env("PATH", "")
+        .args(["profile", "show", "developer", "--json"])
+        .output()
+        .unwrap();
+    assert!(show.status.success());
+    let response: Value = serde_json::from_slice(&show.stdout).unwrap();
+    assert_eq!(response["data"]["name"], "developer");
+    assert!(response["data"]["associations"].as_array().unwrap().len() >= 5);
+}
+
+#[test]
+fn unknown_profile_has_stable_json_error() {
+    let output = dutis()
+        .args(["profile", "show", "unknown", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "profile");
+    assert_eq!(response["error"]["kind"], "not_found");
+}
+
+#[test]
 fn mcp_stdio_initializes_and_advertises_read_only_tools() {
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -121,7 +161,8 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
         "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n",
         "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_history\",\"arguments\":{}}}\n",
-        "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_policy\",\"arguments\":{}}}\n"
+        "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_policy\",\"arguments\":{}}}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_profile\",\"arguments\":{\"profile\":\"minimal\"}}}\n"
     );
     child
         .stdin
@@ -137,15 +178,21 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         .lines()
         .map(|line| serde_json::from_str::<Value>(line).unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(responses.len(), 4);
+    assert_eq!(responses.len(), 5);
     assert_eq!(responses[0]["result"]["protocolVersion"], "2024-11-05");
     let tools = responses[1]["result"]["tools"].as_array().unwrap();
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_diff"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_policy"));
+    assert!(tools.iter().any(|tool| tool["name"] == "dutis_profiles"));
+    assert!(tools.iter().any(|tool| tool["name"] == "dutis_recommend"));
     assert!(!tools.iter().any(|tool| tool["name"] == "dutis_apply"));
     assert_eq!(
         responses[3]["result"]["structuredContent"]["data"]["approval_mode"],
         "explicit"
+    );
+    assert_eq!(
+        responses[4]["result"]["structuredContent"]["data"]["name"],
+        "minimal"
     );
 
     let audit = String::from_utf8(output.stderr)
@@ -153,10 +200,11 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         .lines()
         .map(|line| serde_json::from_str::<Value>(line).unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(audit.len(), 2);
+    assert_eq!(audit.len(), 3);
     assert_eq!(audit[0]["schema_version"], 1);
     assert_eq!(audit[0]["tool"], "dutis_history");
     assert_eq!(audit[1]["tool"], "dutis_policy");
+    assert_eq!(audit[2]["tool"], "dutis_profile");
     assert!(audit.iter().all(|event| event["access"] == "read"));
 }
 


### PR DESCRIPTION
## Summary
- add developer, designer, media, and minimal built-in profiles
- add explainable read-only recommendations with evidence, proposed TOML, deterministic plans, and policy assessment
- expose profile workflows through CLI and three read-only MCP tools
- document the safety boundary and update the Dutis agent skill
- bump the release version to 2.10.0

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --all-targets --locked
- cargo build --release --locked
- cargo package --allow-dirty --locked
- real CLI recommendation smoke test on macOS
- real MCP stdio recommendation smoke test (read-only audit)