### PR TITLE
feat: add drift and mutation event sinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.12.0"
+version = "2.13.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 - 💡 **Explainable Profiles**: Generate evidence-backed developer, designer, media, or minimal proposals without changing the system
 - 👀 **Drift Monitoring**: Detect association changes continuously, notify through macOS, and optionally remediate through snapshots and policy
 - 🔗 **Typed Associations**: Manage extensions, UTIs, MIME types, URL schemes, and Launch Services roles through one verified pipeline
+- 📡 **Event Sinks**: Stream versioned drift and mutation lifecycle events to private JSONL logs or trusted local commands
 
 ## Installation
 
@@ -194,6 +195,20 @@ Monitoring is read-only by default. Automatic remediation requires
 audit, safety snapshot, apply, and verification. See
 [drift detection](docs/drift-detection.md).
 
+Send drift and mutation lifecycle events to automation without parsing human
+output:
+
+```bash
+dutis --event-log ./dutis-events.jsonl watch dutis.toml --once --json
+dutis --event-command /absolute/path/to/event-handler apply dutis.toml \
+  --plan-digest <reviewed-digest> --requester codex --yes
+```
+
+Event options are global and can appear before or after a subcommand. The same
+settings can be provided through `DUTIS_EVENT_LOG` and
+`DUTIS_EVENT_COMMAND`. See [event sinks](docs/event-sinks.md) for the schema,
+command contract, LaunchAgent behavior, and delivery guarantees.
+
 All write paths enforce the same local policy before mutation and record the
 requester, reviewed plan, result, and verification. See the
 [policy and audit guide](docs/policy-and-audit.md). A reusable agent workflow is
@@ -208,7 +223,7 @@ Declarative apply also uses `7` for a stale plan and `8` for partial failure.
 Policy denial uses exit code `9`.
 
 The product and engineering sequence for declarative configuration, rollback,
-MCP, agent policies, profiles, and drift detection is documented in the
+MCP, agent policies, profiles, drift detection, and event delivery is documented in the
 [Agent Roadmap](docs/agent-roadmap.md).
 
 ## How It Works

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -177,10 +177,31 @@ Acceptance criteria:
 - Unit and fake-`duti` integration tests cover normalization, planning, dry-run,
   mutation arguments, snapshotting, auditing, and verification.
 
+## Phase 9: Event sinks
+
+Status: implemented for v2.13.0
+
+Expose versioned drift and mutation lifecycle events without requiring
+automation to scrape terminal output or audit directories.
+
+Acceptance criteria:
+
+- Global CLI options and environment variables configure private JSONL and
+  trusted local-command sinks.
+- Every drift check emits a `drift.checked` event; governed mutations emit
+  pending, denied, failed, and completed lifecycle events after the
+  corresponding durable audit update.
+- Event commands receive exactly one JSON object on stdin, with stdout
+  discarded so CLI and MCP protocol output cannot be corrupted.
+- Sink delivery is best effort and cannot bypass policy, suppress audit
+  storage, or change the result of a completed mutation.
+- LaunchAgent installation preserves normalized sink paths without persisting
+  approval tokens.
+
 ## Near-term engineering sequence
 
-1. Release Phase 8 and validate typed association read-back on supported macOS
-   releases and both CPU architectures.
-2. Add richer event sinks for drift and mutation events.
-3. Extend application metadata discovery beyond filename extensions where
+1. Release Phase 9 and validate long-running event delivery and log rotation.
+2. Extend application metadata discovery beyond filename extensions where
    Launch Services exposes reliable declarations.
+3. Add optional network adapters as external event commands, keeping transport
+   credentials outside Dutis configuration and audit records.

--- a/docs/drift-detection.md
+++ b/docs/drift-detection.md
@@ -31,6 +31,17 @@ During one watcher session, macOS notifications are deduplicated. Dutis
 notifies when drift first appears, when its plan changes, or when associations
 return to the declared state. Every check is still written to stdout.
 
+Every check can also produce a versioned `drift.checked` event through a JSONL
+or command sink:
+
+```bash
+dutis --event-log ./events.jsonl watch dutis.toml --interval-seconds 60
+```
+
+Unlike desktop notifications, event sinks receive every check so external
+automation can use them as both state changes and monitoring heartbeats. See
+[event sinks](event-sinks.md).
+
 ## Optional LaunchAgent
 
 Install a per-user background monitor:
@@ -50,6 +61,10 @@ watcher, and writes:
 ```
 
 If `DUTIS_STATE_DIR` is set while installing, logs and state use that directory.
+If `--event-log`, `--event-command`, `DUTIS_EVENT_LOG`, or
+`DUTIS_EVENT_COMMAND` is set while installing, the normalized sink paths are
+copied into the LaunchAgent environment. Reinstall the agent after changing a
+sink.
 The LaunchAgent plist is stored at:
 
 ```text

--- a/docs/event-sinks.md
+++ b/docs/event-sinks.md
@@ -1,0 +1,108 @@
+# Event sinks
+
+Dutis v2.13 can deliver versioned drift and mutation events to a private JSONL
+file, a trusted local executable, or both. This gives agents and automation a
+stable interface without scraping terminal output or watching audit folders.
+
+## Configure a sink
+
+The global flags can appear before or after any subcommand:
+
+```bash
+dutis --event-log ./events.jsonl watch dutis.toml --once
+dutis apply dutis.toml --dry-run --event-log ./events.jsonl
+dutis --event-command /absolute/path/to/handler watch dutis.toml --once
+```
+
+Equivalent environment variables are useful for MCP servers, scripts, and
+LaunchAgents:
+
+```bash
+export DUTIS_EVENT_LOG="$HOME/Library/Application Support/dutis/events.jsonl"
+export DUTIS_EVENT_COMMAND="/absolute/path/to/handler"
+```
+
+Relative paths are resolved against the current working directory at startup.
+An event command must resolve to an existing executable file. Dutis never runs
+it through a shell.
+
+## Event schema
+
+Each event is one compact JSON object:
+
+```json
+{
+  "schema_version": 1,
+  "id": "1787366400000000000-1234-0",
+  "emitted_at": "2026-08-22T00:00:00Z",
+  "event_type": "drift.checked",
+  "source": "watcher",
+  "payload": {}
+}
+```
+
+Supported event types are:
+
+| Event | Payload |
+| --- | --- |
+| `drift.checked` | The complete drift report, plan, and policy assessment |
+| `mutation.pending` | The durable pending mutation audit record |
+| `mutation.denied` | The durable denied audit record and policy violations |
+| `mutation.failed` | A pre-mutation failure record, such as a snapshot failure |
+| `mutation.completed` | The final audit record with result and verification |
+
+The `source` field is `watcher` for CLI/LaunchAgent checks, `mcp` for
+`dutis_drift`, and `governance` for mutation lifecycle events. Mutation
+payloads retain their more specific `channel` field.
+
+Mutation events are emitted only after Dutis attempts the corresponding durable
+audit update. Event payloads can contain local paths, bundle identifiers,
+requester identity, and complete plans. Approval tokens and token hashes are
+never included.
+
+## JSONL sink
+
+`--event-log` appends one event per line. Dutis creates a missing parent
+directory with owner-only permissions and keeps the event file at mode `0600`
+on Unix. Existing parent-directory permissions are not changed.
+
+Log rotation is managed externally. A safe rotation replaces or renames the
+file between Dutis invocations; a long-running watcher opens the file for each
+event, so it follows the new path on the next check.
+
+## Command sink
+
+For each event, Dutis starts the configured executable and:
+
+- writes exactly one JSON event followed by a newline to stdin;
+- sets `DUTIS_EVENT_ID` and `DUTIS_EVENT_TYPE` for routing;
+- discards stdout so JSON CLI and MCP protocol streams remain valid;
+- captures stderr and reports a concise warning when the command fails.
+
+Dutis removes its approval-token variables from the child environment before
+starting the handler. Other environment variables are inherited so the handler
+can use its own separately scoped credentials.
+
+The command runs synchronously. Keep handlers short and delegate slow delivery
+to a queue or background service. Store webhook credentials in the handler's
+own protected configuration rather than in Dutis arguments, policy, or event
+payloads.
+
+Example handler:
+
+```sh
+#!/bin/sh
+exec /usr/bin/logger -t dutis-event
+```
+
+## Failure behavior
+
+Event sinks are observability outputs, not part of authorization. A sink
+failure prints a warning to stderr and does not:
+
+- permit a policy-denied mutation;
+- bypass the mandatory audit or safety snapshot;
+- roll back or relabel an already completed mutation;
+- stop a continuous watcher from performing later checks.
+
+When both sinks are configured, Dutis attempts both even if one fails.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -124,3 +124,9 @@ Each tool call emits one JSON audit event to stderr:
 
 Audit events never include tool arguments or approval tokens. Snapshot storage
 continues to use `DUTIS_STATE_DIR` when set.
+
+Start the server with global `--event-log` or `--event-command` options, or set
+their `DUTIS_EVENT_LOG` / `DUTIS_EVENT_COMMAND` environment variables, to emit
+`dutis_drift` checks and governed mutation lifecycle events. Event-command
+stdout is discarded and cannot corrupt the JSON-RPC stream. See
+[event sinks](event-sinks.md).

--- a/docs/policy-and-audit.md
+++ b/docs/policy-and-audit.md
@@ -121,3 +121,9 @@ safety snapshot ID, per-entry result, and verification summary. Dutis atomically
 writes a `pending` record before a mutation. If policy denies the request, it
 writes a `denied` record and never invokes the system mutation. If audit storage
 cannot be prepared, the mutation is refused.
+
+Configured [event sinks](event-sinks.md) receive the persisted mutation
+lifecycle as `mutation.pending`, `mutation.denied`, `mutation.failed`, and
+`mutation.completed` events. Event delivery is downstream of the safety
+boundary: a sink failure is reported as a warning and cannot turn an audited
+successful mutation into a failure or authorize a denied mutation.

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -30,6 +30,12 @@ Use Dutis for macOS Launch Services associations. Preserve its
 7. Verify with `dutis get`, then use `dutis audit` when the user needs the full
    local record.
 
+When the user requests integration with another local tool, prefer the global
+`--event-log` or `--event-command` sink. Treat an event command as executable
+code: require a user-chosen trusted absolute path, and never generate or enable
+one implicitly. Events may contain application paths, bundle IDs, requester
+identity, and complete plans, but never approval tokens.
+
 For monitoring requests, use `dutis_drift` or `dutis watch <config> --once`
 first. Explain whether the report is `in_sync`, `drift_detected`, or
 `unresolved`. Do not enable `--remediate` or install a remediating LaunchAgent

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,10 +6,16 @@ use std::path::PathBuf;
 #[command(
     name = "dutis",
     version,
-    about = "Manage default macOS applications by file extension",
+    about = "Manage default macOS Launch Services handlers",
     after_help = "Run without a command to start interactive mode.\nMore information: https://github.com/tsonglew/dutis"
 )]
 pub struct Cli {
+    /// Append versioned drift and mutation events to this JSONL file
+    #[arg(long, global = true, value_name = "PATH")]
+    pub event_log: Option<PathBuf>,
+    /// Pipe each event as JSON to this executable command
+    #[arg(long, global = true, value_name = "PATH")]
+    pub event_command: Option<PathBuf>,
     #[command(subcommand)]
     pub command: Option<CliCommand>,
 }
@@ -136,7 +142,7 @@ pub enum SnapshotCommand {
 
 #[derive(Debug, Args)]
 pub struct SnapshotCreateArgs {
-    /// Limit the snapshot to extensions in this configuration
+    /// Limit the snapshot to association targets in this configuration
     #[arg(long)]
     pub config: Option<PathBuf>,
     /// Emit stable machine-readable JSON
@@ -397,6 +403,26 @@ mod tests {
                 ..
             }))
         ));
+    }
+
+    #[test]
+    fn parses_global_event_sinks_before_or_after_subcommands() {
+        let cli = Cli::try_parse_from([
+            "dutis",
+            "--event-log",
+            "events.jsonl",
+            "watch",
+            "dutis.toml",
+            "--once",
+            "--event-command",
+            "/usr/local/bin/event-sink",
+        ])
+        .unwrap();
+        assert_eq!(cli.event_log, Some(PathBuf::from("events.jsonl")));
+        assert_eq!(
+            cli.event_command,
+            Some(PathBuf::from("/usr/local/bin/event-sink"))
+        );
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,438 @@
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+pub const EVENT_SCHEMA_VERSION: u32 = 1;
+pub const EVENT_LOG_ENV: &str = "DUTIS_EVENT_LOG";
+pub const EVENT_COMMAND_ENV: &str = "DUTIS_EVENT_COMMAND";
+
+static EVENT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+pub enum EventType {
+    #[serde(rename = "drift.checked")]
+    DriftChecked,
+    #[serde(rename = "mutation.pending")]
+    MutationPending,
+    #[serde(rename = "mutation.denied")]
+    MutationDenied,
+    #[serde(rename = "mutation.failed")]
+    MutationFailed,
+    #[serde(rename = "mutation.completed")]
+    MutationCompleted,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventSource {
+    Watcher,
+    Mcp,
+    Governance,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EventEnvelope {
+    pub schema_version: u32,
+    pub id: String,
+    pub emitted_at: String,
+    pub event_type: EventType,
+    pub source: EventSource,
+    pub payload: Value,
+}
+
+impl EventEnvelope {
+    pub fn new<T: Serialize>(
+        event_type: EventType,
+        source: EventSource,
+        payload: &T,
+    ) -> Result<Self> {
+        let now = OffsetDateTime::now_utc();
+        let sequence = EVENT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        Ok(Self {
+            schema_version: EVENT_SCHEMA_VERSION,
+            id: format!(
+                "{}-{}-{sequence}",
+                now.unix_timestamp_nanos(),
+                std::process::id()
+            ),
+            emitted_at: now
+                .format(&Rfc3339)
+                .context("failed to format event timestamp")?,
+            event_type,
+            source,
+            payload: serde_json::to_value(payload).context("failed to serialize event payload")?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct EventDispatcher {
+    log: Option<PathBuf>,
+    command: Option<PathBuf>,
+}
+
+impl EventDispatcher {
+    pub fn from_environment() -> Result<Self> {
+        let log = std::env::var_os(EVENT_LOG_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from);
+        let command = std::env::var_os(EVENT_COMMAND_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from);
+        Self::new(log, command)
+    }
+
+    pub fn new(log: Option<PathBuf>, command: Option<PathBuf>) -> Result<Self> {
+        let log = log.map(absolute_path).transpose()?;
+        let command = command.map(absolute_path).transpose()?;
+        if let Some(command) = &command {
+            validate_command(command)?;
+        }
+        Ok(Self { log, command })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.log.is_some() || self.command.is_some()
+    }
+
+    pub fn log(&self) -> Option<&Path> {
+        self.log.as_deref()
+    }
+
+    pub fn command(&self) -> Option<&Path> {
+        self.command.as_deref()
+    }
+
+    pub fn emit<T: Serialize>(
+        &self,
+        event_type: EventType,
+        source: EventSource,
+        payload: &T,
+    ) -> Result<Option<EventEnvelope>> {
+        if !self.is_enabled() {
+            return Ok(None);
+        }
+        let event = EventEnvelope::new(event_type, source, payload)?;
+        let mut encoded = serde_json::to_vec(&event).context("failed to encode event")?;
+        encoded.push(b'\n');
+        let mut failures = Vec::new();
+        if let Some(path) = &self.log {
+            if let Err(error) = append_json_line(path, &encoded) {
+                failures.push(format!("JSONL sink {}: {error:#}", path.display()));
+            }
+        }
+        if let Some(command) = &self.command {
+            if let Err(error) = run_event_command(command, &event, &encoded) {
+                failures.push(format!("command sink {}: {error:#}", command.display()));
+            }
+        }
+        if failures.is_empty() {
+            Ok(Some(event))
+        } else {
+            bail!(failures.join("; "))
+        }
+    }
+}
+
+pub fn configure_process_sinks(
+    log_override: Option<&Path>,
+    command_override: Option<&Path>,
+) -> Result<EventDispatcher> {
+    if let Some(path) = log_override {
+        let path = absolute_path(path.to_path_buf())?;
+        std::env::set_var(EVENT_LOG_ENV, &path);
+    }
+    if let Some(path) = command_override {
+        let path = absolute_path(path.to_path_buf())?;
+        validate_command(&path)?;
+        std::env::set_var(EVENT_COMMAND_ENV, &path);
+    }
+    let dispatcher = EventDispatcher::from_environment()?;
+    if let Some(path) = dispatcher.log() {
+        std::env::set_var(EVENT_LOG_ENV, path);
+    }
+    if let Some(path) = dispatcher.command() {
+        std::env::set_var(EVENT_COMMAND_ENV, path);
+    }
+    Ok(dispatcher)
+}
+
+pub fn emit_best_effort<T: Serialize>(event_type: EventType, source: EventSource, payload: &T) {
+    let result = EventDispatcher::from_environment()
+        .and_then(|dispatcher| dispatcher.emit(event_type, source, payload).map(|_| ()));
+    if let Err(error) = result {
+        eprintln!("Warning: failed to deliver Dutis event: {error:#}");
+    }
+}
+
+fn absolute_path(path: PathBuf) -> Result<PathBuf> {
+    if path.as_os_str().is_empty() {
+        bail!("event sink path cannot be empty");
+    }
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(std::env::current_dir()
+            .context("failed to resolve the current directory")?
+            .join(path))
+    }
+}
+
+fn validate_command(path: &Path) -> Result<()> {
+    if !path.is_absolute() || !path.is_file() {
+        bail!(
+            "event command must be an existing absolute file: {}",
+            path.display()
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if fs::metadata(path)?.permissions().mode() & 0o111 == 0 {
+            bail!("event command is not executable: {}", path.display());
+        }
+    }
+    Ok(())
+}
+
+fn append_json_line(path: &Path, encoded: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        create_private_directories(parent)?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    file.write_all(encoded)
+        .with_context(|| format!("failed to append {}", path.display()))?;
+    file.flush()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+fn create_private_directories(path: &Path) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    let mut missing = Vec::new();
+    let mut current = Some(path);
+    while let Some(directory) = current {
+        if directory.exists() {
+            break;
+        }
+        missing.push(directory);
+        current = directory.parent();
+    }
+    fs::create_dir_all(path).with_context(|| format!("failed to create {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for directory in missing.into_iter().rev() {
+            fs::set_permissions(directory, fs::Permissions::from_mode(0o700))?;
+        }
+    }
+    Ok(())
+}
+
+fn run_event_command(command: &Path, event: &EventEnvelope, encoded: &[u8]) -> Result<()> {
+    let event_type = serde_json::to_value(event.event_type)?;
+    let event_type = event_type
+        .as_str()
+        .ok_or_else(|| anyhow!("event type did not serialize as a string"))?;
+    let mut process = Command::new(command);
+    process
+        .env("DUTIS_EVENT_ID", &event.id)
+        .env("DUTIS_EVENT_TYPE", event_type)
+        .env_remove("DUTIS_APPROVAL_TOKEN")
+        .env_remove("DUTIS_MCP_APPROVAL_TOKEN")
+        .env_remove("DUTIS_WATCH_APPROVAL_TOKEN")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    let mut child = process
+        .spawn()
+        .with_context(|| format!("failed to start {}", command.display()))?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("event command stdin is unavailable"))?
+        .write_all(encoded)?;
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim().chars().take(1024).collect::<String>();
+        bail!(
+            "event command exited with {}{}",
+            output.status,
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_root(label: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "dutis-events-{label}-{}-{unique}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn disabled_dispatcher_is_a_noop() {
+        let dispatcher = EventDispatcher::new(None, None).unwrap();
+        assert!(!dispatcher.is_enabled());
+        assert!(dispatcher
+            .emit(EventType::DriftChecked, EventSource::Watcher, &json!({}))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn jsonl_sink_appends_versioned_events_with_private_permissions() {
+        let root = temp_root("jsonl");
+        let log = root.join("nested/events.jsonl");
+        let dispatcher = EventDispatcher::new(Some(log.clone()), None).unwrap();
+        dispatcher
+            .emit(
+                EventType::DriftChecked,
+                EventSource::Watcher,
+                &json!({"state": "in_sync"}),
+            )
+            .unwrap();
+        dispatcher
+            .emit(
+                EventType::MutationCompleted,
+                EventSource::Governance,
+                &json!({"audit_id": "audit-1"}),
+            )
+            .unwrap();
+        let events = fs::read_to_string(&log)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<EventEnvelope>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].schema_version, EVENT_SCHEMA_VERSION);
+        assert_eq!(events[0].event_type, EventType::DriftChecked);
+        assert_eq!(events[1].payload["audit_id"], "audit-1");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&log).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+            assert_eq!(
+                fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(root.join("nested"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn command_sink_receives_json_on_stdin_and_event_metadata_in_environment() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_root("command");
+        fs::create_dir_all(&root).unwrap();
+        let command = root.join("sink.sh");
+        let output = root.join("received.jsonl");
+        fs::write(
+            &command,
+            "#!/bin/sh\nprintf '%s|%s\\n' \"$DUTIS_EVENT_TYPE\" \"$DUTIS_EVENT_ID\" >> \"$DUTIS_TEST_METADATA\"\ncat >> \"$DUTIS_TEST_OUTPUT\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&command, fs::Permissions::from_mode(0o700)).unwrap();
+        std::env::set_var("DUTIS_TEST_OUTPUT", &output);
+        std::env::set_var("DUTIS_TEST_METADATA", root.join("metadata"));
+        let dispatcher = EventDispatcher::new(None, Some(command)).unwrap();
+        let event = dispatcher
+            .emit(
+                EventType::MutationPending,
+                EventSource::Governance,
+                &json!({"audit_id": "audit-1"}),
+            )
+            .unwrap()
+            .unwrap();
+        let received: EventEnvelope =
+            serde_json::from_str(fs::read_to_string(output).unwrap().trim()).unwrap();
+        assert_eq!(received, event);
+        let metadata = fs::read_to_string(root.join("metadata")).unwrap();
+        assert_eq!(metadata.trim(), format!("mutation.pending|{}", event.id));
+        std::env::remove_var("DUTIS_TEST_OUTPUT");
+        std::env::remove_var("DUTIS_TEST_METADATA");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_or_non_executable_commands() {
+        let root = temp_root("invalid-command");
+        let missing = root.join("missing");
+        assert!(EventDispatcher::new(None, Some(missing)).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn attempts_jsonl_sink_even_when_command_sink_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_root("partial-delivery");
+        fs::create_dir_all(&root).unwrap();
+        let command = root.join("fail.sh");
+        fs::write(&command, "#!/bin/sh\necho rejected >&2\nexit 7\n").unwrap();
+        fs::set_permissions(&command, fs::Permissions::from_mode(0o700)).unwrap();
+        let log = root.join("events.jsonl");
+        let dispatcher = EventDispatcher::new(Some(log.clone()), Some(command)).unwrap();
+        let error = dispatcher
+            .emit(
+                EventType::MutationDenied,
+                EventSource::Governance,
+                &json!({"audit_id": "audit-1"}),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("rejected"));
+        assert_eq!(fs::read_to_string(log).unwrap().lines().count(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -1,5 +1,6 @@
 use crate::application::normalize_extension;
 use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
+use crate::events::{emit_best_effort, EventSource, EventType};
 use crate::planner::{ApplyReport, AssociationPlan, PlanAction};
 use crate::snapshot::{apply_plan_with_snapshot, SnapshotReason, SnapshotStore};
 use anyhow::{anyhow, bail, Context, Result};
@@ -611,6 +612,7 @@ where
             audit_id: Some(record.id.clone()),
             violations: assessment.violations.clone(),
         })?;
+        emit_best_effort(EventType::MutationDenied, EventSource::Governance, &record);
         return Err(GovernanceError {
             kind: GovernanceErrorKind::PolicyDenied,
             message: format!(
@@ -628,6 +630,7 @@ where
         audit_id: Some(record.id.clone()),
         violations: Vec::new(),
     })?;
+    emit_best_effort(EventType::MutationPending, EventSource::Governance, &record);
 
     let protected = match apply_plan_with_snapshot(snapshot_store, plan, reason, apply) {
         Ok(protected) => protected,
@@ -635,6 +638,7 @@ where
             record.outcome = AuditOutcome::FailedBeforeMutation;
             record.error = Some(format!("{error:#}"));
             let _ = audit_store.save(&record);
+            emit_best_effort(EventType::MutationFailed, EventSource::Governance, &record);
             return Err(GovernanceError {
                 kind: GovernanceErrorKind::SnapshotFailed,
                 message: format!(
@@ -671,6 +675,11 @@ where
         audit_id: Some(record.id.clone()),
         violations: Vec::new(),
     })?;
+    emit_best_effort(
+        EventType::MutationCompleted,
+        EventSource::Governance,
+        &record,
+    );
 
     Ok(GovernedMutation {
         audit_id: record.id,

--- a/src/launch_agent.rs
+++ b/src/launch_agent.rs
@@ -277,10 +277,16 @@ mod tests {
             notify: true,
             remediation_requester: None,
             state_dir: PathBuf::from("/Users/test/Library/Application Support/dutis"),
-            environment: BTreeMap::from([(
-                "PATH".to_owned(),
-                "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".to_owned(),
-            )]),
+            environment: BTreeMap::from([
+                (
+                    "PATH".to_owned(),
+                    "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin".to_owned(),
+                ),
+                (
+                    "DUTIS_EVENT_LOG".to_owned(),
+                    "/Users/test/Library/Application Support/dutis/events.jsonl".to_owned(),
+                ),
+            ]),
         };
         let value = plist::to_value(&plist(&spec)).unwrap();
         let dictionary = value.as_dictionary().unwrap();
@@ -292,6 +298,11 @@ mod tests {
             .iter()
             .any(|value| value.as_string() == Some("--remediate")));
         assert_eq!(dictionary["KeepAlive"].as_boolean(), Some(true));
+        assert_eq!(
+            dictionary["EnvironmentVariables"].as_dictionary().unwrap()["DUTIS_EVENT_LOG"]
+                .as_string(),
+            Some("/Users/test/Library/Application Support/dutis/events.jsonl")
+        );
         assert!(arguments.windows(2).any(|pair| {
             pair[0].as_string() == Some("--interval-seconds") && pair[1].as_string() == Some("300")
         }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod application;
 pub mod association;
 pub mod config;
 pub mod drift;
+pub mod events;
 pub mod governance;
 pub mod launch_agent;
 pub mod mcp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,10 @@ use dutis::application::{
 use dutis::association::{AssociationKind, AssociationTarget, HandlerRole};
 use dutis::config::DutisConfig;
 use dutis::drift::{send_macos_notification, DriftReport, DriftState, DriftTracker};
+use dutis::events::{
+    configure_process_sinks, emit_best_effort, EventSource, EventType, EVENT_COMMAND_ENV,
+    EVENT_LOG_ENV,
+};
 use dutis::governance::{
     execute_governed_plan, ApprovalMode, AuditStore, GovernanceErrorKind, GovernedMutation,
     LoadedPolicy, MutationChannel, MutationOperation, MutationRequest, PolicyAssessment,
@@ -229,8 +233,11 @@ fn main() -> ExitCode {
         .map(command_name)
         .unwrap_or("interactive");
     let json = cli.command.as_ref().is_some_and(command_uses_json);
+    let event_setup =
+        configure_process_sinks(cli.event_log.as_deref(), cli.event_command.as_deref())
+            .map_err(|error| CliError::usage(format!("invalid event sink: {error:#}")));
 
-    match dispatch(cli.command) {
+    match event_setup.and_then(|_| dispatch(cli.command)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             if json {
@@ -546,6 +553,11 @@ fn run_watch(args: WatchArgs) -> Result<(), CliError> {
             report,
             remediation,
         };
+        emit_best_effort(
+            EventType::DriftChecked,
+            EventSource::Watcher,
+            &result.report,
+        );
         print_watch_result(&result, args.json)?;
         if args.once {
             return Ok(());
@@ -697,6 +709,11 @@ fn run_launch_agent_install(args: LaunchAgentInstallArgs) -> Result<(), CliError
             "DUTIS_POLICY_FILE".to_owned(),
             value.to_string_lossy().into_owned(),
         );
+    }
+    for name in [EVENT_LOG_ENV, EVENT_COMMAND_ENV] {
+        if let Some(value) = std::env::var_os(name).filter(|value| !value.is_empty()) {
+            environment.insert(name.to_owned(), value.to_string_lossy().into_owned());
+        }
     }
     let spec = LaunchAgentSpec {
         executable,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -2,6 +2,7 @@ use crate::application::{find_apps_for_extension, normalize_extension, Applicati
 use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use crate::config::DutisConfig;
 use crate::drift::DriftReport;
+use crate::events::{emit_best_effort, EventSource, EventType};
 use crate::governance::{
     execute_governed_plan, AuditStore, GovernanceError, GovernanceErrorKind, LoadedPolicy,
     MutationChannel, MutationOperation, MutationRequest,
@@ -361,7 +362,9 @@ impl<B: McpBackend> McpServer<B> {
             }
             "dutis_drift" => {
                 let config = parse_config(arguments)?;
-                self.backend.drift(&config).map_err(operation_error)
+                let report = self.backend.drift(&config).map_err(operation_error)?;
+                emit_best_effort(EventType::DriftChecked, EventSource::Mcp, &report);
+                Ok(report)
             }
             "dutis_query" => {
                 let extension = argument_string(arguments, "extension")?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -35,6 +35,27 @@ fn json_usage_errors_have_a_stable_envelope_and_exit_code() {
 }
 
 #[test]
+fn invalid_global_event_command_has_a_stable_usage_error() {
+    let output = dutis()
+        .args([
+            "--event-command",
+            "/definitely/missing/dutis-event-sink",
+            "doctor",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "doctor");
+    assert_eq!(response["error"]["kind"], "usage");
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("event command"));
+}
+
+#[test]
 fn set_requires_confirmation_before_scanning_or_mutating() {
     let output = dutis()
         .args(["set", "md", "com.example.Editor", "--json"])
@@ -266,6 +287,7 @@ fn typed_config_dry_run_and_apply_cover_every_duti_argument_shape() {
     let calls = root.join("duti-calls.log");
     let fake_state = root.join("applied");
     let state = root.join("state");
+    let events = root.join("events.jsonl");
     let configure = |command: &mut Command| {
         command
             .env("PATH", &bin)
@@ -312,6 +334,8 @@ fn typed_config_dry_run_and_apply_cover_every_duti_argument_shape() {
             "integration-test",
             "--yes",
             "--json",
+            "--event-log",
+            events.to_str().unwrap(),
         ])
         .output()
         .unwrap();
@@ -339,6 +363,15 @@ fn typed_config_dry_run_and_apply_cover_every_duti_argument_shape() {
         .any(|line| line == "-s com.apple.TextEdit https"));
     assert_eq!(fs::read_dir(state.join("snapshots")).unwrap().count(), 1);
     assert_eq!(fs::read_dir(state.join("audit")).unwrap().count(), 1);
+    let events = fs::read_to_string(events)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["event_type"], "mutation.pending");
+    assert_eq!(events[1]["event_type"], "mutation.completed");
+    assert_eq!(events[1]["payload"]["outcome"], "succeeded");
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -401,12 +434,31 @@ fn watch_once_reports_drift_without_invoking_duti_set() {
     )
     .unwrap();
     let calls = root.join("duti-calls.log");
+    let events = root.join("events.jsonl");
+    let command_events = root.join("command-events.jsonl");
+    let event_command = root.join("event-sink.sh");
+    fs::write(
+        &event_command,
+        "#!/bin/sh\n/bin/cat >> \"$DUTIS_TEST_EVENT_OUTPUT\"\nprintf 'discarded command output\\n'\n",
+    )
+    .unwrap();
+    fs::set_permissions(&event_command, fs::Permissions::from_mode(0o700)).unwrap();
 
     let output = dutis()
         .env("PATH", &bin)
         .env("DUTI_CALL_LOG", &calls)
         .env("DUTIS_STATE_DIR", root.join("state"))
-        .args(["watch", config.to_str().unwrap(), "--once", "--json"])
+        .env("DUTIS_TEST_EVENT_OUTPUT", &command_events)
+        .args([
+            "watch",
+            config.to_str().unwrap(),
+            "--once",
+            "--json",
+            "--event-log",
+            events.to_str().unwrap(),
+            "--event-command",
+            event_command.to_str().unwrap(),
+        ])
         .output()
         .unwrap();
     assert!(
@@ -421,6 +473,14 @@ fn watch_once_reports_drift_without_invoking_duti_set() {
     assert!(calls.lines().any(|line| line == "-V"));
     assert!(calls.lines().any(|line| line == "-x md"));
     assert!(!calls.lines().any(|line| line.starts_with("-s ")));
+    let event: Value = serde_json::from_str(fs::read_to_string(events).unwrap().trim()).unwrap();
+    assert_eq!(event["schema_version"], 1);
+    assert_eq!(event["event_type"], "drift.checked");
+    assert_eq!(event["source"], "watcher");
+    assert_eq!(event["payload"]["state"], "drift_detected");
+    let command_event: Value =
+        serde_json::from_str(fs::read_to_string(command_events).unwrap().trim()).unwrap();
+    assert_eq!(command_event, event);
     fs::remove_dir_all(root).unwrap();
 }
 


### PR DESCRIPTION
## Summary

- add versioned event envelopes for drift checks and mutation lifecycle updates
- support owner-only JSONL logs and trusted executable sinks through global CLI options or environment variables
- emit consistent drift events from watcher and MCP flows, plus pending, denied, failed, and completed governance events
- preserve sink settings in LaunchAgent installs while stripping Dutis approval tokens from event-command environments
- document the event contract and mark Phase 9 implemented for v2.13.0

## Safety

- event delivery is best effort and cannot authorize, suppress audit, or relabel a mutation
- event commands are validated executable paths, receive JSON only through stdin, and have stdout discarded
- JSONL files use mode 0600 and newly created directories use mode 0700 on Unix

## Validation

- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline (98 passed)
- cargo build --release --locked --offline
- cargo package --allow-dirty --locked --offline
- git diff --check
- fake-duti integration verifies drift and mutation events without changing real system associations