### PR TITLE
feat: support typed Launch Services associations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.11.0"
+version = "2.12.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Dutis - macOS Application File Extension Manager
+# Dutis - macOS Default Application Manager
 
-A comprehensive Rust application for viewing file extensions supported by macOS applications and setting default applications for file types.
+A Rust application for inspecting and safely managing macOS default handlers for filename extensions, UTIs, MIME types, and URL schemes.
 
 **Website:** [tsonglew.github.io/dutis](https://tsonglew.github.io/dutis/)
 
@@ -23,6 +23,7 @@ A comprehensive Rust application for viewing file extensions supported by macOS 
 - 🛡️ **Policy and Audit**: Enforce local allowlists and approvals with durable, verified mutation records
 - 💡 **Explainable Profiles**: Generate evidence-backed developer, designer, media, or minimal proposals without changing the system
 - 👀 **Drift Monitoring**: Detect association changes continuously, notify through macOS, and optionally remediate through snapshots and policy
+- 🔗 **Typed Associations**: Manage extensions, UTIs, MIME types, URL schemes, and Launch Services roles through one verified pipeline
 
 ## Installation
 
@@ -89,6 +90,11 @@ dutis list
 dutis query md
 dutis get .md
 
+# Inspect typed Launch Services handlers
+dutis handler get uti public.plain-text --role viewer
+dutis handler get mime text/plain --role editor
+dutis handler get url-scheme https
+
 # Emit a versioned JSON response
 dutis query json --json
 
@@ -97,6 +103,10 @@ dutis set md com.microsoft.VSCode --dry-run --json
 
 # Apply and verify a change; --yes is required for non-interactive writes
 dutis set md com.microsoft.VSCode --yes
+
+# Preview a typed handler change (URL schemes use the implicit `all` role)
+dutis handler set uti public.plain-text com.apple.TextEdit --role viewer --dry-run
+dutis handler set url-scheme https com.apple.Safari --yes
 
 # Check local readiness
 dutis doctor --json
@@ -212,7 +222,7 @@ MCP, agent policies, profiles, and drift detection is documented in the
 ### Default App Setting
 
 1. **Bundle ID Detection**: Reads the selected application's bundle identifier
-2. **duti Integration**: Sets the handler directly by filename extension
+2. **duti Integration**: Sets extension, UTI, MIME, and URL-scheme handlers with the requested Launch Services role
 3. **Verification**: Reads the resulting association back before reporting success
 
 ## Technical Details

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -159,13 +159,28 @@ Acceptance criteria:
 
 ## Phase 8: Broader association support
 
+Status: implemented for v2.12.0
+
 Expand the model beyond filename extensions to URL schemes, UTIs, MIME types,
 and Launch Services roles. Preserve one normalized planning and verification
 pipeline across all association types.
 
+Acceptance criteria:
+
+- Configuration schema version 2 accepts extension, UTI, MIME, and URL-scheme
+  targets while version 1 extension configurations remain compatible.
+- CLI and MCP expose typed read operations; declarative diff/apply supports all
+  types through the existing digest, policy, snapshot, audit, and verification
+  boundary.
+- Policies can allow kinds and protect a kind/identifier/role tuple.
+- URL schemes reject document roles and use the role-free `duti` invocation.
+- Unit and fake-`duti` integration tests cover normalization, planning, dry-run,
+  mutation arguments, snapshotting, auditing, and verification.
+
 ## Near-term engineering sequence
 
-1. Release Phase 7 and validate long-running LaunchAgent behavior across Intel
-   and Apple Silicon Macs.
-2. Expand normalized planning to URL schemes, UTIs, and MIME types.
-3. Add richer event sinks after the normalized association model is stable.
+1. Release Phase 8 and validate typed association read-back on supported macOS
+   releases and both CPU architectures.
+2. Add richer event sinks for drift and mutation events.
+3. Extend application metadata discovery beyond filename extensions where
+   Launch Services exposes reliable declarations.

--- a/docs/declarative-configuration.md
+++ b/docs/declarative-configuration.md
@@ -1,29 +1,69 @@
 # Declarative configuration
 
-Dutis v2.6 adds a versioned TOML configuration and a reviewable
-`plan -> apply -> verify` workflow for scripts and AI agents.
+Dutis uses a versioned TOML configuration and a reviewable
+`plan -> apply -> verify` workflow for scripts and AI agents. Version 2 extends
+the same pipeline from filename extensions to UTIs, MIME types, URL schemes,
+and Launch Services roles.
 
-## Schema version 1
+## Schema version 2
 
 ```toml
-version = 1
+version = 2
 
+# The compact version 1 extension syntax remains supported.
 [associations]
 md = "com.microsoft.VSCode"
 json = "/Applications/Visual Studio Code.app"
 txt = "TextEdit"
+
+[[handlers]]
+kind = "uti"
+identifier = "public.plain-text"
+role = "viewer"
+application = "com.apple.TextEdit"
+
+[[handlers]]
+kind = "mime"
+identifier = "text/plain"
+role = "editor"
+application = "com.apple.TextEdit"
+
+[[handlers]]
+kind = "url_scheme"
+identifier = "https"
+application = "com.apple.Safari"
 ```
 
 Association keys are filename extensions. A leading dot and uppercase letters
-are accepted and normalized. Each value must resolve to exactly one installed
-application using, in priority order:
+are accepted and normalized. Typed `[[handlers]]` entries accept these `kind`
+values:
+
+| Kind | Example identifier | Roles |
+| --- | --- | --- |
+| `extension` | `md` | `all`, `viewer`, `editor`, `shell` |
+| `uti` | `public.plain-text` | `all`, `viewer`, `editor`, `shell` |
+| `mime` | `text/plain` | `all`, `viewer`, `editor`, `shell` |
+| `url_scheme` | `https` | `all` only |
+
+The role defaults to `all`. URL schemes reject document-specific roles because
+`duti` does not accept a role for URL-scheme registration. Each `application`
+or compact association value must resolve to exactly one installed application
+using, in priority order:
 
 1. Exact application path.
 2. Exact bundle identifier.
 3. Case-insensitive, unambiguous application name.
 
-Unknown fields, unsupported schema versions, invalid extensions, empty
-selectors, and duplicate normalized extensions are rejected.
+Unknown fields, unsupported schema versions, invalid identifiers, invalid
+kind/role combinations, empty selectors, and duplicate normalized targets are
+rejected.
+
+For one-off typed inspection or mutation, use:
+
+```bash
+dutis handler get uti public.html --role viewer --json
+dutis handler set mime text/plain com.apple.TextEdit --role editor --dry-run
+```
 
 ## Review and apply
 
@@ -77,11 +117,16 @@ code `9` and no association is changed. See
 
 ## Versioning and migration
 
-- `version` is the configuration schema version and is currently `1`.
-- `schema_version` in plan JSON is currently `1`.
+- `version` is the configuration schema version and is currently `2`.
+- Configuration version `1` remains accepted for legacy `[associations]` files.
+  Typed `[[handlers]]` require version `2`.
+- `schema_version` in plan JSON is currently `2`.
 - `api_version` in the CLI JSON envelope remains `1`.
 - Unknown configuration fields are rejected so misspellings cannot silently
   change policy.
+- Existing serialized plan, result, and snapshot objects retain the legacy
+  `extension` field as the normalized identifier. The accompanying `kind` and
+  `role` fields identify its meaning.
 - A future incompatible schema will use a new configuration version and include
   explicit migration documentation. Dutis never silently upgrades a file.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -35,6 +35,8 @@ The server advertises these read tools:
 - `dutis_drift`: check inline TOML for drift and return a timestamped report with policy assessment.
 - `dutis_query`: find installed handlers for one extension.
 - `dutis_get`: inspect the current default handler.
+- `dutis_handler_get`: inspect an extension, UTI, MIME type, or URL scheme with
+  an optional `all`, `viewer`, `editor`, or `shell` role.
 - `dutis_diff`: parse inline versioned TOML and return a deterministic plan.
 - `dutis_history`: list local safety snapshots.
 - `dutis_rollback_plan`: preview a snapshot rollback and return its digest.
@@ -42,7 +44,9 @@ The server advertises these read tools:
 - `dutis_policy_check`: evaluate an inline TOML plan against policy.
 - `dutis_audit`: inspect persistent mutation audit records.
 
-`dutis_diff` accepts `config_toml` rather than a filesystem path. This keeps the
+`dutis_handler_get` accepts `kind`, `identifier`, and optional `role` fields.
+The kind uses `url_scheme` in JSON; URL schemes accept only the default `all`
+role. `dutis_diff` accepts `config_toml` rather than a filesystem path. This keeps the
 MCP surface independent from unrestricted file access and makes the exact input
 part of the reviewed tool call.
 

--- a/docs/policy-and-audit.md
+++ b/docs/policy-and-audit.md
@@ -29,21 +29,33 @@ Start from [`dutis.policy.example.toml`](../dutis.policy.example.toml):
 version = 1
 approval_mode = "explicit"
 allowed_extensions = ["md", "txt"]
+allowed_kinds = ["extension", "uti", "mime", "url_scheme"]
 allowed_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
 
 [protected_associations]
 pdf = "com.apple.Preview"
+
+[[protected_handlers]]
+kind = "uti"
+identifier = "public.plain-text"
+role = "viewer"
+application = "com.apple.TextEdit"
 ```
 
 - `allowed_extensions` limits changed extensions. Omit it to allow any
-  extension; use an empty list to deny all extensions.
+  extension; use an empty list to deny all extensions. It does not constrain
+  other association kinds.
+- `allowed_kinds` limits changes by normalized association kind. Omit it to
+  allow all four kinds; use an empty list to deny all kinds.
 - `allowed_applications` limits target bundle identifiers with the same
   omitted-versus-empty behavior.
 - `protected_associations` permits an extension only when the target is the
   configured bundle identifier. This allows restoration to the protected value
   while denying changes away from it.
-- Unknown fields, invalid extensions, duplicate normalized values, and unknown
-  versions fail closed.
+- `protected_handlers` applies the same protection to a typed kind, identifier,
+  and role tuple. The role defaults to `all`; URL schemes accept only `all`.
+- Unknown fields, invalid identifiers or roles, duplicate normalized targets,
+  and unknown versions fail closed.
 
 Check a configuration against the current system state and policy without
 changing anything:

--- a/docs/snapshots-and-rollback.md
+++ b/docs/snapshots-and-rollback.md
@@ -13,9 +13,11 @@ Snapshots are JSON files stored at:
 
 Set `DUTIS_STATE_DIR` to use another state directory, which is useful for CI,
 isolated agent runs, or backups. Files are written atomically with owner-only
-permissions on Unix. They contain extension associations, bundle identifiers,
-application paths reported by `duti`, timestamps, and plan digests. They do not
-contain tokens or credentials.
+permissions on Unix. They contain normalized association kinds, identifiers,
+roles, bundle identifiers, application paths reported by `duti`, timestamps,
+and plan digests. They do not contain tokens or credentials. Older extension-
+only snapshots remain readable; missing kind and role fields default to
+`extension` and `all`.
 
 ## Create and inspect
 
@@ -25,7 +27,7 @@ Capture every extension declared by installed applications:
 dutis snapshot create
 ```
 
-Limit capture to extensions in a declarative configuration:
+Limit capture to every typed target in a declarative configuration:
 
 ```bash
 dutis snapshot create --config dutis.toml --json
@@ -67,10 +69,10 @@ snapshot and return per-entry results.
 ## Known safe limitation
 
 `duti` can set an association but does not provide a safe command to remove one.
-If a snapshot records that an extension had no default and it now has one,
-Dutis marks that entry unresolved and refuses the whole rollback. It never
-claims to restore an absent association or performs a broad Launch Services
-reset. The snapshot remains available for inspection and future tooling.
+If a snapshot records that a target had no default and it now has one, Dutis
+marks that entry unresolved and refuses the whole rollback. It never claims to
+restore an absent association or performs a broad Launch Services reset. The
+snapshot remains available for inspection and future tooling.
 
 ## Snapshot schema
 

--- a/dutis.example.toml
+++ b/dutis.example.toml
@@ -1,7 +1,25 @@
-# Dutis declarative configuration schema v1.
-version = 1
+# Dutis declarative configuration schema v2.
+version = 2
 
 # Values may be an exact bundle ID, exact .app path, or unique application name.
 [associations]
 md = "com.apple.TextEdit"
 txt = "com.apple.TextEdit"
+
+# Typed handlers cover UTIs, MIME types, URL schemes, and role-specific rules.
+[[handlers]]
+kind = "uti"
+identifier = "public.plain-text"
+role = "viewer"
+application = "com.apple.TextEdit"
+
+[[handlers]]
+kind = "mime"
+identifier = "text/plain"
+role = "editor"
+application = "com.apple.TextEdit"
+
+[[handlers]]
+kind = "url_scheme"
+identifier = "https"
+application = "com.apple.Safari"

--- a/dutis.policy.example.toml
+++ b/dutis.policy.example.toml
@@ -1,10 +1,18 @@
 version = 1
 approval_mode = "explicit"
 
-# Omit either allowlist to permit any value. An empty list permits none.
+# Omit an allowlist to permit any value. An empty list permits none.
 allowed_extensions = ["md", "txt", "json"]
+allowed_kinds = ["extension", "uti", "mime", "url_scheme"]
 allowed_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
 
 # A protected extension may only remain on, or be restored to, this bundle ID.
 [protected_associations]
 pdf = "com.apple.Preview"
+
+# Typed protected handlers can include a Launch Services role.
+[[protected_handlers]]
+kind = "uti"
+identifier = "public.plain-text"
+role = "viewer"
+application = "com.apple.TextEdit"

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -1,25 +1,27 @@
 ---
 name: dutis
-description: Inspect, plan, safely change, or roll back macOS default file applications with Dutis through its CLI or MCP tools.
+description: Inspect, plan, safely change, or roll back macOS default handlers for extensions, UTIs, MIME types, and URL schemes with Dutis through its CLI or MCP tools.
 ---
 
 # Dutis
 
-Use Dutis for macOS filename-extension associations. Preserve its
+Use Dutis for macOS Launch Services associations. Preserve its
 `inspect -> plan -> policy check -> approval -> apply -> verify` boundary.
 
 ## Workflow
 
 1. Start read-only. Check readiness and the effective policy, then inspect the
-   requested extensions and installed handlers.
+   requested association targets and installed handlers. Use `handler get` or
+   `dutis_handler_get` for UTIs, MIME types, URL schemes, and role-specific
+   reads.
 2. If the user asks for a general setup or is unsure which application to use,
    inspect `dutis_profiles` / `dutis_profile`, then use `dutis_recommend` (or
    the equivalent CLI commands). Present candidate evidence and treat the
    recommendation strictly as a proposal, never as approval.
-3. Express multi-extension changes as versioned TOML. Build a fresh plan and
+3. Express multi-target changes as version 2 TOML. Build a fresh plan and
    run the policy check. Treat unresolved selectors or policy violations as a
    stop condition.
-4. Show the user the exact changed extensions, target bundle IDs, plan digest,
+4. Show the user the exact changed kinds, identifiers, roles, target bundle IDs, plan digest,
    and any policy constraints. Run dry-run before requesting approval.
 5. Ask for explicit approval immediately before a write. Never infer approval
    from an earlier inspection request.

--- a/src/association.rs
+++ b/src/association.rs
@@ -1,0 +1,208 @@
+use anyhow::{bail, Result};
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(
+    Debug, Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, ValueEnum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum AssociationKind {
+    #[default]
+    Extension,
+    Uti,
+    Mime,
+    UrlScheme,
+}
+
+#[derive(
+    Debug, Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, ValueEnum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum HandlerRole {
+    #[default]
+    All,
+    Viewer,
+    Editor,
+    Shell,
+}
+
+impl HandlerRole {
+    pub fn as_duti_argument(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Viewer => "viewer",
+            Self::Editor => "editor",
+            Self::Shell => "shell",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct AssociationTarget {
+    #[serde(default)]
+    pub kind: AssociationKind,
+    pub identifier: String,
+    #[serde(default)]
+    pub role: HandlerRole,
+}
+
+impl AssociationTarget {
+    pub fn extension(value: &str) -> Result<Self> {
+        Self::new(AssociationKind::Extension, value, HandlerRole::All)
+    }
+
+    pub fn new(kind: AssociationKind, value: &str, role: HandlerRole) -> Result<Self> {
+        if kind == AssociationKind::UrlScheme && role != HandlerRole::All {
+            bail!("URL schemes do not accept a Launch Services role");
+        }
+        let identifier = normalize_identifier(kind, value)?;
+        Ok(Self {
+            kind,
+            identifier,
+            role,
+        })
+    }
+
+    pub fn duti_identifier(&self) -> String {
+        if self.kind == AssociationKind::Extension {
+            format!(".{}", self.identifier)
+        } else {
+            self.identifier.clone()
+        }
+    }
+
+    pub fn display_name(&self) -> String {
+        match self.kind {
+            AssociationKind::Extension => format!(".{}", self.identifier),
+            AssociationKind::Uti => format!("UTI {}", self.identifier),
+            AssociationKind::Mime => format!("MIME {}", self.identifier),
+            AssociationKind::UrlScheme => format!("{}://", self.identifier),
+        }
+    }
+}
+
+impl fmt::Display for AssociationTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.display_name())?;
+        if self.kind != AssociationKind::UrlScheme && self.role != HandlerRole::All {
+            write!(formatter, " ({})", self.role.as_duti_argument())?;
+        }
+        Ok(())
+    }
+}
+
+pub fn normalize_identifier(kind: AssociationKind, value: &str) -> Result<String> {
+    let value = value.trim();
+    match kind {
+        AssociationKind::Extension => {
+            let normalized = value.trim_start_matches('.').to_ascii_lowercase();
+            if normalized.is_empty()
+                || normalized.len() > 64
+                || !normalized.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '+')
+                })
+            {
+                bail!("invalid filename extension '{value}'");
+            }
+            Ok(normalized)
+        }
+        AssociationKind::Uti => {
+            let normalized = value.to_ascii_lowercase();
+            if normalized.is_empty()
+                || normalized.len() > 255
+                || !normalized.contains('.')
+                || !normalized.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '.' | '-')
+                })
+            {
+                bail!("invalid UTI '{value}'");
+            }
+            Ok(normalized)
+        }
+        AssociationKind::Mime => {
+            let normalized = value.to_ascii_lowercase();
+            let mut parts = normalized.split('/');
+            let type_name = parts.next().unwrap_or_default();
+            let subtype = parts.next().unwrap_or_default();
+            if type_name.is_empty()
+                || subtype.is_empty()
+                || parts.next().is_some()
+                || !normalized.chars().all(|character| {
+                    character.is_ascii_alphanumeric()
+                        || matches!(
+                            character,
+                            '/' | '!' | '#' | '$' | '&' | '^' | '_' | '+' | '-' | '.'
+                        )
+                })
+            {
+                bail!("invalid MIME type '{value}'");
+            }
+            Ok(normalized)
+        }
+        AssociationKind::UrlScheme => {
+            let normalized = value
+                .trim_end_matches("://")
+                .trim_end_matches(':')
+                .to_ascii_lowercase();
+            let mut characters = normalized.chars();
+            if normalized.is_empty()
+                || normalized.len() > 64
+                || !characters
+                    .next()
+                    .is_some_and(|character| character.is_ascii_alphabetic())
+                || !characters.all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.')
+                })
+            {
+                bail!("invalid URL scheme '{value}'");
+            }
+            Ok(normalized)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_each_supported_kind() {
+        assert_eq!(
+            AssociationTarget::extension(".MD").unwrap().identifier,
+            "md"
+        );
+        assert_eq!(
+            AssociationTarget::new(AssociationKind::Uti, "Public.HTML", HandlerRole::Viewer)
+                .unwrap()
+                .identifier,
+            "public.html"
+        );
+        assert_eq!(
+            AssociationTarget::new(AssociationKind::Mime, "Text/Plain", HandlerRole::All)
+                .unwrap()
+                .identifier,
+            "text/plain"
+        );
+        assert_eq!(
+            AssociationTarget::new(AssociationKind::UrlScheme, "HTTPS://", HandlerRole::All)
+                .unwrap()
+                .identifier,
+            "https"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_identifiers_and_url_roles() {
+        assert!(AssociationTarget::extension("../../etc/passwd").is_err());
+        assert!(AssociationTarget::new(AssociationKind::Uti, "plain", HandlerRole::All).is_err());
+        assert!(AssociationTarget::new(AssociationKind::Mime, "text", HandlerRole::All).is_err());
+        assert!(
+            AssociationTarget::new(AssociationKind::UrlScheme, "123bad", HandlerRole::All).is_err()
+        );
+        assert!(
+            AssociationTarget::new(AssociationKind::UrlScheme, "https", HandlerRole::Viewer)
+                .is_err()
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand};
+use dutis::association::{AssociationKind, HandlerRole};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -43,6 +44,8 @@ pub enum CliCommand {
     Profile(ProfileArgs),
     /// Generate an explainable proposal from a built-in profile
     Recommend(RecommendArgs),
+    /// Read or set typed Launch Services handlers
+    Handler(HandlerArgs),
     /// Detect and optionally remediate drift from a declarative configuration
     Watch(WatchArgs),
     /// Manage the optional per-user drift monitoring LaunchAgent
@@ -212,6 +215,61 @@ pub struct RecommendArgs {
     /// Emit stable machine-readable JSON
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct HandlerArgs {
+    #[command(subcommand)]
+    pub command: HandlerCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum HandlerCommand {
+    /// Read the current handler for an extension, UTI, MIME type, or URL scheme
+    Get(HandlerGetArgs),
+    /// Set a handler for an extension, UTI, MIME type, or URL scheme
+    Set(HandlerSetArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct HandlerGetArgs {
+    /// Association kind
+    #[arg(value_enum)]
+    pub kind: AssociationKind,
+    /// Extension, UTI, MIME type, or URL scheme
+    pub identifier: String,
+    /// Launch Services role; URL schemes only support all
+    #[arg(long, value_enum, default_value_t = HandlerRole::All)]
+    pub role: HandlerRole,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct HandlerSetArgs {
+    /// Association kind
+    #[arg(value_enum)]
+    pub kind: AssociationKind,
+    /// Extension, UTI, MIME type, or URL scheme
+    pub identifier: String,
+    /// Exact bundle ID, application path, or unambiguous application name
+    pub app_selector: String,
+    /// Launch Services role; URL schemes only support all
+    #[arg(long, value_enum, default_value_t = HandlerRole::All)]
+    pub role: HandlerRole,
+    /// Resolve and display the operation without changing the system
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Confirm a non-interactive system change
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+    /// Identity recorded in the local mutation audit
+    #[arg(long)]
+    pub requester: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -447,5 +505,41 @@ mod tests {
             "5",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn parses_typed_handler_commands_and_roles() {
+        let cli = Cli::try_parse_from([
+            "dutis",
+            "handler",
+            "get",
+            "uti",
+            "public.html",
+            "--role",
+            "viewer",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Handler(HandlerArgs {
+                command: HandlerCommand::Get(HandlerGetArgs {
+                    kind: AssociationKind::Uti,
+                    role: HandlerRole::Viewer,
+                    json: true,
+                    ..
+                })
+            }))
+        ));
+        assert!(Cli::try_parse_from([
+            "dutis",
+            "handler",
+            "set",
+            "url-scheme",
+            "https",
+            "com.example.Browser",
+            "--dry-run",
+        ])
+        .is_ok());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,16 +1,39 @@
-use crate::application::normalize_extension;
+use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-pub const CONFIG_VERSION: u32 = 1;
+pub const CONFIG_VERSION: u32 = 2;
+pub const LEGACY_CONFIG_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct DutisConfig {
+    pub version: u32,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub associations: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub handlers: Vec<AssociationRule>,
+}
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct DutisConfig {
-    pub version: u32,
-    pub associations: BTreeMap<String, String>,
+pub struct AssociationRule {
+    pub kind: AssociationKind,
+    pub identifier: String,
+    #[serde(default)]
+    pub role: HandlerRole,
+    pub application: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    version: u32,
+    #[serde(default)]
+    associations: BTreeMap<String, String>,
+    #[serde(default)]
+    handlers: Vec<AssociationRule>,
 }
 
 impl DutisConfig {
@@ -21,18 +44,22 @@ impl DutisConfig {
     }
 
     pub fn parse(contents: &str) -> Result<Self> {
-        let parsed: Self = toml::from_str(contents).context("failed to parse TOML")?;
-        if parsed.version != CONFIG_VERSION {
+        let parsed: RawConfig = toml::from_str(contents).context("failed to parse TOML")?;
+        if !matches!(parsed.version, LEGACY_CONFIG_VERSION | CONFIG_VERSION) {
             bail!(
-                "unsupported configuration version {}; expected {}",
+                "unsupported configuration version {}; expected {} or {}",
                 parsed.version,
+                LEGACY_CONFIG_VERSION,
                 CONFIG_VERSION
             );
+        }
+        if parsed.version == LEGACY_CONFIG_VERSION && !parsed.handlers.is_empty() {
+            bail!("typed handlers require configuration version {CONFIG_VERSION}");
         }
 
         let mut associations = BTreeMap::new();
         for (input_extension, input_selector) in parsed.associations {
-            let extension = normalize_extension(&input_extension)?;
+            let extension = AssociationTarget::extension(&input_extension)?.identifier;
             let selector = input_selector.trim();
             if selector.is_empty() {
                 bail!("application selector for .{extension} cannot be empty");
@@ -45,10 +72,63 @@ impl DutisConfig {
             }
         }
 
+        let mut seen = associations
+            .keys()
+            .map(|extension| {
+                AssociationTarget::extension(extension).expect("normalized extension is valid")
+            })
+            .collect::<BTreeSet<_>>();
+        let mut handlers = Vec::with_capacity(parsed.handlers.len());
+        for handler in parsed.handlers {
+            let target = AssociationTarget::new(handler.kind, &handler.identifier, handler.role)?;
+            let application = handler.application.trim();
+            if application.is_empty() {
+                bail!("application selector for {target} cannot be empty");
+            }
+            if !seen.insert(target.clone()) {
+                bail!("duplicate association target {target}");
+            }
+            handlers.push(AssociationRule {
+                kind: target.kind,
+                identifier: target.identifier,
+                role: target.role,
+                application: application.to_owned(),
+            });
+        }
+        handlers.sort_by(|left, right| {
+            (&left.kind, &left.identifier, &left.role).cmp(&(
+                &right.kind,
+                &right.identifier,
+                &right.role,
+            ))
+        });
+
         Ok(Self {
             version: parsed.version,
             associations,
+            handlers,
         })
+    }
+
+    pub fn rules(&self) -> Result<Vec<(AssociationTarget, &str)>> {
+        let mut rules = self
+            .associations
+            .iter()
+            .map(|(extension, application)| {
+                Ok((
+                    AssociationTarget::extension(extension)?,
+                    application.as_str(),
+                ))
+            })
+            .chain(self.handlers.iter().map(|handler| {
+                Ok((
+                    AssociationTarget::new(handler.kind, &handler.identifier, handler.role)?,
+                    handler.application.as_str(),
+                ))
+            }))
+            .collect::<Result<Vec<_>>>()?;
+        rules.sort_by(|left, right| left.0.cmp(&right.0));
+        Ok(rules)
     }
 }
 
@@ -72,15 +152,65 @@ mod tests {
         assert_eq!(config.version, 1);
         assert_eq!(config.associations["md"], "com.example.Editor");
         assert_eq!(config.associations["json"], "/Applications/Editor.app");
+        assert!(config.handlers.is_empty());
     }
 
     #[test]
     fn rejects_unknown_versions_and_duplicate_normalized_extensions() {
-        assert!(DutisConfig::parse("version = 2\n[associations]\nmd = 'Editor'").is_err());
+        assert!(DutisConfig::parse("version = 3\n[associations]\nmd = 'Editor'").is_err());
         assert!(
             DutisConfig::parse("version = 1\n[associations]\nmd = 'Editor'\n'.MD' = 'Other'")
                 .is_err()
         );
+    }
+
+    #[test]
+    fn parses_and_orders_typed_handlers_in_version_two() {
+        let config = DutisConfig::parse(
+            r#"
+                version = 2
+
+                [associations]
+                md = "com.example.Editor"
+
+                [[handlers]]
+                kind = "url_scheme"
+                identifier = "HTTPS://"
+                application = "com.example.Browser"
+
+                [[handlers]]
+                kind = "uti"
+                identifier = "Public.HTML"
+                role = "viewer"
+                application = "com.example.Browser"
+            "#,
+        )
+        .unwrap();
+        let rules = config.rules().unwrap();
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].0.kind, AssociationKind::Extension);
+        assert_eq!(rules[1].0.kind, AssociationKind::Uti);
+        assert_eq!(rules[1].0.identifier, "public.html");
+        assert_eq!(rules[1].0.role, HandlerRole::Viewer);
+        assert_eq!(rules[2].0.kind, AssociationKind::UrlScheme);
+        assert_eq!(rules[2].0.identifier, "https");
+    }
+
+    #[test]
+    fn keeps_version_one_compatible_and_rejects_typed_handlers() {
+        assert!(DutisConfig::parse("version = 1\n[associations]\nmd = 'Editor'").is_ok());
+        assert!(DutisConfig::parse(
+            "version = 1\n[[handlers]]\nkind = 'uti'\nidentifier = 'public.text'\napplication = 'Editor'"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_targets_across_legacy_and_typed_entries() {
+        assert!(DutisConfig::parse(
+            "version = 2\n[associations]\nmd = 'Editor'\n[[handlers]]\nkind = 'extension'\nidentifier = '.MD'\napplication = 'Other'"
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -175,8 +175,10 @@ mod tests {
                 approval_mode: ApprovalMode::Explicit,
                 approval_token_configured: false,
                 allowed_extensions: None,
+                allowed_kinds: None,
                 allowed_applications: None,
                 protected_associations: BTreeMap::new(),
+                protected_handlers: Vec::new(),
             },
             PolicyAssessment {
                 allowed: true,
@@ -191,6 +193,8 @@ mod tests {
         let plan = assemble_plan(
             1,
             vec![PlanEntry {
+                kind: crate::association::AssociationKind::Extension,
+                role: crate::association::HandlerRole::All,
                 extension: "md".to_owned(),
                 selector: "com.example.Editor".to_owned(),
                 current: None,

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -1,4 +1,5 @@
 use crate::application::normalize_extension;
+use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use crate::planner::{ApplyReport, AssociationPlan, PlanAction};
 use crate::snapshot::{apply_plan_with_snapshot, SnapshotReason, SnapshotStore};
 use anyhow::{anyhow, bail, Context, Result};
@@ -32,8 +33,11 @@ pub struct Policy {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_extensions: Option<BTreeSet<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_kinds: Option<BTreeSet<AssociationKind>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_applications: Option<BTreeSet<String>>,
     pub protected_associations: BTreeMap<String, String>,
+    pub protected_handlers: Vec<ProtectedHandler>,
     #[serde(skip_serializing)]
     approval_token_sha256: Option<String>,
 }
@@ -45,10 +49,23 @@ struct RawPolicy {
     #[serde(default)]
     approval_mode: ApprovalMode,
     allowed_extensions: Option<Vec<String>>,
+    allowed_kinds: Option<Vec<AssociationKind>>,
     allowed_applications: Option<Vec<String>>,
     #[serde(default)]
     protected_associations: BTreeMap<String, String>,
+    #[serde(default)]
+    protected_handlers: Vec<ProtectedHandler>,
     approval_token_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProtectedHandler {
+    pub kind: AssociationKind,
+    pub identifier: String,
+    #[serde(default)]
+    pub role: HandlerRole,
+    pub application: String,
 }
 
 impl Default for Policy {
@@ -57,8 +74,10 @@ impl Default for Policy {
             version: POLICY_VERSION,
             approval_mode: ApprovalMode::Explicit,
             allowed_extensions: None,
+            allowed_kinds: None,
             allowed_applications: None,
             protected_associations: BTreeMap::new(),
+            protected_handlers: Vec::new(),
             approval_token_sha256: None,
         }
     }
@@ -82,6 +101,7 @@ impl Policy {
             .allowed_applications
             .map(|values| normalize_nonempty_set(values, "allowed application"))
             .transpose()?;
+        let allowed_kinds = raw.allowed_kinds.map(|values| values.into_iter().collect());
         let mut protected_associations = BTreeMap::new();
         for (input_extension, input_bundle_id) in raw.protected_associations {
             let extension = normalize_extension(&input_extension)?;
@@ -96,6 +116,36 @@ impl Policy {
                 bail!("duplicate protected extension .{extension}");
             }
         }
+        let mut seen_handlers = protected_associations
+            .keys()
+            .map(|extension| {
+                AssociationTarget::extension(extension).expect("normalized extension is valid")
+            })
+            .collect::<BTreeSet<_>>();
+        let mut protected_handlers = Vec::with_capacity(raw.protected_handlers.len());
+        for handler in raw.protected_handlers {
+            let target = AssociationTarget::new(handler.kind, &handler.identifier, handler.role)?;
+            let application = handler.application.trim();
+            if application.is_empty() {
+                bail!("protected application for {target} cannot be empty");
+            }
+            if !seen_handlers.insert(target.clone()) {
+                bail!("duplicate protected handler {target}");
+            }
+            protected_handlers.push(ProtectedHandler {
+                kind: target.kind,
+                identifier: target.identifier,
+                role: target.role,
+                application: application.to_owned(),
+            });
+        }
+        protected_handlers.sort_by(|left, right| {
+            (&left.kind, &left.identifier, &left.role).cmp(&(
+                &right.kind,
+                &right.identifier,
+                &right.role,
+            ))
+        });
         if raw.approval_mode == ApprovalMode::Token {
             let digest = raw.approval_token_sha256.as_deref().ok_or_else(|| {
                 anyhow!("approval_token_sha256 is required when approval_mode is 'token'")
@@ -112,8 +162,10 @@ impl Policy {
             version: raw.version,
             approval_mode: raw.approval_mode,
             allowed_extensions,
+            allowed_kinds,
             allowed_applications,
             protected_associations,
+            protected_handlers,
             approval_token_sha256: raw
                 .approval_token_sha256
                 .map(|digest| digest.to_ascii_lowercase()),
@@ -137,9 +189,17 @@ impl Policy {
             .filter(|entry| entry.action == PlanAction::Change)
         {
             if self
-                .allowed_extensions
+                .allowed_kinds
                 .as_ref()
-                .is_some_and(|allowed| !allowed.contains(&entry.extension))
+                .is_some_and(|allowed| !allowed.contains(&entry.kind))
+            {
+                violations.push(format!("association kind {:?} is not allowed", entry.kind));
+            }
+            if entry.kind == AssociationKind::Extension
+                && self
+                    .allowed_extensions
+                    .as_ref()
+                    .is_some_and(|allowed| !allowed.contains(&entry.extension))
             {
                 violations.push(format!("extension .{} is not allowed", entry.extension));
             }
@@ -151,15 +211,30 @@ impl Policy {
                 target_bundle_id.is_none_or(|bundle_id| !allowed.contains(bundle_id))
             }) {
                 violations.push(format!(
-                    "target application for .{} is not allowed",
-                    entry.extension
+                    "target application for {} is not allowed",
+                    entry.association()
                 ));
             }
-            if let Some(required) = self.protected_associations.get(&entry.extension) {
-                if target_bundle_id != Some(required.as_str()) {
+            if entry.kind == AssociationKind::Extension {
+                if let Some(required) = self.protected_associations.get(&entry.extension) {
+                    if target_bundle_id != Some(required.as_str()) {
+                        violations.push(format!(
+                            "protected association .{} must remain assigned to {}",
+                            entry.extension, required
+                        ));
+                    }
+                }
+            }
+            if let Some(required) = self.protected_handlers.iter().find(|handler| {
+                handler.kind == entry.kind
+                    && handler.identifier == entry.extension
+                    && handler.role == entry.role
+            }) {
+                if target_bundle_id != Some(required.application.as_str()) {
                     violations.push(format!(
-                        "protected association .{} must remain assigned to {}",
-                        entry.extension, required
+                        "protected handler {} must remain assigned to {}",
+                        entry.association(),
+                        required.application
                     ));
                 }
             }
@@ -261,8 +336,10 @@ impl LoadedPolicy {
             approval_mode: self.policy.approval_mode,
             approval_token_configured: self.policy.approval_token_sha256.is_some(),
             allowed_extensions: self.policy.allowed_extensions.clone(),
+            allowed_kinds: self.policy.allowed_kinds.clone(),
             allowed_applications: self.policy.allowed_applications.clone(),
             protected_associations: self.policy.protected_associations.clone(),
+            protected_handlers: self.policy.protected_handlers.clone(),
         }
     }
 }
@@ -276,8 +353,10 @@ pub struct PolicySummary {
     pub approval_mode: ApprovalMode,
     pub approval_token_configured: bool,
     pub allowed_extensions: Option<BTreeSet<String>>,
+    pub allowed_kinds: Option<BTreeSet<AssociationKind>>,
     pub allowed_applications: Option<BTreeSet<String>>,
     pub protected_associations: BTreeMap<String, String>,
+    pub protected_handlers: Vec<ProtectedHandler>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -478,7 +557,7 @@ pub fn execute_governed_plan<F>(
     apply: F,
 ) -> std::result::Result<GovernedMutation, GovernanceError>
 where
-    F: FnMut(&str, &str) -> Result<()>,
+    F: FnMut(&AssociationTarget, &str) -> Result<()>,
 {
     let policy = LoadedPolicy::from_environment().map_err(|error| GovernanceError {
         kind: GovernanceErrorKind::PolicyDenied,
@@ -519,7 +598,7 @@ fn execute_governed_plan_with<F>(
     apply: F,
 ) -> std::result::Result<GovernedMutation, GovernanceError>
 where
-    F: FnMut(&str, &str) -> Result<()>,
+    F: FnMut(&AssociationTarget, &str) -> Result<()>,
 {
     let assessment = loaded_policy.policy.authorize(plan, request);
     let mut record = new_audit_record(loaded_policy, plan, request);
@@ -740,9 +819,13 @@ mod tests {
         assemble_plan(
             1,
             vec![PlanEntry {
+                kind: crate::association::AssociationKind::Extension,
+                role: crate::association::HandlerRole::All,
                 extension: extension.to_owned(),
                 selector: target.to_owned(),
                 current: Some(DefaultApplication {
+                    kind: crate::association::AssociationKind::Extension,
+                    role: crate::association::HandlerRole::All,
                     extension: extension.to_owned(),
                     name: None,
                     path: None,
@@ -858,6 +941,34 @@ mod tests {
         let denied = policy.assess(&plan("md", "com.example.Other"));
         assert!(!denied.allowed);
         assert!(denied.violations[0].contains("must remain assigned"));
+    }
+
+    #[test]
+    fn typed_policy_restricts_kinds_and_protects_role_specific_handlers() {
+        let policy = Policy::parse(
+            r#"
+                version = 1
+                allowed_kinds = ["uti"]
+
+                [[protected_handlers]]
+                kind = "uti"
+                identifier = "Public.HTML"
+                role = "viewer"
+                application = "com.example.Browser"
+            "#,
+        )
+        .unwrap();
+        let mut typed = plan("public.html", "com.example.Other");
+        typed.entries[0].kind = AssociationKind::Uti;
+        typed.entries[0].role = HandlerRole::Viewer;
+        let denied = policy.assess(&typed);
+        assert!(!denied.allowed);
+        assert!(denied.violations[0].contains("must remain assigned"));
+
+        let extension = plan("md", "com.example.Browser");
+        let denied = policy.assess(&extension);
+        assert!(!denied.allowed);
+        assert!(denied.violations[0].contains("kind"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app_scanner;
 pub mod application;
+pub mod association;
 pub mod config;
 pub mod drift;
 pub mod governance;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,18 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{
-    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, LaunchAgentArgs, LaunchAgentCommand,
-    LaunchAgentInstallArgs, McpArgs, OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand,
-    ProfileArgs, ProfileCommand, ProfileShowArgs, RecommendArgs, RollbackArgs, SetArgs,
-    SnapshotArgs, SnapshotCommand, SnapshotCreateArgs, WatchArgs,
+    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, HandlerArgs, HandlerCommand,
+    HandlerGetArgs, HandlerSetArgs, LaunchAgentArgs, LaunchAgentCommand, LaunchAgentInstallArgs,
+    McpArgs, OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand, ProfileArgs, ProfileCommand,
+    ProfileShowArgs, RecommendArgs, RollbackArgs, SetArgs, SnapshotArgs, SnapshotCommand,
+    SnapshotCreateArgs, WatchArgs,
 };
 use colored::*;
 use dutis::application::{
     find_apps_for_extension, find_fuzzy_matches, normalize_extension, resolve_app, Application,
     ApplicationCatalog,
 };
+use dutis::association::{AssociationKind, AssociationTarget, HandlerRole};
 use dutis::config::DutisConfig;
 use dutis::drift::{send_macos_notification, DriftReport, DriftState, DriftTracker};
 use dutis::governance::{
@@ -24,7 +26,7 @@ use dutis::planner::{
 };
 use dutis::profiles::{find_profile, profiles, recommend_profile, ProfileRecommendation};
 use dutis::snapshot::{
-    build_rollback_plan, capture_associations, SnapshotReason, SnapshotStore, SnapshotSummary,
+    build_rollback_plan, capture_targets, SnapshotReason, SnapshotStore, SnapshotSummary,
 };
 use dutis::system;
 use serde::Serialize;
@@ -136,6 +138,18 @@ struct QueryResult<'a> {
 struct SetResult<'a> {
     status: &'static str,
     extension: &'a str,
+    application: &'a Application,
+    command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    audit_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    safety_snapshot_id: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct HandlerSetResult<'a> {
+    status: &'static str,
+    association: &'a AssociationTarget,
     application: &'a Application,
     command: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -258,6 +272,7 @@ fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
         Some(CliCommand::Audit(args)) => run_audit(args),
         Some(CliCommand::Profile(args)) => run_profile(args),
         Some(CliCommand::Recommend(args)) => run_recommend(args),
+        Some(CliCommand::Handler(args)) => run_handler(args),
         Some(CliCommand::Watch(args)) => run_watch(args),
         Some(CliCommand::LaunchAgent(args)) => run_launch_agent(args),
         Some(CliCommand::Mcp(args)) => run_mcp(args),
@@ -281,6 +296,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Audit(_) => "audit",
         CliCommand::Profile(_) => "profile",
         CliCommand::Recommend(_) => "recommend",
+        CliCommand::Handler(_) => "handler",
         CliCommand::Watch(_) => "watch",
         CliCommand::LaunchAgent(_) => "launch-agent",
         CliCommand::Mcp(_) => "mcp",
@@ -310,6 +326,10 @@ fn command_uses_json(command: &CliCommand) -> bool {
             ProfileCommand::Show(args) => args.json,
         },
         CliCommand::Recommend(args) => args.json,
+        CliCommand::Handler(args) => match &args.command {
+            HandlerCommand::Get(args) => args.json,
+            HandlerCommand::Set(args) => args.json,
+        },
         CliCommand::Watch(args) => args.json,
         CliCommand::LaunchAgent(args) => match &args.command {
             LaunchAgentCommand::Install(args) => args.json,
@@ -317,6 +337,158 @@ fn command_uses_json(command: &CliCommand) -> bool {
         },
         CliCommand::Mcp(_) => false,
     }
+}
+
+fn run_handler(args: HandlerArgs) -> Result<(), CliError> {
+    match args.command {
+        HandlerCommand::Get(args) => run_handler_get(args),
+        HandlerCommand::Set(args) => run_handler_set(args),
+    }
+}
+
+fn run_handler_get(args: HandlerGetArgs) -> Result<(), CliError> {
+    let association = AssociationTarget::new(args.kind, &args.identifier, args.role)
+        .map_err(|error| CliError::usage(error.to_string()))?;
+    let current = system::get_default_handler(&association)
+        .map_err(|error| CliError::operation(format!("{error:#}")))?
+        .ok_or_else(|| {
+            CliError::not_found(format!(
+                "no default application is registered for {association}"
+            ))
+        })?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "handler",
+            data: current,
+        })?;
+    } else {
+        println!("Default application for {association}:");
+        println!("Bundle ID: {}", current.bundle_id);
+        if let Some(name) = current.name {
+            println!("Name: {name}");
+        }
+        if let Some(path) = current.path {
+            println!("Path: {path}");
+        }
+    }
+    Ok(())
+}
+
+fn run_handler_set(args: HandlerSetArgs) -> Result<(), CliError> {
+    if !args.dry_run && !args.yes {
+        return Err(CliError::usage(
+            "refusing to change the system without --yes; use --dry-run to preview",
+        ));
+    }
+    let association = AssociationTarget::new(args.kind, &args.identifier, args.role)
+        .map_err(|error| CliError::usage(error.to_string()))?;
+    let catalog = scan_catalog()?;
+    report_metadata_failures(catalog.metadata_failures);
+    let matches = resolve_app(&catalog.applications, &args.app_selector);
+    let app = match matches.as_slice() {
+        [] => {
+            return Err(CliError::not_found(format!(
+                "no installed application matches '{}'",
+                args.app_selector
+            )))
+        }
+        [app] => *app,
+        matches => {
+            let paths = matches
+                .iter()
+                .map(|app| app.path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(CliError::ambiguous(format!(
+                "application name '{}' is ambiguous; use a bundle ID or exact path ({paths})",
+                args.app_selector
+            )));
+        }
+    };
+    let bundle_id = app.bundle_id.as_deref().ok_or_else(|| {
+        CliError::operation(format!(
+            "{} has no readable bundle identifier",
+            app.path.display()
+        ))
+    })?;
+    let mut command = vec!["duti".to_owned()];
+    command.extend(system::duti_set_arguments(&association, bundle_id));
+    let mutation = if args.dry_run {
+        None
+    } else {
+        system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
+        let current = system::query_default_handler(&association)
+            .map_err(|error| CliError::operation(format!("{error:#}")))?;
+        let action = if current.as_ref().map(|value| value.bundle_id.as_str()) == Some(bundle_id) {
+            PlanAction::Unchanged
+        } else {
+            PlanAction::Change
+        };
+        let plan = assemble_plan(
+            dutis::config::CONFIG_VERSION,
+            vec![PlanEntry {
+                kind: association.kind,
+                role: association.role,
+                extension: association.identifier.clone(),
+                selector: args.app_selector.clone(),
+                current,
+                target: PlannedApplication::from_application(app),
+                action,
+                reason: None,
+            }],
+        )
+        .map_err(|error| CliError::operation(format!("failed to build handler plan: {error:#}")))?;
+        let request = cli_mutation_request(args.requester.as_deref(), MutationOperation::Set);
+        let result = execute_governed_cli_plan(&plan, SnapshotReason::BeforeApply, &request)?;
+        if result.report.failed > 0 {
+            let details = serde_json::to_value(&result).map_err(|error| {
+                CliError::operation(format!("failed to serialize report: {error}"))
+            })?;
+            return Err(CliError::partial_failure(
+                "the handler failed to apply or verify",
+                details,
+            ));
+        }
+        Some(result)
+    };
+    let status = match mutation.as_ref() {
+        None => "planned",
+        Some(result) if result.report.applied > 0 => "applied",
+        Some(_) => "unchanged",
+    };
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "handler",
+            data: HandlerSetResult {
+                status,
+                association: &association,
+                application: app,
+                command,
+                audit_id: mutation.as_ref().map(|result| result.audit_id.as_str()),
+                safety_snapshot_id: mutation
+                    .as_ref()
+                    .and_then(|result| result.safety_snapshot_id.as_deref()),
+            },
+        })?;
+    } else if args.dry_run {
+        println!(
+            "Dry run: would set {association} to {} ({bundle_id})",
+            app.name
+        );
+        println!("Command: {}", shell_display(&command));
+    } else if let Some(result) = mutation {
+        println!(
+            "Set {association} to {} ({bundle_id}) and verified it",
+            app.name
+        );
+        println!("Audit record: {}", result.audit_id);
+        if let Some(snapshot_id) = result.safety_snapshot_id {
+            println!("Safety snapshot: {snapshot_id}");
+        }
+    }
+    Ok(())
 }
 
 fn run_watch(args: WatchArgs) -> Result<(), CliError> {
@@ -346,7 +518,7 @@ fn run_watch(args: WatchArgs) -> Result<(), CliError> {
                 &report.plan,
                 SnapshotReason::BeforeRemediation,
                 &request,
-                system::set_default_app,
+                system::set_default_handler,
             ) {
                 Ok(result) => Some(WatchRemediation {
                     status: if result.report.failed == 0 {
@@ -438,12 +610,12 @@ fn print_watch_result(result: &WatchResult, json: bool) -> Result<(), CliError> 
             .as_ref()
             .map(|application| application.bundle_id.as_str())
             .unwrap_or("<unresolved>");
-        println!("DRIFT .{}: {} -> {}", entry.extension, current, target);
+        println!("DRIFT {}: {} -> {}", entry.association(), current, target);
     }
     for entry in &result.report.unresolved {
         println!(
-            "UNRESOLVED .{}: {}",
-            entry.extension,
+            "UNRESOLVED {}: {}",
+            entry.association(),
             entry.reason.as_deref().unwrap_or("unknown reason")
         );
     }
@@ -983,6 +1155,8 @@ fn run_set(args: SetArgs) -> Result<(), CliError> {
         let plan = assemble_plan(
             dutis::config::CONFIG_VERSION,
             vec![PlanEntry {
+                kind: AssociationKind::Extension,
+                role: HandlerRole::All,
                 extension: extension.clone(),
                 selector: args.app_selector.clone(),
                 current,
@@ -1172,12 +1346,14 @@ fn run_snapshot(args: SnapshotArgs) -> Result<(), CliError> {
 }
 
 fn run_snapshot_create(args: SnapshotCreateArgs) -> Result<(), CliError> {
-    let extensions = if let Some(path) = args.config {
+    let targets = if let Some(path) = args.config {
         DutisConfig::load(&path)
             .map_err(|error| CliError::usage(format!("{error:#}")))?
-            .associations
-            .into_keys()
-            .collect::<BTreeSet<_>>()
+            .rules()
+            .map_err(|error| CliError::usage(format!("{error:#}")))?
+            .into_iter()
+            .map(|(target, _)| target)
+            .collect::<Vec<_>>()
     } else {
         let catalog = scan_catalog()?;
         report_metadata_failures(catalog.metadata_failures);
@@ -1186,11 +1362,17 @@ fn run_snapshot_create(args: SnapshotCreateArgs) -> Result<(), CliError> {
             .into_iter()
             .flat_map(|application| application.extensions)
             .collect::<BTreeSet<_>>()
+            .into_iter()
+            .map(|extension| AssociationTarget::extension(&extension))
+            .collect::<Result<Vec<_>>>()
+            .map_err(|error| {
+                CliError::operation(format!("failed to normalize target: {error:#}"))
+            })?
     };
 
     system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
     let associations =
-        capture_associations(extensions, system::query_default_app).map_err(|error| {
+        capture_targets(targets, system::query_default_handler).map_err(|error| {
             CliError::operation(format!("failed to capture associations: {error:#}"))
         })?;
     let store = snapshot_store()?;
@@ -1265,10 +1447,12 @@ fn run_rollback(args: RollbackArgs) -> Result<(), CliError> {
     let catalog = scan_catalog()?;
     report_metadata_failures(catalog.metadata_failures);
     system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
-    let plan = build_rollback_plan(&snapshot, &catalog.applications, system::query_default_app)
-        .map_err(|error| {
-            CliError::operation(format!("failed to build rollback plan: {error:#}"))
-        })?;
+    let plan = build_rollback_plan(
+        &snapshot,
+        &catalog.applications,
+        system::query_default_handler,
+    )
+    .map_err(|error| CliError::operation(format!("failed to build rollback plan: {error:#}")))?;
 
     if args.dry_run {
         if args.json {
@@ -1337,7 +1521,7 @@ fn execute_governed_cli_plan(
     reason: SnapshotReason,
     request: &MutationRequest,
 ) -> Result<GovernedMutation, CliError> {
-    execute_governed_plan(plan, reason, request, system::set_default_app)
+    execute_governed_plan(plan, reason, request, system::set_default_handler)
         .map_err(governance_cli_error)
 }
 
@@ -1392,8 +1576,12 @@ fn build_declarative_plan(path: &Path) -> Result<AssociationPlan, CliError> {
     let catalog = scan_catalog()?;
     report_metadata_failures(catalog.metadata_failures);
     system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
-    build_plan(&config, &catalog.applications, system::query_default_app)
-        .map_err(|error| CliError::operation(format!("failed to inspect current state: {error:#}")))
+    build_plan(
+        &config,
+        &catalog.applications,
+        system::query_default_handler,
+    )
+    .map_err(|error| CliError::operation(format!("failed to inspect current state: {error:#}")))
 }
 
 fn print_plan(plan: &AssociationPlan, changes_only: bool) {
@@ -1413,7 +1601,12 @@ fn print_plan(plan: &AssociationPlan, changes_only: bool) {
                     .as_ref()
                     .map(|app| app.bundle_id.as_str())
                     .unwrap_or("<unresolved>");
-                println!("CHANGE    .{}: {} -> {}", entry.extension, current, target);
+                println!(
+                    "CHANGE    {}: {} -> {}",
+                    entry.association(),
+                    current,
+                    target
+                );
             }
             PlanAction::Unchanged => {
                 let bundle_id = entry
@@ -1421,11 +1614,11 @@ fn print_plan(plan: &AssociationPlan, changes_only: bool) {
                     .as_ref()
                     .map(|app| app.bundle_id.as_str())
                     .unwrap_or("<unknown>");
-                println!("UNCHANGED .{}: {}", entry.extension, bundle_id);
+                println!("UNCHANGED {}: {}", entry.association(), bundle_id);
             }
             PlanAction::Unresolved => println!(
-                "UNRESOLVED .{}: {}",
-                entry.extension,
+                "UNRESOLVED {}: {}",
+                entry.association(),
                 entry.reason.as_deref().unwrap_or("unknown reason")
             ),
         }
@@ -1444,9 +1637,13 @@ fn print_mutation_result(result: &GovernedMutation) {
     }
     for entry in &result.report.results {
         println!(
-            "{:?} .{}{}",
+            "{:?} {}{}",
             entry.status,
-            entry.extension,
+            AssociationTarget {
+                kind: entry.kind,
+                identifier: entry.extension.clone(),
+                role: entry.role,
+            },
             entry
                 .error
                 .as_ref()
@@ -1707,6 +1904,8 @@ fn set_default_and_report(extension: &str, app: &Application) {
             let plan = assemble_plan(
                 dutis::config::CONFIG_VERSION,
                 vec![PlanEntry {
+                    kind: AssociationKind::Extension,
+                    role: HandlerRole::All,
                     extension: extension.to_owned(),
                     selector: bundle_id.to_owned(),
                     current,
@@ -1721,7 +1920,7 @@ fn set_default_and_report(extension: &str, app: &Application) {
                 &plan,
                 SnapshotReason::BeforeApply,
                 &request,
-                system::set_default_app,
+                system::set_default_handler,
             )
             .map_err(anyhow::Error::from)
         });

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,4 +1,5 @@
 use crate::application::{find_apps_for_extension, normalize_extension, ApplicationCatalog};
+use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use crate::config::DutisConfig;
 use crate::drift::DriftReport;
 use crate::governance::{
@@ -83,6 +84,7 @@ trait McpBackend {
     fn drift(&mut self, config: &DutisConfig) -> Result<Value>;
     fn query(&mut self, extension: &str) -> Result<Value>;
     fn get(&mut self, extension: &str) -> Result<Value>;
+    fn get_handler(&mut self, association: &AssociationTarget) -> Result<Value>;
     fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan>;
     fn apply(
         &mut self,
@@ -135,7 +137,7 @@ impl McpBackend for SystemBackend {
     fn drift(&mut self, config: &DutisConfig) -> Result<Value> {
         system::duti_version()?;
         let catalog = ApplicationCatalog::scan()?;
-        let plan = build_plan(config, &catalog.applications, system::query_default_app)?;
+        let plan = build_plan(config, &catalog.applications, system::query_default_handler)?;
         let policy = LoadedPolicy::from_environment()?;
         let assessment = policy.policy.assess(&plan);
         serde_json::to_value(DriftReport::new(plan, policy.summary(), assessment)?)
@@ -157,10 +159,15 @@ impl McpBackend for SystemBackend {
         Ok(json!({"extension": extension, "default": default}))
     }
 
+    fn get_handler(&mut self, association: &AssociationTarget) -> Result<Value> {
+        let default = system::get_default_handler(association)?;
+        Ok(json!({"association": association, "default": default}))
+    }
+
     fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan> {
         system::duti_version()?;
         let catalog = ApplicationCatalog::scan()?;
-        build_plan(config, &catalog.applications, system::query_default_app)
+        build_plan(config, &catalog.applications, system::query_default_handler)
     }
 
     fn apply(
@@ -169,7 +176,7 @@ impl McpBackend for SystemBackend {
         reason: SnapshotReason,
         request: &MutationRequest,
     ) -> Result<Value> {
-        let result = execute_governed_plan(plan, reason, request, system::set_default_app)
+        let result = execute_governed_plan(plan, reason, request, system::set_default_handler)
             .map_err(anyhow::Error::from)?;
         serde_json::to_value(result).context("failed to serialize mutation result")
     }
@@ -184,7 +191,11 @@ impl McpBackend for SystemBackend {
         let snapshot = store.load(snapshot_id)?;
         system::duti_version()?;
         let catalog = ApplicationCatalog::scan()?;
-        build_rollback_plan(&snapshot, &catalog.applications, system::query_default_app)
+        build_rollback_plan(
+            &snapshot,
+            &catalog.applications,
+            system::query_default_handler,
+        )
     }
 
     fn policy(&mut self) -> Result<Value> {
@@ -364,6 +375,12 @@ impl<B: McpBackend> McpServer<B> {
                     .map_err(|error| ToolError::new("invalid_arguments", error.to_string()))?;
                 self.backend.get(&extension).map_err(operation_error)
             }
+            "dutis_handler_get" => {
+                let association = parse_association(arguments)?;
+                self.backend
+                    .get_handler(&association)
+                    .map_err(operation_error)
+            }
             "dutis_diff" => {
                 let config = parse_config(arguments)?;
                 let plan = self.backend.plan(&config).map_err(operation_error)?;
@@ -516,6 +533,41 @@ fn argument_string<'a>(
         })
 }
 
+fn parse_association(
+    arguments: &Map<String, Value>,
+) -> std::result::Result<AssociationTarget, ToolError> {
+    let kind = match argument_string(arguments, "kind")? {
+        "extension" => AssociationKind::Extension,
+        "uti" => AssociationKind::Uti,
+        "mime" => AssociationKind::Mime,
+        "url_scheme" => AssociationKind::UrlScheme,
+        value => {
+            return Err(ToolError::new(
+                "invalid_arguments",
+                format!("unsupported association kind '{value}'"),
+            ))
+        }
+    };
+    let role = match arguments
+        .get("role")
+        .and_then(Value::as_str)
+        .unwrap_or("all")
+    {
+        "all" => HandlerRole::All,
+        "viewer" => HandlerRole::Viewer,
+        "editor" => HandlerRole::Editor,
+        "shell" => HandlerRole::Shell,
+        value => {
+            return Err(ToolError::new(
+                "invalid_arguments",
+                format!("unsupported handler role '{value}'"),
+            ))
+        }
+    };
+    AssociationTarget::new(kind, argument_string(arguments, "identifier")?, role)
+        .map_err(|error| ToolError::new("invalid_arguments", error.to_string()))
+}
+
 fn parse_config(arguments: &Map<String, Value>) -> std::result::Result<DutisConfig, ToolError> {
     let contents = argument_string(arguments, "config_toml")?;
     if contents.len() > MAX_CONFIG_BYTES {
@@ -630,6 +682,16 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
         "required": ["extension"],
         "additionalProperties": false,
     });
+    let handler_schema = json!({
+        "type": "object",
+        "properties": {
+            "kind": {"type": "string", "enum": ["extension", "uti", "mime", "url_scheme"]},
+            "identifier": {"type": "string", "minLength": 1},
+            "role": {"type": "string", "enum": ["all", "viewer", "editor", "shell"], "default": "all"}
+        },
+        "required": ["kind", "identifier"],
+        "additionalProperties": false,
+    });
     let config_schema = json!({
         "type": "object",
         "properties": {"config_toml": {"type": "string", "minLength": 1}},
@@ -695,6 +757,12 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
             "dutis_get",
             "Read the current default application for an extension.",
             extension_schema,
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_handler_get",
+            "Read the current handler for an extension, UTI, MIME type, or URL scheme.",
+            handler_schema,
             read_annotations.clone(),
         ),
         tool_definition(
@@ -907,6 +975,10 @@ mod tests {
             Ok(json!({"extension": extension, "default": null}))
         }
 
+        fn get_handler(&mut self, association: &AssociationTarget) -> Result<Value> {
+            Ok(json!({"association": association, "default": null}))
+        }
+
         fn plan(&mut self, _config: &DutisConfig) -> Result<AssociationPlan> {
             Ok(self.plan.clone())
         }
@@ -988,6 +1060,7 @@ mod tests {
         assert!(names.contains(&"dutis_profile"));
         assert!(names.contains(&"dutis_recommend"));
         assert!(names.contains(&"dutis_drift"));
+        assert!(names.contains(&"dutis_handler_get"));
         assert!(names.contains(&"dutis_policy_check"));
         assert!(names.contains(&"dutis_audit"));
         assert!(!names.contains(&"dutis_apply"));
@@ -1051,6 +1124,38 @@ mod tests {
             "in_sync"
         );
         assert_eq!(outcome.audit.unwrap().access, "read");
+    }
+
+    #[test]
+    fn typed_handler_get_validates_kind_identifier_and_role() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let outcome = server.handle(request(
+            8,
+            "tools/call",
+            json!({
+                "name": "dutis_handler_get",
+                "arguments": {"kind": "uti", "identifier": "public.html", "role": "viewer"}
+            }),
+        ));
+        let response = outcome.response.unwrap();
+        assert_eq!(
+            response["result"]["structuredContent"]["data"]["association"]["kind"],
+            "uti"
+        );
+        assert_eq!(outcome.audit.unwrap().access, "read");
+
+        let invalid = server.handle(request(
+            9,
+            "tools/call",
+            json!({
+                "name": "dutis_handler_get",
+                "arguments": {"kind": "url_scheme", "identifier": "https", "role": "viewer"}
+            }),
+        ));
+        assert_eq!(
+            invalid.response.unwrap()["result"]["structuredContent"]["error"]["kind"],
+            "invalid_arguments"
+        );
     }
 
     #[test]

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -1,4 +1,5 @@
 use crate::application::{resolve_app, Application};
+use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use crate::config::DutisConfig;
 use crate::system::DefaultApplication;
 use anyhow::Result;
@@ -6,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 
-pub const PLAN_SCHEMA_VERSION: u32 = 1;
+pub const PLAN_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -35,6 +36,11 @@ impl PlannedApplication {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PlanEntry {
+    #[serde(default)]
+    pub kind: AssociationKind,
+    #[serde(default)]
+    pub role: HandlerRole,
+    /// Normalized identifier. The legacy field name preserves JSON compatibility.
     pub extension: String,
     pub selector: String,
     pub current: Option<DefaultApplication>,
@@ -42,6 +48,16 @@ pub struct PlanEntry {
     pub action: PlanAction,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+}
+
+impl PlanEntry {
+    pub fn association(&self) -> AssociationTarget {
+        AssociationTarget {
+            kind: self.kind,
+            identifier: self.extension.clone(),
+            role: self.role,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -77,6 +93,10 @@ pub enum ApplyStatus {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ApplyEntryResult {
+    #[serde(default)]
+    pub kind: AssociationKind,
+    #[serde(default)]
+    pub role: HandlerRole,
     pub extension: String,
     pub bundle_id: Option<String>,
     pub status: ApplyStatus,
@@ -99,19 +119,20 @@ pub fn build_plan<F>(
     mut query_default: F,
 ) -> Result<AssociationPlan>
 where
-    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+    F: FnMut(&AssociationTarget) -> Result<Option<DefaultApplication>>,
 {
-    let mut entries = Vec::with_capacity(config.associations.len());
-    for (extension, selector) in &config.associations {
+    let rules = config.rules()?;
+    let mut entries = Vec::with_capacity(rules.len());
+    for (association, selector) in rules {
         let matches = resolve_app(applications, selector);
         let entry = match matches.as_slice() {
             [] => unresolved_entry(
-                extension,
+                &association,
                 selector,
                 format!("no installed application matches '{selector}'"),
             ),
             [application] if application.bundle_id.is_none() => unresolved_entry(
-                extension,
+                &association,
                 selector,
                 format!(
                     "{} has no readable bundle identifier",
@@ -119,7 +140,7 @@ where
                 ),
             ),
             [application] => {
-                let current = query_default(extension)?;
+                let current = query_default(&association)?;
                 let action = if current.as_ref().map(|app| app.bundle_id.as_str())
                     == application.bundle_id.as_deref()
                 {
@@ -128,8 +149,10 @@ where
                     PlanAction::Change
                 };
                 PlanEntry {
-                    extension: extension.clone(),
-                    selector: selector.clone(),
+                    kind: association.kind,
+                    role: association.role,
+                    extension: association.identifier.clone(),
+                    selector: selector.to_owned(),
                     current,
                     target: PlannedApplication::from_application(application),
                     action,
@@ -137,7 +160,7 @@ where
                 }
             }
             matches => unresolved_entry(
-                extension,
+                &association,
                 selector,
                 format!(
                     "selector is ambiguous: {}",
@@ -169,18 +192,22 @@ pub fn assemble_plan(config_version: u32, entries: Vec<PlanEntry>) -> Result<Ass
 
 pub fn apply_plan<F>(plan: &AssociationPlan, mut apply: F) -> ApplyReport
 where
-    F: FnMut(&str, &str) -> Result<()>,
+    F: FnMut(&AssociationTarget, &str) -> Result<()>,
 {
     let mut results = Vec::with_capacity(plan.entries.len());
     for entry in &plan.entries {
         let result = match entry.action {
             PlanAction::Unchanged => ApplyEntryResult {
+                kind: entry.kind,
+                role: entry.role,
                 extension: entry.extension.clone(),
                 bundle_id: entry.target.as_ref().map(|target| target.bundle_id.clone()),
                 status: ApplyStatus::Skipped,
                 error: None,
             },
             PlanAction::Unresolved => ApplyEntryResult {
+                kind: entry.kind,
+                role: entry.role,
                 extension: entry.extension.clone(),
                 bundle_id: None,
                 status: ApplyStatus::Failed,
@@ -192,14 +219,18 @@ where
                     .as_ref()
                     .map(|target| target.bundle_id.as_str())
                     .expect("resolved plan entries have bundle IDs");
-                match apply(&entry.extension, bundle_id) {
+                match apply(&entry.association(), bundle_id) {
                     Ok(()) => ApplyEntryResult {
+                        kind: entry.kind,
+                        role: entry.role,
                         extension: entry.extension.clone(),
                         bundle_id: Some(bundle_id.to_owned()),
                         status: ApplyStatus::Applied,
                         error: None,
                     },
                     Err(error) => ApplyEntryResult {
+                        kind: entry.kind,
+                        role: entry.role,
                         extension: entry.extension.clone(),
                         bundle_id: Some(bundle_id.to_owned()),
                         status: ApplyStatus::Failed,
@@ -229,9 +260,11 @@ where
     }
 }
 
-fn unresolved_entry(extension: &str, selector: &str, reason: String) -> PlanEntry {
+fn unresolved_entry(association: &AssociationTarget, selector: &str, reason: String) -> PlanEntry {
     PlanEntry {
-        extension: extension.to_owned(),
+        kind: association.kind,
+        role: association.role,
+        extension: association.identifier.clone(),
         selector: selector.to_owned(),
         current: None,
         target: None,
@@ -267,6 +300,8 @@ struct DigestMaterial<'a> {
 
 #[derive(Serialize)]
 struct DigestEntry<'a> {
+    kind: AssociationKind,
+    role: HandlerRole,
     extension: &'a str,
     selector: &'a str,
     current_bundle_id: Option<&'a str>,
@@ -283,6 +318,8 @@ fn calculate_digest(config_version: u32, entries: &[PlanEntry]) -> Result<String
         entries: entries
             .iter()
             .map(|entry| DigestEntry {
+                kind: entry.kind,
+                role: entry.role,
                 extension: &entry.extension,
                 selector: &entry.selector,
                 current_bundle_id: entry.current.as_ref().map(|app| app.bundle_id.as_str()),
@@ -304,6 +341,7 @@ fn calculate_digest(config_version: u32, entries: &[PlanEntry]) -> Result<String
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::AssociationRule;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
@@ -323,11 +361,14 @@ mod tests {
                 .iter()
                 .map(|(extension, selector)| ((*extension).to_owned(), (*selector).to_owned()))
                 .collect::<BTreeMap<_, _>>(),
+            handlers: Vec::new(),
         }
     }
 
     fn current(extension: &str, bundle_id: &str) -> DefaultApplication {
         DefaultApplication {
+            kind: AssociationKind::Extension,
+            role: HandlerRole::All,
             extension: extension.to_owned(),
             name: None,
             path: None,
@@ -340,11 +381,11 @@ mod tests {
         let applications = vec![app("Editor", "com.example.Editor")];
         let config = config(&[("json", "Editor"), ("md", "com.example.Editor")]);
         let build = || {
-            build_plan(&config, &applications, |extension| {
-                Ok(Some(if extension == "md" {
-                    current(extension, "com.example.Editor")
+            build_plan(&config, &applications, |association| {
+                Ok(Some(if association.identifier == "md" {
+                    current(&association.identifier, "com.example.Editor")
                 } else {
-                    current(extension, "com.example.Other")
+                    current(&association.identifier, "com.example.Other")
                 }))
             })
             .unwrap()
@@ -365,8 +406,8 @@ mod tests {
         let applications = vec![app("Editor", "com.example.Editor")];
         let config = config(&[("md", "Editor")]);
         let missing = build_plan(&config, &applications, |_| Ok(None)).unwrap();
-        let converged = build_plan(&config, &applications, |extension| {
-            Ok(Some(current(extension, "com.example.Editor")))
+        let converged = build_plan(&config, &applications, |association| {
+            Ok(Some(current(&association.identifier, "com.example.Editor")))
         })
         .unwrap();
         assert_ne!(missing.digest, converged.digest);
@@ -392,8 +433,8 @@ mod tests {
         let applications = vec![app("Editor", "com.example.Editor")];
         let config = config(&[("json", "Editor"), ("md", "Editor")]);
         let plan = build_plan(&config, &applications, |_| Ok(None)).unwrap();
-        let report = apply_plan(&plan, |extension, _| {
-            if extension == "json" {
+        let report = apply_plan(&plan, |association, _| {
+            if association.identifier == "json" {
                 anyhow::bail!("simulated failure");
             }
             Ok(())
@@ -407,13 +448,47 @@ mod tests {
     fn converged_apply_is_idempotent() {
         let applications = vec![app("Editor", "com.example.Editor")];
         let config = config(&[("md", "Editor")]);
-        let plan = build_plan(&config, &applications, |extension| {
-            Ok(Some(current(extension, "com.example.Editor")))
+        let plan = build_plan(&config, &applications, |association| {
+            Ok(Some(current(&association.identifier, "com.example.Editor")))
         })
         .unwrap();
         let report = apply_plan(&plan, |_, _| panic!("unchanged entry was applied"));
         assert_eq!(report.applied, 0);
         assert_eq!(report.skipped, 1);
         assert_eq!(report.failed, 0);
+    }
+
+    #[test]
+    fn builds_one_deterministic_plan_across_association_kinds_and_roles() {
+        let applications = vec![app("Editor", "com.example.Editor")];
+        let config = DutisConfig {
+            version: 2,
+            associations: BTreeMap::new(),
+            handlers: vec![
+                AssociationRule {
+                    kind: AssociationKind::UrlScheme,
+                    identifier: "https".to_owned(),
+                    role: HandlerRole::All,
+                    application: "com.example.Editor".to_owned(),
+                },
+                AssociationRule {
+                    kind: AssociationKind::Uti,
+                    identifier: "public.html".to_owned(),
+                    role: HandlerRole::Viewer,
+                    application: "com.example.Editor".to_owned(),
+                },
+            ],
+        };
+        let plan = build_plan(&config, &applications, |_| Ok(None)).unwrap();
+        assert_eq!(plan.schema_version, 2);
+        assert_eq!(plan.entries[0].kind, AssociationKind::Uti);
+        assert_eq!(plan.entries[0].role, HandlerRole::Viewer);
+        assert_eq!(plan.entries[1].kind, AssociationKind::UrlScheme);
+        assert_eq!(plan.summary.changes, 2);
+
+        let mut editor_config = config;
+        editor_config.handlers[1].role = HandlerRole::Editor;
+        let editor_plan = build_plan(&editor_config, &applications, |_| Ok(None)).unwrap();
+        assert_ne!(plan.digest, editor_plan.digest);
     }
 }

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,4 +1,5 @@
 use crate::application::Application;
+use crate::association::{AssociationKind, HandlerRole};
 use crate::config::{DutisConfig, CONFIG_VERSION};
 use crate::planner::{assemble_plan, AssociationPlan, PlanAction, PlanEntry, PlannedApplication};
 use crate::system::DefaultApplication;
@@ -183,6 +184,8 @@ where
                 selected.bundle_id.to_owned(),
             );
             plan_entries.push(PlanEntry {
+                kind: AssociationKind::Extension,
+                role: HandlerRole::All,
                 extension: association.extension.to_owned(),
                 selector: selected.bundle_id.to_owned(),
                 current: current.clone(),
@@ -219,6 +222,7 @@ where
     let proposed_config = DutisConfig {
         version: CONFIG_VERSION,
         associations: proposed_associations,
+        handlers: Vec::new(),
     };
     let proposed_toml = toml::to_string_pretty(&proposed_config)?;
     let plan = assemble_plan(CONFIG_VERSION, plan_entries)?;
@@ -495,6 +499,8 @@ mod tests {
         ];
         let recommendation = recommend_profile(&profile, &applications, |extension| {
             Ok(Some(DefaultApplication {
+                kind: AssociationKind::Extension,
+                role: HandlerRole::All,
                 extension: extension.to_owned(),
                 name: Some("Current".to_owned()),
                 path: Some("/Applications/Current.app".to_owned()),

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,4 +1,5 @@
 use crate::application::{normalize_extension, resolve_app, Application};
+use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use crate::planner::{
     apply_plan, assemble_plan, ApplyReport, AssociationPlan, PlanAction, PlanEntry,
     PlannedApplication,
@@ -27,6 +28,11 @@ pub enum SnapshotReason {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SnapshotAssociation {
+    #[serde(default)]
+    pub kind: AssociationKind,
+    #[serde(default)]
+    pub role: HandlerRole,
+    /// Normalized identifier. The legacy field name preserves snapshot compatibility.
     pub extension: String,
     pub default: Option<DefaultApplication>,
 }
@@ -213,7 +219,32 @@ where
         .into_iter()
         .map(|extension| {
             let default = query(&extension)?;
-            Ok(SnapshotAssociation { extension, default })
+            Ok(SnapshotAssociation {
+                kind: AssociationKind::Extension,
+                role: HandlerRole::All,
+                extension,
+                default,
+            })
+        })
+        .collect()
+}
+
+pub fn capture_targets<F, I>(targets: I, mut query: F) -> Result<Vec<SnapshotAssociation>>
+where
+    I: IntoIterator<Item = AssociationTarget>,
+    F: FnMut(&AssociationTarget) -> Result<Option<DefaultApplication>>,
+{
+    let normalized = targets.into_iter().collect::<BTreeSet<_>>();
+    normalized
+        .into_iter()
+        .map(|target| {
+            let default = query(&target)?;
+            Ok(SnapshotAssociation {
+                kind: target.kind,
+                role: target.role,
+                extension: target.identifier,
+                default,
+            })
         })
         .collect()
 }
@@ -222,6 +253,8 @@ pub fn associations_from_plan(plan: &AssociationPlan) -> Vec<SnapshotAssociation
     plan.entries
         .iter()
         .map(|entry| SnapshotAssociation {
+            kind: entry.kind,
+            role: entry.role,
             extension: entry.extension.clone(),
             default: entry.current.clone(),
         })
@@ -235,7 +268,7 @@ pub fn apply_plan_with_snapshot<F>(
     apply: F,
 ) -> Result<ProtectedApply>
 where
-    F: FnMut(&str, &str) -> Result<()>,
+    F: FnMut(&AssociationTarget, &str) -> Result<()>,
 {
     let safety_snapshot = if plan.summary.changes > 0 {
         Some(store.create(
@@ -259,14 +292,18 @@ pub fn build_rollback_plan<F>(
     mut query_default: F,
 ) -> Result<AssociationPlan>
 where
-    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+    F: FnMut(&AssociationTarget) -> Result<Option<DefaultApplication>>,
 {
     validate_snapshot(snapshot, None)?;
     let mut entries = Vec::with_capacity(snapshot.associations.len());
     for association in &snapshot.associations {
-        let current = query_default(&association.extension)?;
+        let target =
+            AssociationTarget::new(association.kind, &association.extension, association.role)?;
+        let current = query_default(&target)?;
         let entry = match &association.default {
             None if current.is_none() => PlanEntry {
+                kind: association.kind,
+                role: association.role,
                 extension: association.extension.clone(),
                 selector: "<no default>".to_owned(),
                 current,
@@ -275,6 +312,8 @@ where
                 reason: None,
             },
             None => PlanEntry {
+                kind: association.kind,
+                role: association.role,
                 extension: association.extension.clone(),
                 selector: "<no default>".to_owned(),
                 current,
@@ -297,6 +336,8 @@ where
                             PlanAction::Change
                         };
                         PlanEntry {
+                            kind: association.kind,
+                            role: association.role,
                             extension: association.extension.clone(),
                             selector: previous.bundle_id.clone(),
                             current,
@@ -306,6 +347,8 @@ where
                         }
                     }
                     [] => PlanEntry {
+                        kind: association.kind,
+                        role: association.role,
                         extension: association.extension.clone(),
                         selector: previous.bundle_id.clone(),
                         current,
@@ -317,6 +360,8 @@ where
                         )),
                     },
                     matches => PlanEntry {
+                        kind: association.kind,
+                        role: association.role,
                         extension: association.extension.clone(),
                         selector: previous.bundle_id.clone(),
                         current,
@@ -345,8 +390,12 @@ fn normalize_associations(
     let mut normalized = associations
         .into_iter()
         .map(|association| {
+            let target =
+                AssociationTarget::new(association.kind, &association.extension, association.role)?;
             Ok(SnapshotAssociation {
-                extension: normalize_extension(&association.extension)?,
+                kind: target.kind,
+                role: target.role,
+                extension: target.identifier,
                 default: association.default,
             })
         })
@@ -405,6 +454,8 @@ mod tests {
 
     fn default(extension: &str, bundle_id: &str) -> DefaultApplication {
         DefaultApplication {
+            kind: AssociationKind::Extension,
+            role: HandlerRole::All,
             extension: extension.to_owned(),
             name: None,
             path: None,
@@ -429,6 +480,8 @@ mod tests {
                 SnapshotReason::Manual,
                 None,
                 vec![SnapshotAssociation {
+                    kind: AssociationKind::Extension,
+                    role: HandlerRole::All,
                     extension: ".MD".to_owned(),
                     default: Some(default("md", "com.example.Editor")),
                 }],
@@ -473,6 +526,41 @@ mod tests {
     }
 
     #[test]
+    fn captures_and_restores_typed_targets_with_roles() {
+        let target =
+            AssociationTarget::new(AssociationKind::Uti, "public.html", HandlerRole::Viewer)
+                .unwrap();
+        let associations = capture_targets([target.clone()], |value| {
+            Ok(Some(DefaultApplication {
+                kind: value.kind,
+                role: value.role,
+                extension: value.identifier.clone(),
+                name: None,
+                path: None,
+                bundle_id: "com.example.Editor".to_owned(),
+            }))
+        })
+        .unwrap();
+        assert_eq!(associations[0].kind, AssociationKind::Uti);
+        assert_eq!(associations[0].role, HandlerRole::Viewer);
+
+        let snapshot = Snapshot {
+            schema_version: SNAPSHOT_SCHEMA_VERSION,
+            id: "typed-snapshot".to_owned(),
+            created_at: "2026-08-22T00:00:00Z".to_owned(),
+            reason: SnapshotReason::Manual,
+            source_plan_digest: None,
+            associations,
+        };
+        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |_| {
+            Ok(None)
+        })
+        .unwrap();
+        assert_eq!(plan.entries[0].kind, AssociationKind::Uti);
+        assert_eq!(plan.entries[0].role, HandlerRole::Viewer);
+    }
+
+    #[test]
     fn builds_verified_rollback_plan() {
         let store = temporary_store();
         let snapshot = store
@@ -480,13 +568,15 @@ mod tests {
                 SnapshotReason::BeforeApply,
                 Some("source-plan".to_owned()),
                 vec![SnapshotAssociation {
+                    kind: AssociationKind::Extension,
+                    role: HandlerRole::All,
                     extension: "md".to_owned(),
                     default: Some(default("md", "com.example.Editor")),
                 }],
             )
             .unwrap();
-        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |ext| {
-            Ok(Some(default(ext, "com.example.Other")))
+        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |target| {
+            Ok(Some(default(&target.identifier, "com.example.Other")))
         })
         .unwrap();
         assert_eq!(plan.summary.changes, 1);
@@ -502,13 +592,15 @@ mod tests {
                 SnapshotReason::Manual,
                 None,
                 vec![SnapshotAssociation {
+                    kind: AssociationKind::Extension,
+                    role: HandlerRole::All,
                     extension: "md".to_owned(),
                     default: None,
                 }],
             )
             .unwrap();
-        let plan = build_rollback_plan(&snapshot, &[], |ext| {
-            Ok(Some(default(ext, "com.example.Current")))
+        let plan = build_rollback_plan(&snapshot, &[], |target| {
+            Ok(Some(default(&target.identifier, "com.example.Current")))
         })
         .unwrap();
         assert_eq!(plan.summary.unresolved, 1);
@@ -524,13 +616,15 @@ mod tests {
                 SnapshotReason::Manual,
                 None,
                 vec![SnapshotAssociation {
+                    kind: AssociationKind::Extension,
+                    role: HandlerRole::All,
                     extension: "md".to_owned(),
                     default: Some(default("md", "com.example.Editor")),
                 }],
             )
             .unwrap();
-        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |ext| {
-            Ok(Some(default(ext, "com.example.Other")))
+        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |target| {
+            Ok(Some(default(&target.identifier, "com.example.Other")))
         })
         .unwrap();
         let protected =
@@ -562,12 +656,14 @@ mod tests {
             reason: SnapshotReason::Manual,
             source_plan_digest: None,
             associations: vec![SnapshotAssociation {
+                kind: AssociationKind::Extension,
+                role: HandlerRole::All,
                 extension: "md".to_owned(),
                 default: Some(default("md", "com.example.Editor")),
             }],
         };
-        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |ext| {
-            Ok(Some(default(ext, "com.example.Other")))
+        let plan = build_rollback_plan(&snapshot, &[application("com.example.Editor")], |target| {
+            Ok(Some(default(&target.identifier, "com.example.Other")))
         })
         .unwrap();
         let result =

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,3 +1,4 @@
+use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::io;
@@ -5,6 +6,11 @@ use std::process::Command;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DefaultApplication {
+    #[serde(default)]
+    pub kind: AssociationKind,
+    #[serde(default)]
+    pub role: HandlerRole,
+    /// Normalized identifier. The legacy field name preserves JSON compatibility.
     pub extension: String,
     pub name: Option<String>,
     pub path: Option<String>,
@@ -35,33 +41,81 @@ pub fn duti_version() -> Result<String> {
 }
 
 pub fn get_default_app(extension: &str) -> Result<Option<DefaultApplication>> {
+    let association = AssociationTarget::extension(extension)?;
+    get_default_handler(&association)
+}
+
+pub fn get_default_handler(association: &AssociationTarget) -> Result<Option<DefaultApplication>> {
     duti_version()?;
-    query_default_app(extension)
+    query_default_handler(association)
 }
 
 pub fn query_default_app(extension: &str) -> Result<Option<DefaultApplication>> {
-    let output = Command::new("duti")
-        .args(["-x", extension])
+    let association = AssociationTarget::extension(extension)?;
+    query_default_handler(&association)
+}
+
+pub fn query_default_handler(
+    association: &AssociationTarget,
+) -> Result<Option<DefaultApplication>> {
+    let mut command = Command::new("duti");
+    match association.kind {
+        AssociationKind::Extension => {
+            command.args(["-x", &association.identifier]);
+        }
+        AssociationKind::Uti | AssociationKind::Mime | AssociationKind::UrlScheme => {
+            command.args(["-d", &association.identifier]);
+        }
+    }
+    let output = command
         .output()
         .context("failed to query the default application")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("Failed to get default application") {
+        if stderr.to_ascii_lowercase().contains("no default handler")
+            || stderr.contains("Failed to get default application")
+        {
             return Ok(None);
         }
-        bail!("duti could not query .{extension}: {}", stderr.trim());
+        bail!("duti could not query {association}: {}", stderr.trim());
     }
-
-    parse_default_app(extension, &String::from_utf8_lossy(&output.stdout)).map(Some)
+    if association.kind == AssociationKind::Extension {
+        parse_default_app(
+            &association.identifier,
+            &String::from_utf8_lossy(&output.stdout),
+        )
+        .map(|mut default| {
+            default.kind = association.kind;
+            default.role = association.role;
+            Some(default)
+        })
+    } else {
+        let bundle_id = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        if bundle_id.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(DefaultApplication {
+            kind: association.kind,
+            role: association.role,
+            extension: association.identifier.clone(),
+            name: None,
+            path: None,
+            bundle_id,
+        }))
+    }
 }
 
 pub fn set_default_app(extension: &str, bundle_id: &str) -> Result<()> {
+    let association = AssociationTarget::extension(extension)?;
+    set_default_handler(&association, bundle_id)
+}
+
+pub fn set_default_handler(association: &AssociationTarget, bundle_id: &str) -> Result<()> {
     duti_version()?;
-    let extension_argument = format!(".{extension}");
-    let output = Command::new("duti")
-        .args(["-s", bundle_id, &extension_argument, "all"])
-        .output()
-        .context("failed to run duti")?;
+    let arguments = duti_set_arguments(association, bundle_id);
+    let mut command = Command::new("duti");
+    command.args(&arguments);
+    let output = command.output().context("failed to run duti")?;
     if !output.status.success() {
         bail!(
             "duti could not apply the setting: {}",
@@ -69,8 +123,8 @@ pub fn set_default_app(extension: &str, bundle_id: &str) -> Result<()> {
         );
     }
 
-    let actual = query_default_app(extension)?
-        .ok_or_else(|| anyhow!("verification found no default application for .{extension}"))?;
+    let actual = query_default_handler(association)?
+        .ok_or_else(|| anyhow!("verification found no default application for {association}"))?;
     if actual.bundle_id != bundle_id {
         bail!(
             "verification returned bundle ID '{}' instead of '{}'",
@@ -79,6 +133,18 @@ pub fn set_default_app(extension: &str, bundle_id: &str) -> Result<()> {
         );
     }
     Ok(())
+}
+
+pub fn duti_set_arguments(association: &AssociationTarget, bundle_id: &str) -> Vec<String> {
+    let mut arguments = vec![
+        "-s".to_owned(),
+        bundle_id.to_owned(),
+        association.duti_identifier(),
+    ];
+    if association.kind != AssociationKind::UrlScheme {
+        arguments.push(association.role.as_duti_argument().to_owned());
+    }
+    arguments
 }
 
 fn parse_default_app(extension: &str, output: &str) -> Result<DefaultApplication> {
@@ -92,6 +158,8 @@ fn parse_default_app(extension: &str, output: &str) -> Result<DefaultApplication
     };
 
     Ok(DefaultApplication {
+        kind: AssociationKind::Extension,
+        role: HandlerRole::All,
         extension: extension.to_owned(),
         name: lines.first().map(|value| (*value).to_owned()),
         path: lines.get(1).map(|value| (*value).to_owned()),
@@ -122,5 +190,26 @@ mod tests {
     #[test]
     fn rejects_empty_duti_query_output() {
         assert!(parse_default_app("unknown", "\n").is_err());
+    }
+
+    #[test]
+    fn builds_kind_and_role_aware_set_arguments() {
+        let extension = AssociationTarget::extension("md").unwrap();
+        assert_eq!(
+            duti_set_arguments(&extension, "com.example.Editor"),
+            ["-s", "com.example.Editor", ".md", "all"]
+        );
+        let uti = AssociationTarget::new(AssociationKind::Uti, "public.html", HandlerRole::Viewer)
+            .unwrap();
+        assert_eq!(
+            duti_set_arguments(&uti, "com.example.Browser"),
+            ["-s", "com.example.Browser", "public.html", "viewer"]
+        );
+        let scheme =
+            AssociationTarget::new(AssociationKind::UrlScheme, "https", HandlerRole::All).unwrap();
+        assert_eq!(
+            duti_set_arguments(&scheme, "com.example.Browser"),
+            ["-s", "com.example.Browser", "https"]
+        );
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -138,6 +138,210 @@ fn unknown_profile_has_stable_json_error() {
     assert_eq!(response["error"]["kind"], "not_found");
 }
 
+#[cfg(unix)]
+#[test]
+fn typed_handler_get_uses_duti_default_handler_query() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root =
+        std::env::temp_dir().join(format!("dutis-handler-get-{}-{unique}", std::process::id()));
+    let bin = root.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let duti = bin.join("duti");
+    fs::write(
+        &duti,
+        concat!(
+            "#!/bin/sh\n",
+            "printf '%s\\n' \"$*\" >> \"$DUTI_CALL_LOG\"\n",
+            "if [ \"$1\" = \"-V\" ]; then printf 'test-duti\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-d\" ]; then printf 'com.example.Browser\\n'; exit 0; fi\n",
+            "exit 99\n",
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&duti, fs::Permissions::from_mode(0o700)).unwrap();
+    let calls = root.join("duti-calls.log");
+    let output = dutis()
+        .env("PATH", &bin)
+        .env("DUTI_CALL_LOG", &calls)
+        .args([
+            "handler",
+            "get",
+            "uti",
+            "Public.HTML",
+            "--role",
+            "viewer",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["data"]["kind"], "uti");
+    assert_eq!(response["data"]["role"], "viewer");
+    assert_eq!(response["data"]["extension"], "public.html");
+    assert_eq!(response["data"]["bundle_id"], "com.example.Browser");
+    let calls = fs::read_to_string(&calls).unwrap();
+    assert_eq!(calls.lines().collect::<Vec<_>>(), ["-V", "-d public.html"]);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn url_scheme_rejects_document_roles_before_querying_duti() {
+    let output = dutis()
+        .args([
+            "handler",
+            "get",
+            "url-scheme",
+            "https",
+            "--role",
+            "viewer",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["error"]["kind"], "usage");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn typed_config_dry_run_and_apply_cover_every_duti_argument_shape() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root =
+        std::env::temp_dir().join(format!("dutis-typed-apply-{}-{unique}", std::process::id()));
+    let bin = root.join("bin");
+    fs::create_dir_all(&bin).unwrap();
+    let duti = bin.join("duti");
+    fs::write(
+        &duti,
+        concat!(
+            "#!/bin/sh\n",
+            "printf '%s\\n' \"$*\" >> \"$DUTI_CALL_LOG\"\n",
+            "if [ \"$1\" = \"-V\" ]; then printf 'test-duti\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-s\" ]; then : > \"$DUTI_FAKE_STATE\"; exit 0; fi\n",
+            "if [ \"$1\" = \"-x\" ] && [ -f \"$DUTI_FAKE_STATE\" ]; then printf 'TextEdit\\n/System/Applications/TextEdit.app\\ncom.apple.TextEdit\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-x\" ]; then printf 'Other\\n/Applications/Other.app\\ncom.example.Other\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-d\" ] && [ -f \"$DUTI_FAKE_STATE\" ]; then printf 'com.apple.TextEdit\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-d\" ]; then printf 'com.example.Other\\n'; exit 0; fi\n",
+            "exit 99\n",
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&duti, fs::Permissions::from_mode(0o700)).unwrap();
+    let config = root.join("dutis.toml");
+    fs::write(
+        &config,
+        concat!(
+            "version = 2\n",
+            "[associations]\n",
+            "md = 'com.apple.TextEdit'\n",
+            "[[handlers]]\n",
+            "kind = 'uti'\n",
+            "identifier = 'public.plain-text'\n",
+            "role = 'viewer'\n",
+            "application = 'com.apple.TextEdit'\n",
+            "[[handlers]]\n",
+            "kind = 'mime'\n",
+            "identifier = 'text/plain'\n",
+            "role = 'editor'\n",
+            "application = 'com.apple.TextEdit'\n",
+            "[[handlers]]\n",
+            "kind = 'url_scheme'\n",
+            "identifier = 'https'\n",
+            "application = 'com.apple.TextEdit'\n",
+        ),
+    )
+    .unwrap();
+    let calls = root.join("duti-calls.log");
+    let fake_state = root.join("applied");
+    let state = root.join("state");
+    let configure = |command: &mut Command| {
+        command
+            .env("PATH", &bin)
+            .env("DUTI_CALL_LOG", &calls)
+            .env("DUTI_FAKE_STATE", &fake_state)
+            .env("DUTIS_STATE_DIR", &state);
+    };
+
+    let mut plan_command = dutis();
+    configure(&mut plan_command);
+    let plan_output = plan_command
+        .args(["plan", config.to_str().unwrap(), "--json"])
+        .output()
+        .unwrap();
+    assert!(plan_output.status.success());
+    let plan: Value = serde_json::from_slice(&plan_output.stdout).unwrap();
+    assert_eq!(plan["data"]["schema_version"], 2);
+    assert_eq!(plan["data"]["summary"]["changes"], 4);
+    let digest = plan["data"]["digest"].as_str().unwrap();
+
+    fs::write(&calls, "").unwrap();
+    let mut dry_run_command = dutis();
+    configure(&mut dry_run_command);
+    let dry_run = dry_run_command
+        .args(["apply", config.to_str().unwrap(), "--dry-run", "--json"])
+        .output()
+        .unwrap();
+    assert!(dry_run.status.success());
+    assert!(!fs::read_to_string(&calls)
+        .unwrap()
+        .lines()
+        .any(|line| line.starts_with("-s ")));
+
+    fs::write(&calls, "").unwrap();
+    let mut apply_command = dutis();
+    configure(&mut apply_command);
+    let apply = apply_command
+        .args([
+            "apply",
+            config.to_str().unwrap(),
+            "--plan-digest",
+            digest,
+            "--requester",
+            "integration-test",
+            "--yes",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        apply.status.success(),
+        "{}",
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let response: Value = serde_json::from_slice(&apply.stdout).unwrap();
+    assert_eq!(response["data"]["applied"], 4);
+    assert!(response["data"]["safety_snapshot_id"].is_string());
+    assert!(response["data"]["audit_id"].is_string());
+    let calls = fs::read_to_string(&calls).unwrap();
+    assert!(calls
+        .lines()
+        .any(|line| line == "-s com.apple.TextEdit .md all"));
+    assert!(calls
+        .lines()
+        .any(|line| line == "-s com.apple.TextEdit public.plain-text viewer"));
+    assert!(calls
+        .lines()
+        .any(|line| line == "-s com.apple.TextEdit text/plain editor"));
+    assert!(calls
+        .lines()
+        .any(|line| line == "-s com.apple.TextEdit https"));
+    assert_eq!(fs::read_dir(state.join("snapshots")).unwrap().count(), 1);
+    assert_eq!(fs::read_dir(state.join("audit")).unwrap().count(), 1);
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[test]
 fn watch_remediation_requires_explicit_approval_before_reading_config() {
     let output = dutis()


### PR DESCRIPTION
## Summary

- add normalized extension, UTI, MIME type, URL scheme, and Launch Services role targets
- extend config v2, planning, policy, snapshots, rollback, drift, CLI, and MCP while preserving config v1 compatibility
- add typed handler CLI/MCP reads and verified governed writes
- update roadmap, examples, skill, and user documentation for v2.12.0

## Validation

- cargo fmt --all -- --check
- cargo check --all-targets --locked
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --all-targets --locked (91 passed)
- cargo build --release --locked
- cargo package --allow-dirty --locked --offline
- git diff --check
- fake-duti end-to-end test covers dry-run, four target kinds, viewer/editor roles, snapshot, audit, mutation arguments, and verification
- real duti smoke test was read-only; no system associations were changed