### PR TITLE
feat: add drift detection and monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A comprehensive Rust application for viewing file extensions supported by macOS 
 - 🔌 **Local MCP Server**: Give agents read-only discovery and planning tools with separately gated writes
 - 🛡️ **Policy and Audit**: Enforce local allowlists and approvals with durable, verified mutation records
 - 💡 **Explainable Profiles**: Generate evidence-backed developer, designer, media, or minimal proposals without changing the system
+- 👀 **Drift Monitoring**: Detect association changes continuously, notify through macOS, and optionally remediate through snapshots and policy
 
 ## Installation
 
@@ -163,6 +164,25 @@ support, the current handler, the proposed TOML, a deterministic plan digest,
 and the effective policy assessment. They never change system associations.
 Review [profiles and recommendations](docs/profiles-and-recommendations.md) for
 selection rules and the safe path from a proposal to an approved apply.
+
+Check a declared configuration once or monitor it continuously:
+
+```bash
+dutis watch dutis.toml --once --json
+dutis watch dutis.toml --interval-seconds 60 --notify
+```
+
+Install an optional per-user LaunchAgent that keeps the monitor running:
+
+```bash
+dutis launch-agent install dutis.toml --interval-seconds 300 --notify
+dutis launch-agent status
+```
+
+Monitoring is read-only by default. Automatic remediation requires
+`--remediate --yes --requester <identity>` and always passes through policy,
+audit, safety snapshot, apply, and verification. See
+[drift detection](docs/drift-detection.md).
 
 All write paths enforce the same local policy before mutation and record the
 requester, reviewed plan, result, and verification. See the

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -139,9 +139,23 @@ Acceptance criteria:
 
 ## Phase 7: Drift detection
 
+Status: implemented for v2.11.0
+
 Add `dutis watch` and an optional LaunchAgent to detect differences from a
 declared policy. Start with notifications and reports. Automatic remediation is
 opt-in and requires rollback-ready snapshots.
+
+Acceptance criteria:
+
+- One-shot and continuous checks emit timestamped, versioned drift reports.
+- Notifications are sent only when drift changes or the monitored state
+  recovers during a watcher session.
+- The optional per-user LaunchAgent uses an absolute executable and config path,
+  keeps secrets out of its plist, and records JSON Lines logs.
+- Remediation requires explicit opt-in and a requester identity, then passes
+  through policy, audit, safety snapshot, mutation, and verification.
+- MCP exposes drift inspection as a read-only tool and does not add an
+  autonomous write tool.
 
 ## Phase 8: Broader association support
 
@@ -151,7 +165,7 @@ pipeline across all association types.
 
 ## Near-term engineering sequence
 
-1. Release Phase 6 and validate profile evidence across common macOS setups.
-2. Design notification-first drift detection on top of the audited policy
-   layer.
-3. Expand normalized planning to URL schemes, UTIs, and MIME types.
+1. Release Phase 7 and validate long-running LaunchAgent behavior across Intel
+   and Apple Silicon Macs.
+2. Expand normalized planning to URL schemes, UTIs, and MIME types.
+3. Add richer event sinks after the normalized association model is stable.

--- a/docs/drift-detection.md
+++ b/docs/drift-detection.md
@@ -1,0 +1,105 @@
+# Drift detection
+
+Dutis can compare current macOS file associations with a declared TOML
+configuration once or continuously. Detection is read-only by default.
+
+## One-time report
+
+```bash
+dutis watch dutis.toml --once
+dutis watch dutis.toml --once --json
+```
+
+Each report includes:
+
+- a schema version and UTC check time;
+- `in_sync`, `drift_detected`, or `unresolved` state;
+- changed and unresolved entries with current and target applications;
+- the complete deterministic plan and digest;
+- the effective policy summary and remediation assessment.
+
+JSON mode emits one compact object per line, so the same output works for a
+single check and long-running log ingestion.
+
+## Continuous monitoring and notifications
+
+```bash
+dutis watch dutis.toml --interval-seconds 60 --notify
+```
+
+During one watcher session, macOS notifications are deduplicated. Dutis
+notifies when drift first appears, when its plan changes, or when associations
+return to the declared state. Every check is still written to stdout.
+
+## Optional LaunchAgent
+
+Install a per-user background monitor:
+
+```bash
+dutis launch-agent install dutis.toml --interval-seconds 300 --notify
+dutis launch-agent status --json
+```
+
+The installed service is named `io.github.tsonglew.dutis.watch`. It stores an
+absolute path to the Dutis executable and configuration, runs the continuous
+watcher, and writes:
+
+```text
+~/Library/Application Support/dutis/logs/watch.jsonl
+~/Library/Application Support/dutis/logs/watch.error.log
+```
+
+If `DUTIS_STATE_DIR` is set while installing, logs and state use that directory.
+The LaunchAgent plist is stored at:
+
+```text
+~/Library/LaunchAgents/io.github.tsonglew.dutis.watch.plist
+```
+
+Replace an existing agent by running `install` again. Remove it with:
+
+```bash
+dutis launch-agent uninstall
+```
+
+The configuration file must remain at the recorded absolute path. Reinstall the
+agent after moving the file or installing Dutis at a different location.
+
+## Automatic remediation
+
+Automatic remediation is deliberately opt-in:
+
+```bash
+dutis watch dutis.toml \
+  --interval-seconds 60 \
+  --remediate --yes \
+  --requester local-watch
+```
+
+For a background agent:
+
+```bash
+dutis launch-agent install dutis.toml \
+  --interval-seconds 300 \
+  --notify \
+  --remediate --yes \
+  --requester local-launch-agent
+```
+
+Every remediation rebuilds the plan from current state and passes through the
+same policy, audit, pre-change snapshot, mutation, and verification pipeline as
+`dutis apply`. Policy denial and failures are reported without disabling later
+checks. Unresolved plans are never remediated.
+
+Foreground token-policy remediation reads the token only from
+`DUTIS_WATCH_APPROVAL_TOKEN`. The token is never printed or accepted as a
+command-line argument. Remediating LaunchAgents require the explicit approval
+policy because Dutis will not persist an approval token in a plist. Use a
+notification-only agent when token approval is required.
+
+## MCP
+
+The read-only `dutis_drift` MCP tool accepts inline `config_toml` and returns the
+same report. No watcher remediation tool is registered. Agents must use the
+reviewed `dutis_diff`, `dutis_policy_check`, and gated `dutis_apply` flow when a
+change is requested.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -32,6 +32,7 @@ The server advertises these read tools:
 - `dutis_profiles`: list built-in profiles and ordered candidates.
 - `dutis_profile`: inspect one profile by its `profile` name.
 - `dutis_recommend`: generate an explainable proposal, plan digest, and policy assessment by `profile` name.
+- `dutis_drift`: check inline TOML for drift and return a timestamped report with policy assessment.
 - `dutis_query`: find installed handlers for one extension.
 - `dutis_get`: inspect the current default handler.
 - `dutis_diff`: parse inline versioned TOML and return a deterministic plan.
@@ -49,6 +50,10 @@ Profile recommendations are also read-only. A recommendation is evidence, not
 approval: it does not register a mutation tool call or change an association.
 To use one, review its `proposed_toml`, rebuild it with `dutis_diff`, run
 `dutis_policy_check`, and follow the normal write approval flow.
+
+`dutis_drift` accepts the same `config_toml` input as `dutis_diff`. It reports
+`in_sync`, `drift_detected`, or `unresolved` and never remediates. MCP clients
+must use the separately gated apply workflow for any change.
 
 ## Enable writes explicitly
 

--- a/docs/policy-and-audit.md
+++ b/docs/policy-and-audit.md
@@ -102,7 +102,8 @@ dutis audit
 dutis audit --json
 ```
 
-Every record includes the requester, channel, operation, policy and plan
+Every record includes the requester, channel (`cli`, `interactive`, `mcp`, or
+`watcher`), operation, policy and plan
 digests, and full reviewed plan. Completed mutation records also include the
 safety snapshot ID, per-entry result, and verification summary. Dutis atomically
 writes a `pending` record before a mutation. If policy denies the request, it

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -28,6 +28,12 @@ Use Dutis for macOS filename-extension associations. Preserve its
 7. Verify with `dutis get`, then use `dutis audit` when the user needs the full
    local record.
 
+For monitoring requests, use `dutis_drift` or `dutis watch <config> --once`
+first. Explain whether the report is `in_sync`, `drift_detected`, or
+`unresolved`. Do not enable `--remediate` or install a remediating LaunchAgent
+without explicit user authorization for continuous system changes. A
+notification-only LaunchAgent is the safe default.
+
 For CLI workflows, prefer `dutis plan`, `dutis policy check`, and
 `dutis apply --dry-run` before the confirmed `dutis apply` command with
 `--yes`, `--plan-digest`, and `--requester`. For rollback, preview with

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,10 @@ pub enum CliCommand {
     Profile(ProfileArgs),
     /// Generate an explainable proposal from a built-in profile
     Recommend(RecommendArgs),
+    /// Detect and optionally remediate drift from a declarative configuration
+    Watch(WatchArgs),
+    /// Manage the optional per-user drift monitoring LaunchAgent
+    LaunchAgent(LaunchAgentArgs),
     /// Run the local Model Context Protocol server over stdio
     Mcp(McpArgs),
     /// Check whether dutis and its runtime dependency are ready
@@ -211,6 +215,73 @@ pub struct RecommendArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct WatchArgs {
+    /// Path to a versioned dutis TOML configuration
+    pub config: PathBuf,
+    /// Seconds between checks in continuous mode
+    #[arg(long, default_value_t = 60, value_parser = clap::value_parser!(u64).range(1..))]
+    pub interval_seconds: u64,
+    /// Check once and exit instead of monitoring continuously
+    #[arg(long)]
+    pub once: bool,
+    /// Send a macOS notification when drift changes or recovers
+    #[arg(long)]
+    pub notify: bool,
+    /// Automatically restore drift through policy, snapshot, audit, and verification
+    #[arg(long)]
+    pub remediate: bool,
+    /// Explicitly approve automatic remediation
+    #[arg(long)]
+    pub yes: bool,
+    /// Identity recorded for automatic remediation audit entries
+    #[arg(long)]
+    pub requester: Option<String>,
+    /// Emit one compact JSON object per check
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct LaunchAgentArgs {
+    #[command(subcommand)]
+    pub command: LaunchAgentCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LaunchAgentCommand {
+    /// Install or replace the per-user drift monitor
+    Install(LaunchAgentInstallArgs),
+    /// Remove the per-user drift monitor
+    Uninstall(OutputArgs),
+    /// Show whether the per-user drift monitor is installed and loaded
+    Status(OutputArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct LaunchAgentInstallArgs {
+    /// Path to a versioned dutis TOML configuration
+    pub config: PathBuf,
+    /// Seconds between scheduled checks (minimum 10)
+    #[arg(long, default_value_t = 300, value_parser = clap::value_parser!(u64).range(10..))]
+    pub interval_seconds: u64,
+    /// Send macOS notifications when drift is detected
+    #[arg(long)]
+    pub notify: bool,
+    /// Automatically restore drift through the governed mutation pipeline
+    #[arg(long)]
+    pub remediate: bool,
+    /// Explicitly approve scheduled automatic remediation
+    #[arg(long)]
+    pub yes: bool,
+    /// Identity recorded for automatic remediation audit entries
+    #[arg(long)]
+    pub requester: Option<String>,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
 pub struct McpArgs {
     /// Register mutation tools; also requires DUTIS_MCP_APPROVAL_TOKEN
     #[arg(long)]
@@ -332,5 +403,49 @@ mod tests {
         assert!(Cli::try_parse_from(["dutis", "profile", "list", "--json"]).is_ok());
         assert!(Cli::try_parse_from(["dutis", "profile", "show", "developer", "--json"]).is_ok());
         assert!(Cli::try_parse_from(["dutis", "recommend", "minimal", "--json"]).is_ok());
+    }
+
+    #[test]
+    fn parses_watch_and_launch_agent_commands() {
+        let cli = Cli::try_parse_from([
+            "dutis",
+            "watch",
+            "dutis.toml",
+            "--once",
+            "--notify",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Watch(WatchArgs {
+                once: true,
+                notify: true,
+                remediate: false,
+                json: true,
+                ..
+            }))
+        ));
+        assert!(Cli::try_parse_from([
+            "dutis",
+            "launch-agent",
+            "install",
+            "dutis.toml",
+            "--interval-seconds",
+            "300",
+            "--notify",
+        ])
+        .is_ok());
+        assert!(Cli::try_parse_from(["dutis", "launch-agent", "status", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["dutis", "launch-agent", "uninstall", "--json"]).is_ok());
+        assert!(Cli::try_parse_from([
+            "dutis",
+            "launch-agent",
+            "install",
+            "dutis.toml",
+            "--interval-seconds",
+            "5",
+        ])
+        .is_err());
     }
 }

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -1,0 +1,231 @@
+use crate::governance::{PolicyAssessment, PolicySummary};
+use crate::planner::{AssociationPlan, PlanAction, PlanEntry};
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+pub const DRIFT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DriftState {
+    InSync,
+    DriftDetected,
+    Unresolved,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct DriftReport {
+    pub schema_version: u32,
+    pub checked_at: String,
+    pub state: DriftState,
+    pub plan_digest: String,
+    pub changes: Vec<PlanEntry>,
+    pub unresolved: Vec<PlanEntry>,
+    pub plan: AssociationPlan,
+    pub policy: PolicySummary,
+    pub assessment: PolicyAssessment,
+}
+
+impl DriftReport {
+    pub fn new(
+        plan: AssociationPlan,
+        policy: PolicySummary,
+        assessment: PolicyAssessment,
+    ) -> Result<Self> {
+        let checked_at = OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .context("failed to format drift check time")?;
+        Ok(Self::at(checked_at, plan, policy, assessment))
+    }
+
+    pub fn at(
+        checked_at: String,
+        plan: AssociationPlan,
+        policy: PolicySummary,
+        assessment: PolicyAssessment,
+    ) -> Self {
+        let changes = plan
+            .entries
+            .iter()
+            .filter(|entry| entry.action == PlanAction::Change)
+            .cloned()
+            .collect::<Vec<_>>();
+        let unresolved = plan
+            .entries
+            .iter()
+            .filter(|entry| entry.action == PlanAction::Unresolved)
+            .cloned()
+            .collect::<Vec<_>>();
+        let state = if !unresolved.is_empty() {
+            DriftState::Unresolved
+        } else if !changes.is_empty() {
+            DriftState::DriftDetected
+        } else {
+            DriftState::InSync
+        };
+        Self {
+            schema_version: DRIFT_SCHEMA_VERSION,
+            checked_at,
+            state,
+            plan_digest: plan.digest.clone(),
+            changes,
+            unresolved,
+            plan,
+            policy,
+            assessment,
+        }
+    }
+
+    pub fn notification(&self) -> DriftNotification {
+        match self.state {
+            DriftState::InSync => DriftNotification {
+                title: "Dutis associations restored".to_owned(),
+                message: "All monitored file associations match the declared configuration."
+                    .to_owned(),
+            },
+            DriftState::DriftDetected => DriftNotification {
+                title: "Dutis drift detected".to_owned(),
+                message: format!(
+                    "{} file association(s) differ from the declared configuration.",
+                    self.changes.len()
+                ),
+            },
+            DriftState::Unresolved => DriftNotification {
+                title: "Dutis drift check needs attention".to_owned(),
+                message: format!(
+                    "{} selector(s) could not be resolved; no automatic change is safe.",
+                    self.unresolved.len()
+                ),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DriftNotification {
+    pub title: String,
+    pub message: String,
+}
+
+#[derive(Debug, Default)]
+pub struct DriftTracker {
+    previous: Option<(DriftState, String)>,
+}
+
+impl DriftTracker {
+    pub fn should_notify(&mut self, report: &DriftReport) -> bool {
+        let current = (report.state, report.plan_digest.clone());
+        let should_notify = match &self.previous {
+            None => report.state != DriftState::InSync,
+            Some((previous_state, previous_digest)) => {
+                *previous_state != report.state
+                    || (report.state != DriftState::InSync
+                        && previous_digest != &report.plan_digest)
+            }
+        };
+        self.previous = Some(current);
+        should_notify
+    }
+}
+
+pub fn send_macos_notification(notification: &DriftNotification) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        bail!("macOS notifications are unavailable on this platform");
+    }
+    let script = format!(
+        "display notification \"{}\" with title \"{}\"",
+        escape_applescript(&notification.message),
+        escape_applescript(&notification.title)
+    );
+    let output = Command::new("/usr/bin/osascript")
+        .args(["-e", &script])
+        .output()
+        .context("failed to send macOS notification")?;
+    if !output.status.success() {
+        bail!(
+            "macOS notification failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+fn escape_applescript(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::governance::{ApprovalMode, PolicyAssessment, PolicySummary};
+    use crate::planner::{assemble_plan, PlanEntry};
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn policy() -> (PolicySummary, PolicyAssessment) {
+        (
+            PolicySummary {
+                path: PathBuf::from("/tmp/policy.toml"),
+                exists: false,
+                digest: "policy-digest".to_owned(),
+                version: 1,
+                approval_mode: ApprovalMode::Explicit,
+                approval_token_configured: false,
+                allowed_extensions: None,
+                allowed_applications: None,
+                protected_associations: BTreeMap::new(),
+            },
+            PolicyAssessment {
+                allowed: true,
+                approval_mode: ApprovalMode::Explicit,
+                violations: Vec::new(),
+            },
+        )
+    }
+
+    fn report(action: PlanAction) -> DriftReport {
+        let (policy, assessment) = policy();
+        let plan = assemble_plan(
+            1,
+            vec![PlanEntry {
+                extension: "md".to_owned(),
+                selector: "com.example.Editor".to_owned(),
+                current: None,
+                target: None,
+                action,
+                reason: (action == PlanAction::Unresolved).then(|| "missing app".to_owned()),
+            }],
+        )
+        .unwrap();
+        DriftReport::at("2026-08-22T00:00:00Z".to_owned(), plan, policy, assessment)
+    }
+
+    #[test]
+    fn classifies_clean_drifted_and_unresolved_plans() {
+        assert_eq!(report(PlanAction::Unchanged).state, DriftState::InSync);
+        assert_eq!(report(PlanAction::Change).state, DriftState::DriftDetected);
+        assert_eq!(report(PlanAction::Unresolved).state, DriftState::Unresolved);
+    }
+
+    #[test]
+    fn tracker_deduplicates_unchanged_drift_and_notifies_on_recovery() {
+        let clean = report(PlanAction::Unchanged);
+        let drift = report(PlanAction::Change);
+        let mut tracker = DriftTracker::default();
+        assert!(!tracker.should_notify(&clean));
+        assert!(tracker.should_notify(&drift));
+        assert!(!tracker.should_notify(&drift));
+        assert!(tracker.should_notify(&clean));
+    }
+
+    #[test]
+    fn escapes_notification_text_for_applescript() {
+        assert_eq!(
+            escape_applescript("a \\\"quote\\\""),
+            "a \\\\\\\"quote\\\\\\\""
+        );
+    }
+}

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -286,6 +286,7 @@ pub enum MutationChannel {
     Cli,
     Interactive,
     Mcp,
+    Watcher,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -294,6 +295,7 @@ pub enum MutationOperation {
     Set,
     Apply,
     Rollback,
+    Remediate,
 }
 
 #[derive(Debug, Clone)]

--- a/src/launch_agent.rs
+++ b/src/launch_agent.rs
@@ -1,0 +1,321 @@
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub const LAUNCH_AGENT_LABEL: &str = "io.github.tsonglew.dutis.watch";
+const LAUNCH_AGENT_DIR_ENV: &str = "DUTIS_LAUNCH_AGENT_DIR";
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct LaunchAgentSpec {
+    pub executable: PathBuf,
+    pub config: PathBuf,
+    pub interval_seconds: u64,
+    pub notify: bool,
+    pub remediation_requester: Option<String>,
+    pub state_dir: PathBuf,
+    pub environment: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct LaunchAgentStatus {
+    pub label: &'static str,
+    pub path: PathBuf,
+    pub installed: bool,
+    pub loaded: Option<bool>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct LaunchAgentPlist {
+    label: &'static str,
+    program_arguments: Vec<String>,
+    run_at_load: bool,
+    keep_alive: bool,
+    throttle_interval: u64,
+    process_type: &'static str,
+    standard_out_path: String,
+    standard_error_path: String,
+    environment_variables: BTreeMap<String, String>,
+}
+
+pub struct LaunchAgentManager {
+    directory: PathBuf,
+}
+
+impl LaunchAgentManager {
+    pub fn from_environment() -> Result<Self> {
+        if let Some(directory) =
+            std::env::var_os(LAUNCH_AGENT_DIR_ENV).filter(|value| !value.is_empty())
+        {
+            return Ok(Self {
+                directory: PathBuf::from(directory),
+            });
+        }
+        let home = std::env::var_os("HOME")
+            .ok_or_else(|| anyhow!("HOME is not set; cannot locate LaunchAgents"))?;
+        Ok(Self {
+            directory: PathBuf::from(home).join("Library/LaunchAgents"),
+        })
+    }
+
+    pub fn path(&self) -> PathBuf {
+        self.directory.join(format!("{LAUNCH_AGENT_LABEL}.plist"))
+    }
+
+    pub fn install(&self, spec: &LaunchAgentSpec) -> Result<LaunchAgentStatus> {
+        validate_spec(spec)?;
+        let log_directory = spec.state_dir.join("logs");
+        fs::create_dir_all(&log_directory)
+            .with_context(|| format!("failed to create {}", log_directory.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&log_directory, fs::Permissions::from_mode(0o700))?;
+        }
+        fs::create_dir_all(&self.directory)
+            .with_context(|| format!("failed to create {}", self.directory.display()))?;
+
+        let path = self.path();
+        let temporary = self
+            .directory
+            .join(format!(".{LAUNCH_AGENT_LABEL}.{}.tmp", std::process::id()));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&temporary)
+            .with_context(|| format!("failed to create {}", temporary.display()))?;
+        plist::to_writer_xml(&mut file, &plist(spec))?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        fs::rename(&temporary, &path)
+            .with_context(|| format!("failed to install {}", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+        }
+        bootstrap(&path)?;
+        self.status()
+    }
+
+    pub fn uninstall(&self) -> Result<LaunchAgentStatus> {
+        let path = self.path();
+        if path.exists() {
+            let _ = bootout(&path);
+            fs::remove_file(&path)
+                .with_context(|| format!("failed to remove {}", path.display()))?;
+        }
+        self.status()
+    }
+
+    pub fn status(&self) -> Result<LaunchAgentStatus> {
+        let path = self.path();
+        let installed = path.is_file();
+        let loaded = if installed {
+            launchctl_loaded()?
+        } else {
+            Some(false)
+        };
+        Ok(LaunchAgentStatus {
+            label: LAUNCH_AGENT_LABEL,
+            path,
+            installed,
+            loaded,
+        })
+    }
+}
+
+fn validate_spec(spec: &LaunchAgentSpec) -> Result<()> {
+    if !spec.executable.is_absolute() || !spec.executable.is_file() {
+        bail!(
+            "LaunchAgent executable must be an existing absolute path: {}",
+            spec.executable.display()
+        );
+    }
+    if !spec.config.is_absolute() || !spec.config.is_file() {
+        bail!(
+            "LaunchAgent configuration must be an existing absolute path: {}",
+            spec.config.display()
+        );
+    }
+    if spec.interval_seconds < 10 {
+        bail!("LaunchAgent interval must be at least 10 seconds");
+    }
+    if spec
+        .remediation_requester
+        .as_deref()
+        .is_some_and(|requester| requester.trim().is_empty())
+    {
+        bail!("remediation requester cannot be empty");
+    }
+    Ok(())
+}
+
+fn plist(spec: &LaunchAgentSpec) -> LaunchAgentPlist {
+    let mut arguments = vec![
+        spec.executable.display().to_string(),
+        "watch".to_owned(),
+        spec.config.display().to_string(),
+        "--json".to_owned(),
+        "--interval-seconds".to_owned(),
+        spec.interval_seconds.to_string(),
+    ];
+    if spec.notify {
+        arguments.push("--notify".to_owned());
+    }
+    if let Some(requester) = &spec.remediation_requester {
+        arguments.extend([
+            "--remediate".to_owned(),
+            "--yes".to_owned(),
+            "--requester".to_owned(),
+            requester.clone(),
+        ]);
+    }
+    LaunchAgentPlist {
+        label: LAUNCH_AGENT_LABEL,
+        program_arguments: arguments,
+        run_at_load: true,
+        keep_alive: true,
+        throttle_interval: 10,
+        process_type: "Background",
+        standard_out_path: spec
+            .state_dir
+            .join("logs/watch.jsonl")
+            .display()
+            .to_string(),
+        standard_error_path: spec
+            .state_dir
+            .join("logs/watch.error.log")
+            .display()
+            .to_string(),
+        environment_variables: spec.environment.clone(),
+    }
+}
+
+fn user_domain() -> Result<String> {
+    let output = Command::new("/usr/bin/id")
+        .arg("-u")
+        .output()
+        .context("failed to determine user ID for launchctl")?;
+    if !output.status.success() {
+        bail!("id -u failed");
+    }
+    Ok(format!(
+        "gui/{}",
+        String::from_utf8_lossy(&output.stdout).trim()
+    ))
+}
+
+fn bootstrap(path: &Path) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        bail!("LaunchAgents are only available on macOS");
+    }
+    let _ = bootout(path);
+    let domain = user_domain()?;
+    let output = Command::new("/bin/launchctl")
+        .args(["bootstrap", &domain])
+        .arg(path)
+        .output()
+        .context("failed to run launchctl bootstrap")?;
+    if !output.status.success() {
+        bail!(
+            "launchctl bootstrap failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+fn bootout(path: &Path) -> Result<()> {
+    let domain = user_domain()?;
+    let output = Command::new("/bin/launchctl")
+        .args(["bootout", &domain])
+        .arg(path)
+        .output()
+        .context("failed to run launchctl bootout")?;
+    if !output.status.success() {
+        bail!(
+            "launchctl bootout failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+fn launchctl_loaded() -> Result<Option<bool>> {
+    if !cfg!(target_os = "macos") {
+        return Ok(None);
+    }
+    let domain = user_domain()?;
+    let service = format!("{domain}/{LAUNCH_AGENT_LABEL}");
+    let output = Command::new("/bin/launchctl")
+        .args(["print", &service])
+        .output()
+        .context("failed to inspect LaunchAgent")?;
+    Ok(Some(output.status.success()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_notification_only_agent_without_mutation_flags() {
+        let spec = LaunchAgentSpec {
+            executable: PathBuf::from("/opt/homebrew/bin/dutis"),
+            config: PathBuf::from("/Users/test/dutis.toml"),
+            interval_seconds: 300,
+            notify: true,
+            remediation_requester: None,
+            state_dir: PathBuf::from("/Users/test/Library/Application Support/dutis"),
+            environment: BTreeMap::from([(
+                "PATH".to_owned(),
+                "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".to_owned(),
+            )]),
+        };
+        let value = plist::to_value(&plist(&spec)).unwrap();
+        let dictionary = value.as_dictionary().unwrap();
+        let arguments = dictionary["ProgramArguments"].as_array().unwrap();
+        assert!(arguments
+            .iter()
+            .any(|value| value.as_string() == Some("--notify")));
+        assert!(!arguments
+            .iter()
+            .any(|value| value.as_string() == Some("--remediate")));
+        assert_eq!(dictionary["KeepAlive"].as_boolean(), Some(true));
+        assert!(arguments.windows(2).any(|pair| {
+            pair[0].as_string() == Some("--interval-seconds") && pair[1].as_string() == Some("300")
+        }));
+    }
+
+    #[test]
+    fn remediation_agent_records_explicit_opt_in_and_requester() {
+        let spec = LaunchAgentSpec {
+            executable: PathBuf::from("/opt/homebrew/bin/dutis"),
+            config: PathBuf::from("/Users/test/dutis.toml"),
+            interval_seconds: 60,
+            notify: false,
+            remediation_requester: Some("launch-agent".to_owned()),
+            state_dir: PathBuf::from("/tmp/dutis"),
+            environment: BTreeMap::new(),
+        };
+        let value = plist::to_value(&plist(&spec)).unwrap();
+        let arguments = value.as_dictionary().unwrap()["ProgramArguments"]
+            .as_array()
+            .unwrap();
+        for expected in ["--remediate", "--yes", "--requester", "launch-agent"] {
+            assert!(arguments
+                .iter()
+                .any(|value| value.as_string() == Some(expected)));
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod app_scanner;
 pub mod application;
 pub mod config;
+pub mod drift;
 pub mod governance;
+pub mod launch_agent;
 pub mod mcp;
 pub mod planner;
 pub mod plist_parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{
-    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, McpArgs, OutputArgs, PolicyArgs,
-    PolicyCheckArgs, PolicyCommand, ProfileArgs, ProfileCommand, ProfileShowArgs, RecommendArgs,
-    RollbackArgs, SetArgs, SnapshotArgs, SnapshotCommand, SnapshotCreateArgs,
+    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, LaunchAgentArgs, LaunchAgentCommand,
+    LaunchAgentInstallArgs, McpArgs, OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand,
+    ProfileArgs, ProfileCommand, ProfileShowArgs, RecommendArgs, RollbackArgs, SetArgs,
+    SnapshotArgs, SnapshotCommand, SnapshotCreateArgs, WatchArgs,
 };
 use colored::*;
 use dutis::application::{
@@ -11,10 +12,12 @@ use dutis::application::{
     ApplicationCatalog,
 };
 use dutis::config::DutisConfig;
+use dutis::drift::{send_macos_notification, DriftReport, DriftState, DriftTracker};
 use dutis::governance::{
-    execute_governed_plan, AuditStore, GovernanceErrorKind, GovernedMutation, LoadedPolicy,
-    MutationChannel, MutationOperation, MutationRequest, PolicyAssessment,
+    execute_governed_plan, ApprovalMode, AuditStore, GovernanceErrorKind, GovernedMutation,
+    LoadedPolicy, MutationChannel, MutationOperation, MutationRequest, PolicyAssessment,
 };
+use dutis::launch_agent::{LaunchAgentManager, LaunchAgentSpec, LaunchAgentStatus};
 use dutis::planner::{
     assemble_plan, build_plan, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
     PlannedApplication,
@@ -26,10 +29,12 @@ use dutis::snapshot::{
 use dutis::system;
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::time::Duration;
 
 mod cli;
 
@@ -182,6 +187,26 @@ struct RecommendResult {
     assessment: PolicyAssessment,
 }
 
+#[derive(Serialize)]
+struct WatchResult {
+    report: DriftReport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    remediation: Option<WatchRemediation>,
+}
+
+#[derive(Serialize)]
+struct WatchRemediation {
+    status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mutation: Option<GovernedMutation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    audit_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    violations: Vec<String>,
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     let command_name = cli
@@ -233,6 +258,8 @@ fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
         Some(CliCommand::Audit(args)) => run_audit(args),
         Some(CliCommand::Profile(args)) => run_profile(args),
         Some(CliCommand::Recommend(args)) => run_recommend(args),
+        Some(CliCommand::Watch(args)) => run_watch(args),
+        Some(CliCommand::LaunchAgent(args)) => run_launch_agent(args),
         Some(CliCommand::Mcp(args)) => run_mcp(args),
         Some(CliCommand::Doctor(args)) => run_doctor(args),
     }
@@ -254,6 +281,8 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Audit(_) => "audit",
         CliCommand::Profile(_) => "profile",
         CliCommand::Recommend(_) => "recommend",
+        CliCommand::Watch(_) => "watch",
+        CliCommand::LaunchAgent(_) => "launch-agent",
         CliCommand::Mcp(_) => "mcp",
         CliCommand::Doctor(_) => "doctor",
     }
@@ -281,8 +310,292 @@ fn command_uses_json(command: &CliCommand) -> bool {
             ProfileCommand::Show(args) => args.json,
         },
         CliCommand::Recommend(args) => args.json,
+        CliCommand::Watch(args) => args.json,
+        CliCommand::LaunchAgent(args) => match &args.command {
+            LaunchAgentCommand::Install(args) => args.json,
+            LaunchAgentCommand::Uninstall(args) | LaunchAgentCommand::Status(args) => args.json,
+        },
         CliCommand::Mcp(_) => false,
     }
+}
+
+fn run_watch(args: WatchArgs) -> Result<(), CliError> {
+    validate_remediation_options(args.remediate, args.yes, args.requester.as_deref())?;
+    let mut tracker = DriftTracker::default();
+    loop {
+        let report = build_drift_report(&args.config)?;
+        if args.notify && tracker.should_notify(&report) {
+            if let Err(error) = send_macos_notification(&report.notification()) {
+                eprintln!("Warning: failed to send drift notification: {error:#}");
+            }
+        }
+        let remediation = if args.remediate && report.state == DriftState::DriftDetected {
+            let request = MutationRequest {
+                requester: args
+                    .requester
+                    .as_deref()
+                    .expect("validated remediation requester")
+                    .trim()
+                    .to_owned(),
+                channel: MutationChannel::Watcher,
+                operation: MutationOperation::Remediate,
+                explicit_approval: args.yes,
+                approval_token: std::env::var("DUTIS_WATCH_APPROVAL_TOKEN").ok(),
+            };
+            match execute_governed_plan(
+                &report.plan,
+                SnapshotReason::BeforeRemediation,
+                &request,
+                system::set_default_app,
+            ) {
+                Ok(result) => Some(WatchRemediation {
+                    status: if result.report.failed == 0 {
+                        "succeeded"
+                    } else {
+                        "partial_failure"
+                    },
+                    mutation: Some(result),
+                    audit_id: None,
+                    error: None,
+                    violations: Vec::new(),
+                }),
+                Err(error) => Some(WatchRemediation {
+                    status: "blocked",
+                    mutation: None,
+                    audit_id: error.audit_id().map(str::to_owned),
+                    error: Some(error.to_string()),
+                    violations: error.violations().to_vec(),
+                }),
+            }
+        } else {
+            None
+        };
+        let result = WatchResult {
+            report,
+            remediation,
+        };
+        print_watch_result(&result, args.json)?;
+        if args.once {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_secs(args.interval_seconds));
+    }
+}
+
+fn validate_remediation_options(
+    remediate: bool,
+    yes: bool,
+    requester: Option<&str>,
+) -> Result<(), CliError> {
+    if remediate && !yes {
+        return Err(CliError::usage(
+            "--remediate requires --yes because it can change system associations",
+        ));
+    }
+    if remediate && requester.is_none_or(|value| value.trim().is_empty()) {
+        return Err(CliError::usage(
+            "--remediate requires a non-empty --requester for the mutation audit",
+        ));
+    }
+    if !remediate && (yes || requester.is_some()) {
+        return Err(CliError::usage(
+            "--yes and --requester are only valid with --remediate",
+        ));
+    }
+    Ok(())
+}
+
+fn build_drift_report(config: &Path) -> Result<DriftReport, CliError> {
+    let plan = build_declarative_plan(config)?;
+    let policy = LoadedPolicy::from_environment()
+        .map_err(|error| CliError::usage(format!("failed to load policy: {error:#}")))?;
+    let assessment = policy.policy.assess(&plan);
+    DriftReport::new(plan, policy.summary(), assessment)
+        .map_err(|error| CliError::operation(format!("failed to build drift report: {error:#}")))
+}
+
+fn print_watch_result(result: &WatchResult, json: bool) -> Result<(), CliError> {
+    if json {
+        let line = serde_json::to_string(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "watch",
+            data: result,
+        })
+        .map_err(|error| CliError::operation(format!("failed to serialize JSON: {error}")))?;
+        println!("{line}");
+        return Ok(());
+    }
+    println!("Checked: {}", result.report.checked_at);
+    println!("State: {:?}", result.report.state);
+    for entry in &result.report.changes {
+        let current = entry
+            .current
+            .as_ref()
+            .map(|application| application.bundle_id.as_str())
+            .unwrap_or("<none>");
+        let target = entry
+            .target
+            .as_ref()
+            .map(|application| application.bundle_id.as_str())
+            .unwrap_or("<unresolved>");
+        println!("DRIFT .{}: {} -> {}", entry.extension, current, target);
+    }
+    for entry in &result.report.unresolved {
+        println!(
+            "UNRESOLVED .{}: {}",
+            entry.extension,
+            entry.reason.as_deref().unwrap_or("unknown reason")
+        );
+    }
+    println!("Plan digest: {}", result.report.plan_digest);
+    println!(
+        "Policy decision: {}",
+        if result.report.assessment.allowed {
+            "allowed"
+        } else {
+            "denied"
+        }
+    );
+    if let Some(remediation) = &result.remediation {
+        println!("Remediation: {}", remediation.status);
+        if let Some(mutation) = &remediation.mutation {
+            println!("Remediation audit: {}", mutation.audit_id);
+            if let Some(snapshot) = &mutation.safety_snapshot_id {
+                println!("Safety snapshot: {snapshot}");
+            }
+            println!("Remediated: {}", mutation.report.applied);
+        }
+        if let Some(error) = &remediation.error {
+            println!("Remediation error: {error}");
+        }
+    }
+    Ok(())
+}
+
+fn run_launch_agent(args: LaunchAgentArgs) -> Result<(), CliError> {
+    match args.command {
+        LaunchAgentCommand::Install(args) => run_launch_agent_install(args),
+        LaunchAgentCommand::Uninstall(args) => {
+            let manager = launch_agent_manager()?;
+            let status = manager.uninstall().map_err(|error| {
+                CliError::operation(format!("failed to uninstall LaunchAgent: {error:#}"))
+            })?;
+            print_launch_agent_status(&status, args.json)
+        }
+        LaunchAgentCommand::Status(args) => {
+            let manager = launch_agent_manager()?;
+            let status = manager.status().map_err(|error| {
+                CliError::operation(format!("failed to inspect LaunchAgent: {error:#}"))
+            })?;
+            print_launch_agent_status(&status, args.json)
+        }
+    }
+}
+
+fn run_launch_agent_install(args: LaunchAgentInstallArgs) -> Result<(), CliError> {
+    validate_remediation_options(args.remediate, args.yes, args.requester.as_deref())?;
+    DutisConfig::load(&args.config).map_err(|error| CliError::usage(format!("{error:#}")))?;
+    let config = std::fs::canonicalize(&args.config).map_err(|error| {
+        CliError::operation(format!(
+            "failed to resolve configuration {}: {error}",
+            args.config.display()
+        ))
+    })?;
+    if args.remediate {
+        let policy = LoadedPolicy::from_environment()
+            .map_err(|error| CliError::usage(format!("failed to load policy: {error:#}")))?;
+        if policy.policy.approval_mode != ApprovalMode::Explicit {
+            return Err(CliError::usage(
+                "LaunchAgent remediation requires approval_mode = 'explicit'; tokens are never stored in the plist",
+            ));
+        }
+    }
+    let executable = locate_invoked_executable()?;
+    let state_dir = snapshot_store()?.root().to_path_buf();
+    let mut environment = BTreeMap::from([(
+        "PATH".to_owned(),
+        "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".to_owned(),
+    )]);
+    environment.insert(
+        "DUTIS_STATE_DIR".to_owned(),
+        state_dir.display().to_string(),
+    );
+    if let Some(value) = std::env::var_os("DUTIS_POLICY_FILE").filter(|value| !value.is_empty()) {
+        environment.insert(
+            "DUTIS_POLICY_FILE".to_owned(),
+            value.to_string_lossy().into_owned(),
+        );
+    }
+    let spec = LaunchAgentSpec {
+        executable,
+        config,
+        interval_seconds: args.interval_seconds,
+        notify: args.notify,
+        remediation_requester: args.remediate.then(|| {
+            args.requester
+                .expect("validated remediation requester")
+                .trim()
+                .to_owned()
+        }),
+        state_dir,
+        environment,
+    };
+    let status = launch_agent_manager()?.install(&spec).map_err(|error| {
+        CliError::operation(format!("failed to install LaunchAgent: {error:#}"))
+    })?;
+    print_launch_agent_status(&status, args.json)
+}
+
+fn launch_agent_manager() -> Result<LaunchAgentManager, CliError> {
+    LaunchAgentManager::from_environment()
+        .map_err(|error| CliError::operation(format!("failed to locate LaunchAgents: {error:#}")))
+}
+
+fn locate_invoked_executable() -> Result<PathBuf, CliError> {
+    let invoked = std::env::args_os()
+        .next()
+        .map(PathBuf::from)
+        .ok_or_else(|| CliError::operation("failed to read the dutis executable path"))?;
+    if invoked.is_absolute() && invoked.is_file() {
+        return Ok(invoked);
+    }
+    if invoked.components().count() > 1 {
+        return std::fs::canonicalize(&invoked).map_err(|error| {
+            CliError::operation(format!("failed to resolve {}: {error}", invoked.display()))
+        });
+    }
+    if let Some(path) = std::env::var_os("PATH") {
+        for directory in std::env::split_paths(&path) {
+            let candidate = directory.join(&invoked);
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+    }
+    std::env::current_exe()
+        .map_err(|error| CliError::operation(format!("failed to locate dutis: {error}")))
+}
+
+fn print_launch_agent_status(status: &LaunchAgentStatus, json: bool) -> Result<(), CliError> {
+    if json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "launch-agent",
+            data: status,
+        })?;
+    } else {
+        println!("Label: {}", status.label);
+        println!("Path: {}", status.path.display());
+        println!("Installed: {}", status.installed);
+        println!(
+            "Loaded: {}",
+            status
+                .loaded
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unavailable".to_owned())
+        );
+    }
+    Ok(())
 }
 
 fn run_profile(args: ProfileArgs) -> Result<(), CliError> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,5 +1,6 @@
 use crate::application::{find_apps_for_extension, normalize_extension, ApplicationCatalog};
 use crate::config::DutisConfig;
+use crate::drift::DriftReport;
 use crate::governance::{
     execute_governed_plan, AuditStore, GovernanceError, GovernanceErrorKind, LoadedPolicy,
     MutationChannel, MutationOperation, MutationRequest,
@@ -79,6 +80,7 @@ trait McpBackend {
     fn profiles(&mut self) -> Result<Value>;
     fn profile(&mut self, name: &str) -> Result<Value>;
     fn recommend(&mut self, name: &str) -> Result<Value>;
+    fn drift(&mut self, config: &DutisConfig) -> Result<Value>;
     fn query(&mut self, extension: &str) -> Result<Value>;
     fn get(&mut self, extension: &str) -> Result<Value>;
     fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan>;
@@ -128,6 +130,16 @@ impl McpBackend for SystemBackend {
             "policy": policy.summary(),
             "recommendation": recommendation,
         }))
+    }
+
+    fn drift(&mut self, config: &DutisConfig) -> Result<Value> {
+        system::duti_version()?;
+        let catalog = ApplicationCatalog::scan()?;
+        let plan = build_plan(config, &catalog.applications, system::query_default_app)?;
+        let policy = LoadedPolicy::from_environment()?;
+        let assessment = policy.policy.assess(&plan);
+        serde_json::to_value(DriftReport::new(plan, policy.summary(), assessment)?)
+            .context("failed to serialize drift report")
     }
 
     fn query(&mut self, extension: &str) -> Result<Value> {
@@ -335,6 +347,10 @@ impl<B: McpBackend> McpServer<B> {
                     ));
                 }
                 self.backend.recommend(profile).map_err(operation_error)
+            }
+            "dutis_drift" => {
+                let config = parse_config(arguments)?;
+                self.backend.drift(&config).map_err(operation_error)
             }
             "dutis_query" => {
                 let extension = argument_string(arguments, "extension")?;
@@ -664,6 +680,12 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
             read_annotations.clone(),
         ),
         tool_definition(
+            "dutis_drift",
+            "Check an inline configuration for drift and return a timestamped report with policy assessment without changing the system.",
+            config_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
             "dutis_query",
             "Find installed applications that declare support for an extension.",
             extension_schema.clone(),
@@ -869,6 +891,14 @@ mod tests {
             Ok(json!({"profile": name, "proposal_only": true}))
         }
 
+        fn drift(&mut self, _config: &DutisConfig) -> Result<Value> {
+            Ok(json!({
+                "schema_version": 1,
+                "state": "in_sync",
+                "plan_digest": self.plan.digest,
+            }))
+        }
+
         fn query(&mut self, extension: &str) -> Result<Value> {
             Ok(json!({"extension": extension, "applications": []}))
         }
@@ -957,6 +987,7 @@ mod tests {
         assert!(names.contains(&"dutis_profiles"));
         assert!(names.contains(&"dutis_profile"));
         assert!(names.contains(&"dutis_recommend"));
+        assert!(names.contains(&"dutis_drift"));
         assert!(names.contains(&"dutis_policy_check"));
         assert!(names.contains(&"dutis_audit"));
         assert!(!names.contains(&"dutis_apply"));
@@ -997,6 +1028,29 @@ mod tests {
             missing.response.unwrap()["result"]["structuredContent"]["error"]["kind"],
             "not_found"
         );
+    }
+
+    #[test]
+    fn drift_tool_is_read_only_and_returns_a_versioned_report() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let outcome = server.handle(request(
+            7,
+            "tools/call",
+            json!({
+                "name": "dutis_drift",
+                "arguments": {"config_toml": config_toml()}
+            }),
+        ));
+        let response = outcome.response.unwrap();
+        assert_eq!(
+            response["result"]["structuredContent"]["data"]["schema_version"],
+            1
+        );
+        assert_eq!(
+            response["result"]["structuredContent"]["data"]["state"],
+            "in_sync"
+        );
+        assert_eq!(outcome.audit.unwrap().access, "read");
     }
 
     #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -22,6 +22,7 @@ pub enum SnapshotReason {
     Manual,
     BeforeApply,
     BeforeRollback,
+    BeforeRemediation,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -139,6 +139,186 @@ fn unknown_profile_has_stable_json_error() {
 }
 
 #[test]
+fn watch_remediation_requires_explicit_approval_before_reading_config() {
+    let output = dutis()
+        .args([
+            "watch",
+            "missing.toml",
+            "--once",
+            "--remediate",
+            "--requester",
+            "test-agent",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "watch");
+    assert_eq!(response["error"]["kind"], "usage");
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("--yes"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn watch_once_reports_drift_without_invoking_duti_set() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "dutis-watch-read-only-{}-{unique}",
+        std::process::id()
+    ));
+    let bin = root.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let duti = bin.join("duti");
+    fs::write(
+        &duti,
+        concat!(
+            "#!/bin/sh\n",
+            "printf '%s\\n' \"$*\" >> \"$DUTI_CALL_LOG\"\n",
+            "if [ \"$1\" = \"-V\" ]; then printf 'test-duti\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-x\" ]; then printf 'Other\\n/Applications/Other.app\\ncom.example.Other\\n'; exit 0; fi\n",
+            "exit 99\n",
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&duti, fs::Permissions::from_mode(0o700)).unwrap();
+    let config = root.join("dutis.toml");
+    fs::write(
+        &config,
+        "version = 1\n[associations]\nmd = 'com.apple.TextEdit'\n",
+    )
+    .unwrap();
+    let calls = root.join("duti-calls.log");
+
+    let output = dutis()
+        .env("PATH", &bin)
+        .env("DUTI_CALL_LOG", &calls)
+        .env("DUTIS_STATE_DIR", root.join("state"))
+        .args(["watch", config.to_str().unwrap(), "--once", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["data"]["report"]["state"], "drift_detected");
+    assert!(response["data"]["remediation"].is_null());
+    let calls = fs::read_to_string(&calls).unwrap();
+    assert!(calls.lines().any(|line| line == "-V"));
+    assert!(calls.lines().any(|line| line == "-x md"));
+    assert!(!calls.lines().any(|line| line.starts_with("-s ")));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn opted_in_watch_remediation_uses_snapshot_audit_and_verification() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "dutis-watch-remediation-{}-{unique}",
+        std::process::id()
+    ));
+    let bin = root.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let duti = bin.join("duti");
+    fs::write(
+        &duti,
+        concat!(
+            "#!/bin/sh\n",
+            "printf '%s\\n' \"$*\" >> \"$DUTI_CALL_LOG\"\n",
+            "if [ \"$1\" = \"-V\" ]; then printf 'test-duti\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-s\" ]; then : > \"$DUTI_FAKE_STATE\"; exit 0; fi\n",
+            "if [ \"$1\" = \"-x\" ] && [ -f \"$DUTI_FAKE_STATE\" ]; then printf 'TextEdit\\n/System/Applications/TextEdit.app\\ncom.apple.TextEdit\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-x\" ]; then printf 'Other\\n/Applications/Other.app\\ncom.example.Other\\n'; exit 0; fi\n",
+            "exit 99\n",
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&duti, fs::Permissions::from_mode(0o700)).unwrap();
+    let config = root.join("dutis.toml");
+    fs::write(
+        &config,
+        "version = 1\n[associations]\nmd = 'com.apple.TextEdit'\n",
+    )
+    .unwrap();
+    let calls = root.join("duti-calls.log");
+    let fake_state = root.join("applied");
+    let state = root.join("state");
+
+    let output = dutis()
+        .env("PATH", &bin)
+        .env("DUTI_CALL_LOG", &calls)
+        .env("DUTI_FAKE_STATE", &fake_state)
+        .env("DUTIS_STATE_DIR", &state)
+        .args([
+            "watch",
+            config.to_str().unwrap(),
+            "--once",
+            "--remediate",
+            "--yes",
+            "--requester",
+            "integration-test",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["data"]["remediation"]["status"], "succeeded");
+    assert_eq!(response["data"]["remediation"]["mutation"]["applied"], 1);
+    assert!(response["data"]["remediation"]["mutation"]["safety_snapshot_id"].is_string());
+    assert!(response["data"]["remediation"]["mutation"]["audit_id"].is_string());
+    let calls = fs::read_to_string(&calls).unwrap();
+    assert!(calls
+        .lines()
+        .any(|line| line == "-s com.apple.TextEdit .md all"));
+    assert_eq!(fs::read_dir(state.join("snapshots")).unwrap().count(), 1);
+    assert_eq!(fs::read_dir(state.join("audit")).unwrap().count(), 1);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn launch_agent_status_is_read_only_for_an_isolated_directory() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let directory = std::env::temp_dir().join(format!(
+        "dutis-launch-agent-{}-{unique}",
+        std::process::id()
+    ));
+    let output = dutis()
+        .env("DUTIS_LAUNCH_AGENT_DIR", &directory)
+        .args(["launch-agent", "status", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "launch-agent");
+    assert_eq!(response["data"]["installed"], false);
+    assert_eq!(response["data"]["loaded"], false);
+}
+
+#[test]
 fn mcp_stdio_initializes_and_advertises_read_only_tools() {
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -185,6 +365,7 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_policy"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_profiles"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_recommend"));
+    assert!(tools.iter().any(|tool| tool["name"] == "dutis_drift"));
     assert!(!tools.iter().any(|tool| tool["name"] == "dutis_apply"));
     assert_eq!(
         responses[3]["result"]["structuredContent"]["data"]["approval_mode"],


### PR DESCRIPTION
## Summary
- add one-shot and continuous drift reports with deterministic plans and policy assessment
- add deduplicated macOS notifications and optional governed remediation
- add per-user LaunchAgent install, status, and uninstall commands
- add the read-only dutis_drift MCP tool
- document monitoring, safety boundaries, logs, and agent behavior
- bump the release version to 2.11.0

## Safety
- monitoring is read-only by default
- remediation requires --remediate, --yes, and a requester identity
- every remediation uses policy enforcement, a pre-change snapshot, persistent audit, and verification
- approval tokens are never accepted on the command line or stored in LaunchAgent plists

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --all-targets --locked
- cargo build --release --locked
- cargo package --allow-dirty --locked
- real macOS watch and MCP read-only smoke tests
- fake-duti end-to-end tests proving read-only mode never invokes mutation and opted-in remediation creates snapshot and audit records