### PR TITLE
feat: add typed application metadata discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.13.0"
+version = "2.14.0"
 edition = "2021"
 rust-version = "1.88"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 ## Features
 
 - 🔍 **Scan System Applications**: Automatically discovers all installed applications on macOS
-- 📱 **File Extension Analysis**: Shows which file extensions each application supports
+- 📱 **Application Capability Discovery**: Reads declared extensions, UTIs, MIME types, URL schemes, and roles
 - 🎯 **Interactive Query Mode**: Search for applications that support specific file types
 - ⚙️ **Default App Setting**: Set default applications for file types using the `duti` command
 - 🧭 **Accurate App Selection**: Preserves full application paths, including nested and duplicate names
@@ -92,6 +92,9 @@ dutis query md
 dutis get .md
 
 # Inspect typed Launch Services handlers
+dutis handler query uti public.plain-text --role viewer
+dutis handler query mime text/plain --role editor
+dutis handler query url-scheme https
 dutis handler get uti public.plain-text --role viewer
 dutis handler get mime text/plain --role editor
 dutis handler get url-scheme https
@@ -128,6 +131,12 @@ stale digest. Every change is verified, unchanged entries are skipped, and
 partial failures include a result for every association. See the
 [declarative configuration guide](docs/declarative-configuration.md) for the
 schema and safety contract.
+
+Typed queries return compact application candidates with the exact matching
+Info.plist declarations. Full `list --json` output also includes each
+application's registered handlers and imported/exported type definitions. See
+[application metadata](docs/application-metadata.md) for evidence and role
+matching rules.
 
 Create, inspect, and restore local snapshots:
 
@@ -231,8 +240,8 @@ MCP, agent policies, profiles, drift detection, and event delivery is documented
 ### Application Scanning
 
 1. **System Directories**: Scans `/Applications`, `/System/Applications`, and `~/Applications`
-2. **Info.plist Parsing**: Reads each application's `Info.plist` file to extract supported file extensions
-3. **Modern Metadata**: Reads exported and imported UTI declarations as well as legacy document types
+2. **Info.plist Parsing**: Reads document types, URL types, roles, extensions, UTIs, and MIME types
+3. **Modern Metadata**: Keeps handler registrations separate from exported and imported UTI definitions
 
 ### Default App Setting
 

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -198,10 +198,31 @@ Acceptance criteria:
 - LaunchAgent installation preserves normalized sink paths without persisting
   approval tokens.
 
+## Phase 10: Typed application metadata
+
+Status: implemented for v2.14.0
+
+Extend application discovery beyond filename extensions while keeping handler
+registrations distinct from UTI definitions.
+
+Acceptance criteria:
+
+- Parse role-aware document registrations for extensions, UTIs, and MIME types,
+  plus URL-scheme registrations.
+- Parse imported and exported UTI identifiers, conformance, filename tags, and
+  MIME tags as separate type-definition evidence.
+- Preserve the legacy `extensions` field while adding stable typed metadata to
+  application JSON.
+- CLI and MCP expose compact typed handler queries with exact matching
+  declarations and normalized identifiers.
+- Role matching recognizes that an editor can satisfy a viewer query, while
+  shell and editor capabilities remain distinct.
+
 ## Near-term engineering sequence
 
-1. Release Phase 9 and validate long-running event delivery and log rotation.
-2. Extend application metadata discovery beyond filename extensions where
-   Launch Services exposes reliable declarations.
-3. Add optional network adapters as external event commands, keeping transport
+1. Release Phase 10 and validate metadata coverage across native and third-party
+   applications on supported macOS releases.
+2. Add optional network adapters as external event commands, keeping transport
    credentials outside Dutis configuration and audit records.
+3. Explore native Launch Services read APIs for richer role-specific default
+   verification where `duti` exposes only a single default handler.

--- a/docs/application-metadata.md
+++ b/docs/application-metadata.md
@@ -1,0 +1,80 @@
+# Application metadata
+
+Dutis v2.14 reads typed Launch Services declarations from installed application
+bundles. This supports evidence-backed discovery before selecting or changing a
+default handler.
+
+## Query registered handlers
+
+Use the typed query command for extensions, UTIs, MIME types, and URL schemes:
+
+```bash
+dutis handler query extension md
+dutis handler query uti public.plain-text --role viewer
+dutis handler query mime text/plain --role editor --json
+dutis handler query url-scheme https --json
+```
+
+The MCP equivalent is `dutis_handler_query`, with `kind`, `identifier`, and an
+optional `role`. Identifiers use the same normalization and validation as
+planning and mutation commands.
+
+Each result contains a compact application identity and only the declarations
+that matched the query:
+
+```json
+{
+  "name": "TextEdit",
+  "path": "/System/Applications/TextEdit.app",
+  "bundle_id": "com.apple.TextEdit",
+  "declarations": [
+    {
+      "kind": "uti",
+      "identifier": "public.plain-text",
+      "role": "editor",
+      "source": "document_type"
+    }
+  ]
+}
+```
+
+## Evidence sources
+
+Dutis treats these Info.plist records as handler registrations:
+
+- `CFBundleDocumentTypes` with `CFBundleTypeExtensions`,
+  `LSItemContentTypes`, or `CFBundleTypeMIMETypes`;
+- `CFBundleTypeRole` as `viewer`, `editor`, `shell`, or `all` when omitted;
+- `CFBundleURLTypes` with `CFBundleURLSchemes`, always using role `all`.
+
+An explicit `CFBundleTypeRole = None` or an unknown role is not reported as a
+handler capability. Invalid and wildcard identifiers are ignored rather than
+making the whole application unreadable.
+
+For discovery, an `editor` declaration also satisfies a `viewer` query. An
+`all` query returns every matching declaration. Editor and shell capabilities
+do not imply one another.
+
+## Type definitions
+
+`UTExportedTypeDeclarations` and `UTImportedTypeDeclarations` define or import
+types; they do not by themselves prove that the application opens those types.
+Dutis therefore exposes them separately as `type_declarations`, including:
+
+- normalized `UTTypeIdentifier`;
+- whether it is `exported` or `imported`;
+- normalized `UTTypeConformsTo` identifiers;
+- `public.filename-extension` tags;
+- `public.mime-type` tags.
+
+The legacy `extensions` array remains available for compatibility and still
+contains extension tags from both document registrations and type definitions.
+Use `handlers` or `handler query` when the distinction matters.
+
+## Full catalog
+
+`dutis list --json` and MCP `dutis_list` expose `handlers` and
+`type_declarations` alongside the existing name, path, bundle ID, and extension
+fields. Empty typed arrays are omitted to keep output compact. Metadata from
+one malformed application is counted in `metadata_failures` without hiding
+other applications.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -28,13 +28,16 @@ A typical MCP client configuration is:
 
 The server advertises these read tools:
 
-- `dutis_list`: discover installed applications and declared extensions.
+- `dutis_list`: discover installed applications, typed handlers, and UTI
+  definitions.
 - `dutis_profiles`: list built-in profiles and ordered candidates.
 - `dutis_profile`: inspect one profile by its `profile` name.
 - `dutis_recommend`: generate an explainable proposal, plan digest, and policy assessment by `profile` name.
 - `dutis_drift`: check inline TOML for drift and return a timestamped report with policy assessment.
 - `dutis_query`: find installed handlers for one extension.
 - `dutis_get`: inspect the current default handler.
+- `dutis_handler_query`: find applications that explicitly register a matching
+  extension, UTI, MIME type, URL scheme, and compatible role.
 - `dutis_handler_get`: inspect an extension, UTI, MIME type, or URL scheme with
   an optional `all`, `viewer`, `editor`, or `shell` role.
 - `dutis_diff`: parse inline versioned TOML and return a deterministic plan.
@@ -44,11 +47,11 @@ The server advertises these read tools:
 - `dutis_policy_check`: evaluate an inline TOML plan against policy.
 - `dutis_audit`: inspect persistent mutation audit records.
 
-`dutis_handler_get` accepts `kind`, `identifier`, and optional `role` fields.
-The kind uses `url_scheme` in JSON; URL schemes accept only the default `all`
-role. `dutis_diff` accepts `config_toml` rather than a filesystem path. This keeps the
-MCP surface independent from unrestricted file access and makes the exact input
-part of the reviewed tool call.
+`dutis_handler_query` and `dutis_handler_get` accept `kind`, `identifier`, and
+optional `role` fields. The kind uses `url_scheme` in JSON; URL schemes accept
+only the default `all` role. `dutis_diff` accepts `config_toml` rather than a
+filesystem path. This keeps the MCP surface independent from unrestricted file
+access and makes the exact input part of the reviewed tool call.
 
 Profile recommendations are also read-only. A recommendation is evidence, not
 approval: it does not register a mutation tool call or change an association.

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -13,7 +13,9 @@ Use Dutis for macOS Launch Services associations. Preserve its
 1. Start read-only. Check readiness and the effective policy, then inspect the
    requested association targets and installed handlers. Use `handler get` or
    `dutis_handler_get` for UTIs, MIME types, URL schemes, and role-specific
-   reads.
+   defaults. Use `handler query` or `dutis_handler_query` to discover apps that
+   explicitly register the requested kind and compatible role. Treat imported
+   or exported UTI definitions as type evidence, not handler capability.
 2. If the user asks for a general setup or is unsure which application to use,
    inspect `dutis_profiles` / `dutis_profile`, then use `dutis_recommend` (or
    the equivalent CLI commands). Present candidate evidence and treat the

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,8 +1,9 @@
 use crate::app_scanner::AppScanner;
-use crate::plist_parser::PlistParser;
+use crate::association::{AssociationTarget, HandlerRole};
+use crate::plist_parser::{DeclaredHandler, PlistParser, TypeDeclaration};
 use anyhow::{bail, Result};
 use serde::Serialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct Application {
@@ -10,6 +11,10 @@ pub struct Application {
     pub path: PathBuf,
     pub bundle_id: Option<String>,
     pub extensions: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub handlers: Vec<DeclaredHandler>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub type_declarations: Vec<TypeDeclaration>,
 }
 
 #[derive(Debug)]
@@ -31,16 +36,22 @@ impl ApplicationCatalog {
                 if metadata.is_err() {
                     metadata_failures += 1;
                 }
-                let metadata = metadata.ok();
+                let (bundle_id, extensions, handlers, type_declarations) = match metadata {
+                    Ok(metadata) => (
+                        metadata.bundle_id,
+                        metadata.extensions,
+                        metadata.handlers,
+                        metadata.type_declarations,
+                    ),
+                    Err(_) => (None, Vec::new(), Vec::new(), Vec::new()),
+                };
                 Application {
                     name: installed.name,
                     path: installed.path,
-                    bundle_id: metadata
-                        .as_ref()
-                        .and_then(|metadata| metadata.bundle_id.clone()),
-                    extensions: metadata
-                        .map(|metadata| metadata.extensions)
-                        .unwrap_or_default(),
+                    bundle_id,
+                    extensions,
+                    handlers,
+                    type_declarations,
                 }
             })
             .collect();
@@ -50,6 +61,47 @@ impl ApplicationCatalog {
             metadata_failures,
         })
     }
+}
+
+#[derive(Debug, Serialize)]
+pub struct HandlerCandidate<'a> {
+    pub name: &'a str,
+    pub path: &'a Path,
+    pub bundle_id: Option<&'a str>,
+    pub declarations: Vec<&'a DeclaredHandler>,
+}
+
+pub fn find_handler_candidates<'a>(
+    applications: &'a [Application],
+    association: &AssociationTarget,
+) -> Vec<HandlerCandidate<'a>> {
+    applications
+        .iter()
+        .filter_map(|application| {
+            let declarations = application
+                .handlers
+                .iter()
+                .filter(|handler| {
+                    handler.kind == association.kind
+                        && handler.identifier == association.identifier
+                        && role_supports(handler.role, association.role)
+                })
+                .collect::<Vec<_>>();
+            (!declarations.is_empty()).then_some(HandlerCandidate {
+                name: &application.name,
+                path: &application.path,
+                bundle_id: application.bundle_id.as_deref(),
+                declarations,
+            })
+        })
+        .collect()
+}
+
+fn role_supports(declared: HandlerRole, requested: HandlerRole) -> bool {
+    declared == HandlerRole::All
+        || requested == HandlerRole::All
+        || declared == requested
+        || (requested == HandlerRole::Viewer && declared == HandlerRole::Editor)
 }
 
 pub fn find_apps_for_extension<'a>(
@@ -79,6 +131,24 @@ pub fn find_fuzzy_matches<'a>(
                     .extensions
                     .iter()
                     .any(|extension| extension.to_ascii_lowercase().contains(&search_term))
+                || app.handlers.iter().any(|handler| {
+                    handler
+                        .identifier
+                        .to_ascii_lowercase()
+                        .contains(&search_term)
+                })
+                || app.type_declarations.iter().any(|declaration| {
+                    declaration
+                        .identifier
+                        .to_ascii_lowercase()
+                        .contains(&search_term)
+                        || declaration
+                            .mime_types
+                            .iter()
+                            .chain(&declaration.extensions)
+                            .chain(&declaration.conforms_to)
+                            .any(|value| value.to_ascii_lowercase().contains(&search_term))
+                })
         })
         .collect()
 }
@@ -130,6 +200,8 @@ mod tests {
             path: PathBuf::from(path),
             bundle_id: bundle_id.map(str::to_owned),
             extensions: vec!["txt".to_owned()],
+            handlers: Vec::new(),
+            type_declarations: Vec::new(),
         }
     }
 
@@ -168,5 +240,33 @@ mod tests {
         assert_eq!(normalize_extension("c++").unwrap(), "c++");
         assert!(normalize_extension("../../txt").is_err());
         assert!(normalize_extension("...").is_err());
+    }
+
+    #[test]
+    fn finds_declared_handlers_with_role_implication() {
+        let mut editor = app("Editor", "/Applications/Editor.app", Some("dev.editor"));
+        editor.handlers = vec![DeclaredHandler {
+            kind: crate::association::AssociationKind::Uti,
+            identifier: "public.text".to_owned(),
+            role: HandlerRole::Editor,
+            source: crate::plist_parser::HandlerDeclarationSource::DocumentType,
+        }];
+        let applications = vec![editor];
+        let viewer = AssociationTarget::new(
+            crate::association::AssociationKind::Uti,
+            "public.text",
+            HandlerRole::Viewer,
+        )
+        .unwrap();
+        let candidates = find_handler_candidates(&applications, &viewer);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].declarations[0].role, HandlerRole::Editor);
+        let shell = AssociationTarget::new(
+            crate::association::AssociationKind::Uti,
+            "public.text",
+            HandlerRole::Shell,
+        )
+        .unwrap();
+        assert!(find_handler_candidates(&applications, &shell).is_empty());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,8 @@ pub struct HandlerArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum HandlerCommand {
+    /// Find installed applications that declare support for a typed handler
+    Query(HandlerGetArgs),
     /// Read the current handler for an extension, UTI, MIME type, or URL scheme
     Get(HandlerGetArgs),
     /// Set a handler for an extension, UTI, MIME type, or URL scheme
@@ -535,6 +537,27 @@ mod tests {
 
     #[test]
     fn parses_typed_handler_commands_and_roles() {
+        let cli = Cli::try_parse_from([
+            "dutis",
+            "handler",
+            "query",
+            "mime",
+            "text/plain",
+            "--role",
+            "editor",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Handler(HandlerArgs {
+                command: HandlerCommand::Query(HandlerGetArgs {
+                    kind: AssociationKind::Mime,
+                    role: HandlerRole::Editor,
+                    ..
+                })
+            }))
+        ));
+
         let cli = Cli::try_parse_from([
             "dutis",
             "handler",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use cli::{
 };
 use colored::*;
 use dutis::application::{
-    find_apps_for_extension, find_fuzzy_matches, normalize_extension, resolve_app, Application,
-    ApplicationCatalog,
+    find_apps_for_extension, find_fuzzy_matches, find_handler_candidates, normalize_extension,
+    resolve_app, Application, ApplicationCatalog, HandlerCandidate,
 };
 use dutis::association::{AssociationKind, AssociationTarget, HandlerRole};
 use dutis::config::DutisConfig;
@@ -160,6 +160,13 @@ struct HandlerSetResult<'a> {
     audit_id: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     safety_snapshot_id: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct HandlerQueryResult<'a> {
+    association: &'a AssociationTarget,
+    applications: Vec<HandlerCandidate<'a>>,
+    metadata_failures: usize,
 }
 
 #[derive(Serialize)]
@@ -334,6 +341,7 @@ fn command_uses_json(command: &CliCommand) -> bool {
         },
         CliCommand::Recommend(args) => args.json,
         CliCommand::Handler(args) => match &args.command {
+            HandlerCommand::Query(args) => args.json,
             HandlerCommand::Get(args) => args.json,
             HandlerCommand::Set(args) => args.json,
         },
@@ -348,9 +356,40 @@ fn command_uses_json(command: &CliCommand) -> bool {
 
 fn run_handler(args: HandlerArgs) -> Result<(), CliError> {
     match args.command {
+        HandlerCommand::Query(args) => run_handler_query(args),
         HandlerCommand::Get(args) => run_handler_get(args),
         HandlerCommand::Set(args) => run_handler_set(args),
     }
+}
+
+fn run_handler_query(args: HandlerGetArgs) -> Result<(), CliError> {
+    let association = AssociationTarget::new(args.kind, &args.identifier, args.role)
+        .map_err(|error| CliError::usage(error.to_string()))?;
+    let catalog = scan_catalog()?;
+    report_metadata_failures(catalog.metadata_failures);
+    let applications = find_handler_candidates(&catalog.applications, &association);
+    if applications.is_empty() {
+        return Err(CliError::not_found(format!(
+            "no installed applications declare support for {association}"
+        )));
+    }
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "handler",
+            data: HandlerQueryResult {
+                association: &association,
+                applications,
+                metadata_failures: catalog.metadata_failures,
+            },
+        })?;
+    } else {
+        println!("Applications declaring support for {association}:");
+        for application in applications {
+            println!("{}\t{}", application.name, application.path.display());
+        }
+    }
+    Ok(())
 }
 
 fn run_handler_get(args: HandlerGetArgs) -> Result<(), CliError> {
@@ -2024,6 +2063,8 @@ mod tests {
             path: PathBuf::from(format!("/Applications/{name}.app")),
             bundle_id: Some(format!("example.{name}")),
             extensions: extensions.iter().map(|value| (*value).to_owned()).collect(),
+            handlers: Vec::new(),
+            type_declarations: Vec::new(),
         }
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,4 +1,6 @@
-use crate::application::{find_apps_for_extension, normalize_extension, ApplicationCatalog};
+use crate::application::{
+    find_apps_for_extension, find_handler_candidates, normalize_extension, ApplicationCatalog,
+};
 use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use crate::config::DutisConfig;
 use crate::drift::DriftReport;
@@ -85,6 +87,7 @@ trait McpBackend {
     fn drift(&mut self, config: &DutisConfig) -> Result<Value>;
     fn query(&mut self, extension: &str) -> Result<Value>;
     fn get(&mut self, extension: &str) -> Result<Value>;
+    fn query_handler(&mut self, association: &AssociationTarget) -> Result<Value>;
     fn get_handler(&mut self, association: &AssociationTarget) -> Result<Value>;
     fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan>;
     fn apply(
@@ -158,6 +161,16 @@ impl McpBackend for SystemBackend {
     fn get(&mut self, extension: &str) -> Result<Value> {
         let default = system::get_default_app(extension)?;
         Ok(json!({"extension": extension, "default": default}))
+    }
+
+    fn query_handler(&mut self, association: &AssociationTarget) -> Result<Value> {
+        let catalog = ApplicationCatalog::scan()?;
+        let applications = find_handler_candidates(&catalog.applications, association);
+        Ok(json!({
+            "association": association,
+            "applications": applications,
+            "metadata_failures": catalog.metadata_failures,
+        }))
     }
 
     fn get_handler(&mut self, association: &AssociationTarget) -> Result<Value> {
@@ -382,6 +395,12 @@ impl<B: McpBackend> McpServer<B> {
                 let association = parse_association(arguments)?;
                 self.backend
                     .get_handler(&association)
+                    .map_err(operation_error)
+            }
+            "dutis_handler_query" => {
+                let association = parse_association(arguments)?;
+                self.backend
+                    .query_handler(&association)
                     .map_err(operation_error)
             }
             "dutis_diff" => {
@@ -763,6 +782,12 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
             read_annotations.clone(),
         ),
         tool_definition(
+            "dutis_handler_query",
+            "Find installed applications that declare support for an extension, UTI, MIME type, or URL scheme.",
+            handler_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
             "dutis_handler_get",
             "Read the current handler for an extension, UTI, MIME type, or URL scheme.",
             handler_schema,
@@ -978,6 +1003,10 @@ mod tests {
             Ok(json!({"extension": extension, "default": null}))
         }
 
+        fn query_handler(&mut self, association: &AssociationTarget) -> Result<Value> {
+            Ok(json!({"association": association, "applications": []}))
+        }
+
         fn get_handler(&mut self, association: &AssociationTarget) -> Result<Value> {
             Ok(json!({"association": association, "default": null}))
         }
@@ -1064,6 +1093,7 @@ mod tests {
         assert!(names.contains(&"dutis_recommend"));
         assert!(names.contains(&"dutis_drift"));
         assert!(names.contains(&"dutis_handler_get"));
+        assert!(names.contains(&"dutis_handler_query"));
         assert!(names.contains(&"dutis_policy_check"));
         assert!(names.contains(&"dutis_audit"));
         assert!(!names.contains(&"dutis_apply"));
@@ -1159,6 +1189,25 @@ mod tests {
             invalid.response.unwrap()["result"]["structuredContent"]["error"]["kind"],
             "invalid_arguments"
         );
+    }
+
+    #[test]
+    fn typed_handler_query_uses_the_same_closed_target_schema() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let outcome = server.handle(request(
+            10,
+            "tools/call",
+            json!({
+                "name": "dutis_handler_query",
+                "arguments": {"kind": "mime", "identifier": "text/plain", "role": "editor"}
+            }),
+        ));
+        let response = outcome.response.unwrap();
+        assert_eq!(
+            response["result"]["structuredContent"]["data"]["association"]["kind"],
+            "mime"
+        );
+        assert_eq!(outcome.audit.unwrap().access, "read");
     }
 
     #[test]

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -351,6 +351,8 @@ mod tests {
             path: PathBuf::from(format!("/Applications/{name}.app")),
             bundle_id: Some(bundle_id.to_owned()),
             extensions: vec!["md".to_owned(), "json".to_owned()],
+            handlers: Vec::new(),
+            type_declarations: Vec::new(),
         }
     }
 

--- a/src/plist_parser.rs
+++ b/src/plist_parser.rs
@@ -1,5 +1,7 @@
+use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use anyhow::{Context, Result};
 use plist::{Dictionary, Value};
+use serde::Serialize;
 use std::collections::BTreeSet;
 use std::path::Path;
 
@@ -10,6 +12,49 @@ pub struct PlistParser;
 pub struct AppMetadata {
     pub bundle_id: Option<String>,
     pub extensions: Vec<String>,
+    pub handlers: Vec<DeclaredHandler>,
+    pub type_declarations: Vec<TypeDeclaration>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HandlerDeclarationSource {
+    DocumentType,
+    UrlType,
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct DeclaredHandler {
+    pub kind: AssociationKind,
+    pub identifier: String,
+    pub role: HandlerRole,
+    pub source: HandlerDeclarationSource,
+}
+
+impl DeclaredHandler {
+    pub fn association(&self) -> AssociationTarget {
+        AssociationTarget {
+            kind: self.kind,
+            identifier: self.identifier.clone(),
+            role: self.role,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TypeDeclarationSource {
+    Exported,
+    Imported,
+}
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct TypeDeclaration {
+    pub identifier: String,
+    pub source: TypeDeclarationSource,
+    pub conforms_to: Vec<String>,
+    pub extensions: Vec<String>,
+    pub mime_types: Vec<String>,
 }
 
 impl PlistParser {
@@ -20,6 +65,8 @@ impl PlistParser {
     pub fn parse_metadata(&self, plist_path: &Path) -> Result<AppMetadata> {
         let plist = Value::from_file(plist_path)
             .with_context(|| format!("failed to parse {}", plist_path.display()))?;
+        let handlers = extract_handlers(&plist);
+        let type_declarations = extract_type_declarations(&plist);
         Ok(AppMetadata {
             bundle_id: plist
                 .as_dictionary()
@@ -27,6 +74,8 @@ impl PlistParser {
                 .and_then(Value::as_string)
                 .map(str::to_owned),
             extensions: extract_extensions(&plist),
+            handlers,
+            type_declarations,
         })
     }
 }
@@ -41,6 +90,182 @@ fn extract_extensions(plist: &Value) -> Vec<String> {
     collect_type_declaration_extensions(root, "UTExportedTypeDeclarations", &mut extensions);
     collect_type_declaration_extensions(root, "UTImportedTypeDeclarations", &mut extensions);
     extensions.into_iter().collect()
+}
+
+fn extract_handlers(plist: &Value) -> Vec<DeclaredHandler> {
+    let mut handlers = BTreeSet::new();
+    let Some(root) = plist.as_dictionary() else {
+        return Vec::new();
+    };
+    collect_document_type_handlers(root, &mut handlers);
+    collect_url_type_handlers(root, &mut handlers);
+    handlers.into_iter().collect()
+}
+
+fn collect_document_type_handlers(root: &Dictionary, handlers: &mut BTreeSet<DeclaredHandler>) {
+    let Some(document_types) = root.get("CFBundleDocumentTypes").and_then(Value::as_array) else {
+        return;
+    };
+    for document_type in document_types.iter().filter_map(Value::as_dictionary) {
+        let Some(role) = document_handler_role(document_type) else {
+            continue;
+        };
+        collect_handler_values(
+            document_type.get("CFBundleTypeExtensions"),
+            AssociationKind::Extension,
+            role,
+            HandlerDeclarationSource::DocumentType,
+            handlers,
+        );
+        collect_handler_values(
+            document_type.get("LSItemContentTypes"),
+            AssociationKind::Uti,
+            role,
+            HandlerDeclarationSource::DocumentType,
+            handlers,
+        );
+        collect_handler_values(
+            document_type.get("CFBundleTypeMIMETypes"),
+            AssociationKind::Mime,
+            role,
+            HandlerDeclarationSource::DocumentType,
+            handlers,
+        );
+    }
+}
+
+fn collect_url_type_handlers(root: &Dictionary, handlers: &mut BTreeSet<DeclaredHandler>) {
+    let Some(url_types) = root.get("CFBundleURLTypes").and_then(Value::as_array) else {
+        return;
+    };
+    for url_type in url_types.iter().filter_map(Value::as_dictionary) {
+        collect_handler_values(
+            url_type.get("CFBundleURLSchemes"),
+            AssociationKind::UrlScheme,
+            HandlerRole::All,
+            HandlerDeclarationSource::UrlType,
+            handlers,
+        );
+    }
+}
+
+fn document_handler_role(document_type: &Dictionary) -> Option<HandlerRole> {
+    match document_type
+        .get("CFBundleTypeRole")
+        .and_then(Value::as_string)
+        .map(str::trim)
+    {
+        None | Some("") => Some(HandlerRole::All),
+        Some(value) if value.eq_ignore_ascii_case("viewer") => Some(HandlerRole::Viewer),
+        Some(value) if value.eq_ignore_ascii_case("editor") => Some(HandlerRole::Editor),
+        Some(value) if value.eq_ignore_ascii_case("shell") => Some(HandlerRole::Shell),
+        Some(value) if value.eq_ignore_ascii_case("none") => None,
+        Some(_) => None,
+    }
+}
+
+fn collect_handler_values(
+    value: Option<&Value>,
+    kind: AssociationKind,
+    role: HandlerRole,
+    source: HandlerDeclarationSource,
+    handlers: &mut BTreeSet<DeclaredHandler>,
+) {
+    for value in string_values(value) {
+        let Ok(target) = AssociationTarget::new(kind, value, role) else {
+            continue;
+        };
+        handlers.insert(DeclaredHandler {
+            kind: target.kind,
+            identifier: target.identifier,
+            role: target.role,
+            source,
+        });
+    }
+}
+
+fn extract_type_declarations(plist: &Value) -> Vec<TypeDeclaration> {
+    let mut declarations = BTreeSet::new();
+    let Some(root) = plist.as_dictionary() else {
+        return Vec::new();
+    };
+    collect_type_declarations(
+        root,
+        "UTExportedTypeDeclarations",
+        TypeDeclarationSource::Exported,
+        &mut declarations,
+    );
+    collect_type_declarations(
+        root,
+        "UTImportedTypeDeclarations",
+        TypeDeclarationSource::Imported,
+        &mut declarations,
+    );
+    declarations.into_iter().collect()
+}
+
+fn collect_type_declarations(
+    root: &Dictionary,
+    key: &str,
+    source: TypeDeclarationSource,
+    declarations: &mut BTreeSet<TypeDeclaration>,
+) {
+    let Some(values) = root.get(key).and_then(Value::as_array) else {
+        return;
+    };
+    for declaration in values.iter().filter_map(Value::as_dictionary) {
+        let Some(identifier) = declaration
+            .get("UTTypeIdentifier")
+            .and_then(Value::as_string)
+            .and_then(|value| {
+                AssociationTarget::new(AssociationKind::Uti, value, HandlerRole::All).ok()
+            })
+            .map(|target| target.identifier)
+        else {
+            continue;
+        };
+        let conforms_to =
+            normalized_values(declaration.get("UTTypeConformsTo"), AssociationKind::Uti);
+        let tags = declaration
+            .get("UTTypeTagSpecification")
+            .and_then(Value::as_dictionary);
+        let extensions = tags
+            .map(|tags| {
+                normalized_values(
+                    tags.get("public.filename-extension"),
+                    AssociationKind::Extension,
+                )
+            })
+            .unwrap_or_default();
+        let mime_types = tags
+            .map(|tags| normalized_values(tags.get("public.mime-type"), AssociationKind::Mime))
+            .unwrap_or_default();
+        declarations.insert(TypeDeclaration {
+            identifier,
+            source,
+            conforms_to,
+            extensions,
+            mime_types,
+        });
+    }
+}
+
+fn normalized_values(value: Option<&Value>, kind: AssociationKind) -> Vec<String> {
+    string_values(value)
+        .filter_map(|value| AssociationTarget::new(kind, value, HandlerRole::All).ok())
+        .map(|target| target.identifier)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn string_values(value: Option<&Value>) -> impl Iterator<Item = &str> {
+    let values = match value {
+        Some(Value::String(value)) => vec![value.as_str()],
+        Some(Value::Array(values)) => values.iter().filter_map(Value::as_string).collect(),
+        _ => Vec::new(),
+    };
+    values.into_iter()
 }
 
 fn collect_document_type_extensions(root: &Dictionary, extensions: &mut BTreeSet<String>) {
@@ -171,5 +396,101 @@ mod tests {
             Some("com.example.Editor")
         );
         assert_eq!(extract_extensions(&plist), vec!["txt"]);
+    }
+
+    #[test]
+    fn extracts_role_aware_document_and_url_handlers() {
+        let plist = dictionary([
+            (
+                "CFBundleDocumentTypes",
+                Value::Array(vec![
+                    dictionary([
+                        ("CFBundleTypeRole", Value::String("Editor".into())),
+                        (
+                            "CFBundleTypeExtensions",
+                            Value::Array(vec![Value::String("MD".into())]),
+                        ),
+                        (
+                            "LSItemContentTypes",
+                            Value::Array(vec![Value::String("Public.Text".into())]),
+                        ),
+                        (
+                            "CFBundleTypeMIMETypes",
+                            Value::Array(vec![Value::String("Text/Plain".into())]),
+                        ),
+                    ]),
+                    dictionary([
+                        ("CFBundleTypeRole", Value::String("None".into())),
+                        ("CFBundleTypeExtensions", Value::String("pdf".into())),
+                    ]),
+                ]),
+            ),
+            (
+                "CFBundleURLTypes",
+                Value::Array(vec![dictionary([(
+                    "CFBundleURLSchemes",
+                    Value::Array(vec![Value::String("HTTPS".into())]),
+                )])]),
+            ),
+        ]);
+
+        let handlers = extract_handlers(&plist);
+        assert_eq!(handlers.len(), 4);
+        assert_eq!(handlers[0].kind, AssociationKind::Extension);
+        assert_eq!(handlers[0].identifier, "md");
+        assert_eq!(handlers[0].role, HandlerRole::Editor);
+        assert_eq!(handlers[1].kind, AssociationKind::Uti);
+        assert_eq!(handlers[1].identifier, "public.text");
+        assert_eq!(handlers[2].kind, AssociationKind::Mime);
+        assert_eq!(handlers[2].identifier, "text/plain");
+        assert_eq!(handlers[3].kind, AssociationKind::UrlScheme);
+        assert_eq!(handlers[3].identifier, "https");
+        assert_eq!(handlers[3].role, HandlerRole::All);
+    }
+
+    #[test]
+    fn keeps_imported_and_exported_type_definitions_separate_from_handlers() {
+        let declaration = |identifier: &str| {
+            dictionary([
+                ("UTTypeIdentifier", Value::String(identifier.into())),
+                (
+                    "UTTypeConformsTo",
+                    Value::Array(vec![Value::String("Public.Text".into())]),
+                ),
+                (
+                    "UTTypeTagSpecification",
+                    dictionary([
+                        (
+                            "public.filename-extension",
+                            Value::Array(vec![Value::String("Example".into())]),
+                        ),
+                        (
+                            "public.mime-type",
+                            Value::Array(vec![Value::String("Text/X-Example".into())]),
+                        ),
+                    ]),
+                ),
+            ])
+        };
+        let plist = dictionary([
+            (
+                "UTExportedTypeDeclarations",
+                Value::Array(vec![declaration("Com.Example.Exported")]),
+            ),
+            (
+                "UTImportedTypeDeclarations",
+                Value::Array(vec![declaration("Com.Example.Imported")]),
+            ),
+        ]);
+
+        assert!(extract_handlers(&plist).is_empty());
+        let declarations = extract_type_declarations(&plist);
+        assert_eq!(declarations.len(), 2);
+        assert_eq!(declarations[0].identifier, "com.example.exported");
+        assert_eq!(declarations[0].source, TypeDeclarationSource::Exported);
+        assert_eq!(declarations[0].conforms_to, ["public.text"]);
+        assert_eq!(declarations[0].extensions, ["example"]);
+        assert_eq!(declarations[0].mime_types, ["text/x-example"]);
+        assert_eq!(declarations[1].source, TypeDeclarationSource::Imported);
     }
 }

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -464,6 +464,8 @@ mod tests {
             path: PathBuf::from(format!("/Applications/{name}.app")),
             bundle_id: Some(bundle_id.to_owned()),
             extensions: extensions.iter().map(|value| (*value).to_owned()).collect(),
+            handlers: Vec::new(),
+            type_declarations: Vec::new(),
         }
     }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -469,6 +469,8 @@ mod tests {
             path: PathBuf::from("/Applications/Editor.app"),
             bundle_id: Some(bundle_id.to_owned()),
             extensions: vec!["md".to_owned()],
+            handlers: Vec::new(),
+            type_declarations: Vec::new(),
         }
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -630,6 +630,9 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_profiles"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_recommend"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_drift"));
+    assert!(tools
+        .iter()
+        .any(|tool| tool["name"] == "dutis_handler_query"));
     assert!(!tools.iter().any(|tool| tool["name"] == "dutis_apply"));
     assert_eq!(
         responses[3]["result"]["structuredContent"]["data"]["approval_mode"],


### PR DESCRIPTION
## Summary
- parse role-aware extension, UTI, MIME, and URL-scheme handler declarations from application bundles
- keep imported/exported UTI definitions separate from handler capability evidence
- add compact typed handler queries to the CLI and MCP server
- document the v2.14.0 metadata model and roadmap phase

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-targets --locked --offline`
- `cargo clippy --all-targets --locked --offline -- -D warnings`
- `cargo test --all-targets --locked --offline` (102 passed)
- `cargo build --release --locked --offline`
- `cargo package --allow-dirty --locked --offline`
- read-only smoke: `dutis handler query url-scheme https --json`
- `git diff --check`