### PR TITLE
feat: add secure HTTP event adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Check packaging scripts
         run: |
           ruby -c scripts/render_homebrew_formula.rb
+          ruby scripts/render_homebrew_formula.rb \
+            2.15.0 \
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+            https://github.com/tsonglew/dutis/releases/download/v2.15.0/dutis-v2.15.0-macos-universal.tar.gz \
+            "${RUNNER_TEMP}/dutis.rb"
+          grep -F 'bin.install "dutis", "dutis-event-http"' "${RUNNER_TEMP}/dutis.rb"
           bash -n scripts/get_app_extensions.sh
           bash -n scripts/set_default_app.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,11 +175,17 @@ jobs:
             target/aarch64-apple-darwin/release/dutis \
             target/x86_64-apple-darwin/release/dutis \
             -output dist/package/dutis
-          chmod +x dist/package/dutis
+          lipo -create \
+            target/aarch64-apple-darwin/release/dutis-event-http \
+            target/x86_64-apple-darwin/release/dutis-event-http \
+            -output dist/package/dutis-event-http
+          chmod +x dist/package/dutis dist/package/dutis-event-http
           cp -R skills dist/package/skills
           cp dutis.policy.example.toml dist/package/dutis.policy.example.toml
           lipo -info dist/package/dutis
-          tar -C dist/package -czf "dist/${archive}" dutis skills dutis.policy.example.toml
+          lipo -info dist/package/dutis-event-http
+          tar -C dist/package -czf "dist/${archive}" \
+            dutis dutis-event-http skills dutis.policy.example.toml
           cd dist
           shasum -a 256 "${archive}" > "${archive}.sha256"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.14.0"
+version = "2.15.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "dutis"
-version = "2.14.0"
+version = "2.15.0"
 edition = "2021"
 rust-version = "1.88"
+default-run = "dutis"
 description = "A comprehensive macOS application File Extension Manager and default app setter written in Rust"
 authors = ["Tsong Lew <tsonglew@gmail.com>"]
 license = "MIT"
@@ -14,6 +15,10 @@ categories = ["command-line-utilities", "system"]
 [[bin]]
 name = "dutis"
 path = "src/main.rs"
+
+[[bin]]
+name = "dutis-event-http"
+path = "src/bin/dutis-event-http.rs"
 
 [dependencies]
 anyhow = "1.0"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,20 +8,21 @@
 brew install tsonglew/tap/dutis
 ```
 
-The formula installs the universal `dutis` binary and its `duti` dependency.
+The formula installs the universal `dutis` and `dutis-event-http` binaries plus
+the `duti` dependency.
 
 ## Alternative Installation Methods
 
 ### From Pre-built Binary
 
 1. Download the latest release from [GitHub Releases](https://github.com/tsonglew/dutis/releases)
-2. Extract the binary
-3. Move to a directory in your PATH:
+2. Extract the binaries
+3. Move them to a directory in your PATH:
 
    ```bash
-   sudo mv dutis /usr/local/bin/
+   sudo mv dutis dutis-event-http /usr/local/bin/
    # or
-   sudo mv dutis /opt/homebrew/bin/
+   sudo mv dutis dutis-event-http /opt/homebrew/bin/
    ```
 
 ### From Source
@@ -55,6 +56,7 @@ cargo install --path .
 
 ```bash
 dutis --help
+dutis-event-http --version
 ```
 
 ### First Run

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 - 👀 **Drift Monitoring**: Detect association changes continuously, notify through macOS, and optionally remediate through snapshots and policy
 - 🔗 **Typed Associations**: Manage extensions, UTIs, MIME types, URL schemes, and Launch Services roles through one verified pipeline
 - 📡 **Event Sinks**: Stream versioned drift and mutation lifecycle events to private JSONL logs or trusted local commands
+- 🌐 **HTTPS Event Adapter**: Forward events with environment-only credentials, bounded retries, and idempotency headers
 
 ## Installation
 
@@ -39,7 +40,8 @@ A Rust application for inspecting and safely managing macOS default handlers for
 brew install tsonglew/tap/dutis
 ```
 
-The tap installs a prebuilt universal binary for both Apple Silicon and Intel Macs, together with the `duti` runtime dependency.
+The tap installs universal `dutis` and `dutis-event-http` binaries for Apple
+Silicon and Intel Macs, together with the `duti` runtime dependency.
 
 ### Install duti
 
@@ -217,6 +219,17 @@ Event options are global and can appear before or after a subcommand. The same
 settings can be provided through `DUTIS_EVENT_LOG` and
 `DUTIS_EVENT_COMMAND`. See [event sinks](docs/event-sinks.md) for the schema,
 command contract, LaunchAgent behavior, and delivery guarantees.
+
+To forward events over HTTPS without placing credentials in Dutis arguments,
+configuration, or audit records, use the bundled
+[`dutis-event-http`](docs/http-event-adapter.md) command:
+
+```bash
+export DUTIS_HTTP_ENDPOINT='https://events.example.com/hooks/dutis'
+export DUTIS_HTTP_BEARER_TOKEN='replace-with-a-scoped-token'
+export DUTIS_EVENT_COMMAND="$(command -v dutis-event-http)"
+dutis-event-http --check --json
+```
 
 All write paths enforce the same local policy before mutation and record the
 requester, reviewed plan, result, and verification. See the

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -218,11 +218,33 @@ Acceptance criteria:
 - Role matching recognizes that an editor can satisfy a viewer query, while
   shell and editor capabilities remain distinct.
 
+## Phase 11: HTTPS event adapter
+
+Status: implemented for v2.15.0
+
+Ship an optional network adapter as an external event command while keeping
+transport secrets outside Dutis configuration, plans, and audit records.
+
+Acceptance criteria:
+
+- `dutis-event-http` receives one current-schema event on stdin and delivers an
+  HTTPS POST without gaining any mutation capability.
+- Endpoints, Bearer credentials, timeouts, and retries are configured only by
+  adapter-specific environment variables.
+- Endpoint and credential values never appear in child process arguments,
+  check output, or delivery errors; private temporary request files are removed
+  after delivery.
+- Requests include event identity and idempotency headers, enforce a bounded
+  input size, reject plaintext HTTP, do not follow redirects, and discard
+  response bodies.
+- Release archives and the Homebrew formula install both universal binaries;
+  fake-transport tests cover success, sanitization, and rejection paths.
+
 ## Near-term engineering sequence
 
-1. Release Phase 10 and validate metadata coverage across native and third-party
-   applications on supported macOS releases.
-2. Add optional network adapters as external event commands, keeping transport
-   credentials outside Dutis configuration and audit records.
-3. Explore native Launch Services read APIs for richer role-specific default
+1. Release Phase 11 and validate HTTPS delivery against representative webhook
+   receivers and long-running LaunchAgents.
+2. Explore native Launch Services read APIs for richer role-specific default
    verification where `duti` exposes only a single default handler.
+3. Add durable replay tooling for failed external event deliveries without
+   coupling observability failures to association mutations.

--- a/docs/event-sinks.md
+++ b/docs/event-sinks.md
@@ -1,6 +1,6 @@
 # Event sinks
 
-Dutis v2.13 can deliver versioned drift and mutation events to a private JSONL
+Dutis can deliver versioned drift and mutation events to a private JSONL
 file, a trusted local executable, or both. This gives agents and automation a
 stable interface without scraping terminal output or watching audit folders.
 
@@ -94,6 +94,10 @@ Example handler:
 #!/bin/sh
 exec /usr/bin/logger -t dutis-event
 ```
+
+The packaged [`dutis-event-http`](http-event-adapter.md) command provides an
+HTTPS adapter with environment-only endpoint and credential configuration,
+sanitized errors, timeouts, retries, and idempotency headers.
 
 ## Failure behavior
 

--- a/docs/homebrew-installation.md
+++ b/docs/homebrew-installation.md
@@ -15,6 +15,9 @@ $(brew --prefix dutis)/share/dutis/skills/dutis
 The policy example is installed at
 `$(brew --prefix dutis)/share/dutis/dutis.policy.example.toml`.
 
+The formula also installs `dutis-event-http`, the optional HTTPS adapter for
+event-command sinks.
+
 To make it discoverable by Codex, link it into your personal skills directory:
 
 ```bash
@@ -27,7 +30,8 @@ ln -s "$(brew --prefix dutis)/share/dutis/skills/dutis" ~/.codex/skills/dutis
 When you install `dutis` via Homebrew:
 
 1. **Automatic Dependencies**: Homebrew installs the required `duti` runtime dependency
-2. **Binary Installation**: Downloads and installs a universal binary for Intel and Apple Silicon Macs
+2. **Binary Installation**: Downloads and installs universal `dutis` and
+   `dutis-event-http` binaries for Intel and Apple Silicon Macs
 3. **Path Setup**: Adds `dutis` to your system PATH
 4. **Updates**: Easy updates with `brew upgrade dutis`
 

--- a/docs/http-event-adapter.md
+++ b/docs/http-event-adapter.md
@@ -1,0 +1,92 @@
+# HTTP event adapter
+
+Dutis v2.15 includes `dutis-event-http`, an optional external event command
+that forwards versioned Dutis events to an HTTPS endpoint. It does not change
+the core event-sink trust boundary: delivery remains best effort and cannot
+authorize, alter, or roll back a mutation.
+
+## Quick start
+
+Configure the adapter through its environment, validate it without making a
+network request, then select the executable as the Dutis command sink:
+
+```bash
+export DUTIS_HTTP_ENDPOINT='https://events.example.com/hooks/dutis'
+export DUTIS_HTTP_BEARER_TOKEN='replace-with-a-scoped-token'
+export DUTIS_EVENT_COMMAND="$(command -v dutis-event-http)"
+
+dutis-event-http --check --json
+dutis watch dutis.toml --once --json
+```
+
+The check result reports only whether authentication is configured, never the
+endpoint or token.
+
+## Configuration
+
+| Environment variable | Required | Default | Meaning |
+| --- | --- | --- | --- |
+| `DUTIS_HTTP_ENDPOINT` | Yes | — | Absolute `https://` destination |
+| `DUTIS_HTTP_BEARER_TOKEN` | No | — | Value for the `Authorization: Bearer ...` header |
+| `DUTIS_HTTP_TIMEOUT_SECONDS` | No | `10` | Total request timeout, from 1 to 300 seconds |
+| `DUTIS_HTTP_RETRIES` | No | `2` | Curl retry count, from 0 to 10 |
+
+Configuration is deliberately unavailable as Dutis CLI arguments or TOML.
+This keeps webhook URLs and credentials out of shell history, plans, policy,
+snapshots, audit records, and event payloads. Use a narrowly scoped token and
+rotate it independently from Dutis approval tokens.
+
+The adapter uses `/usr/bin/curl`. `DUTIS_HTTP_CURL` can select another absolute
+executable for controlled testing, but should normally remain unset.
+
+## Request contract
+
+For each event, the adapter:
+
+- accepts one JSON event on stdin, up to 1 MiB;
+- requires the current event schema version and a header-safe event ID;
+- sends an HTTPS `POST` with `Content-Type: application/json`;
+- sets `X-Dutis-Event-Id`, `X-Dutis-Event-Type`, and `Idempotency-Key` headers;
+- optionally sets the Bearer authorization header;
+- does not follow redirects and restricts curl to HTTPS;
+- disables the user's ambient `.curlrc` before loading its private request
+  configuration;
+- discards response bodies and exits non-zero for HTTP or transport failures.
+
+Retries can result in repeated delivery when the remote server processes a
+request but the response is lost. Consumers should deduplicate using the event
+ID or `Idempotency-Key`.
+
+The endpoint and token are written only to an owner-readable temporary curl
+configuration file for the lifetime of the request. They are not placed in
+curl's process arguments, are removed from curl's child environment, and are
+not echoed when delivery fails. The event body uses a separate owner-readable
+temporary file. Both files and their private directory are removed after curl
+exits.
+
+## LaunchAgent credentials
+
+Dutis intentionally does not copy HTTP credentials into its LaunchAgent
+plist. For background delivery, point `DUTIS_EVENT_COMMAND` at a small trusted
+wrapper that reads credentials from macOS Keychain and then replaces itself
+with the adapter:
+
+```sh
+#!/bin/sh
+set -eu
+export DUTIS_HTTP_ENDPOINT="$(security find-generic-password -a "$USER" -s dutis-http-endpoint -w)"
+export DUTIS_HTTP_BEARER_TOKEN="$(security find-generic-password -a "$USER" -s dutis-http-token -w)"
+exec /opt/homebrew/bin/dutis-event-http
+```
+
+Store the wrapper at an absolute path with owner-only write permissions, make
+it executable, and reinstall the Dutis LaunchAgent after setting
+`DUTIS_EVENT_COMMAND` to that path. The wrapper contains only Keychain item
+names, not credentials.
+
+## Delivery semantics
+
+The adapter is synchronous and has no durable queue. A failure becomes the
+same best-effort warning as any other event-command failure; Dutis continues
+its primary operation. Use the JSONL sink alongside the adapter when local
+replay or durable delivery is required.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,8 +4,9 @@ Merges into `master` trigger `.github/workflows/release.yml`. The workflow:
 
 1. Reads the version from `Cargo.toml` and creates the matching `vX.Y.Z` tag if it does not exist.
 2. Runs formatting, Clippy, and unit tests.
-3. Builds Intel and Apple Silicon binaries, combines them into one universal
-   macOS binary, and packages the bundled Dutis agent skill.
+3. Builds Intel and Apple Silicon binaries, combines `dutis` and
+   `dutis-event-http` into universal macOS binaries, and packages the bundled
+   Dutis agent skill.
 4. Publishes the archive and SHA-256 checksum to GitHub Releases.
 5. Updates `Formula/dutis.rb` in `tsonglew/homebrew-tap`.
 
@@ -40,5 +41,6 @@ After the workflow succeeds, verify installation in a clean environment:
 brew update
 brew install tsonglew/tap/dutis
 dutis --help
+dutis-event-http --version
 test -f "$(brew --prefix dutis)/share/dutis/skills/dutis/SKILL.md"
 ```

--- a/scripts/render_homebrew_formula.rb
+++ b/scripts/render_homebrew_formula.rb
@@ -19,13 +19,14 @@ formula = <<~RUBY
     depends_on :macos
 
     def install
-      bin.install "dutis"
+      bin.install "dutis", "dutis-event-http"
       pkgshare.install "skills"
       pkgshare.install "dutis.policy.example.toml"
     end
 
     test do
       assert_match version.to_s, shell_output("\#{bin}/dutis --version")
+      assert_match version.to_s, shell_output("\#{bin}/dutis-event-http --version")
     end
   end
 RUBY

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -38,6 +38,12 @@ code: require a user-chosen trusted absolute path, and never generate or enable
 one implicitly. Events may contain application paths, bundle IDs, requester
 identity, and complete plans, but never approval tokens.
 
+For HTTPS delivery, prefer the packaged `dutis-event-http` external command.
+Keep `DUTIS_HTTP_ENDPOINT` and `DUTIS_HTTP_BEARER_TOKEN` out of Dutis TOML,
+plans, prompts, and audit records. Run `dutis-event-http --check --json` before
+enabling it, and use a Keychain-backed wrapper for a LaunchAgent rather than
+persisting transport credentials in its plist.
+
 For monitoring requests, use `dutis_drift` or `dutis watch <config> --once`
 first. Explain whether the report is `in_sync`, `drift_detected`, or
 `unresolved`. Do not enable `--remediate` or install a remediating LaunchAgent

--- a/src/bin/dutis-event-http.rs
+++ b/src/bin/dutis-event-http.rs
@@ -1,0 +1,55 @@
+use clap::Parser;
+use dutis::http_adapter::HttpAdapterConfig;
+use serde_json::json;
+use std::process::ExitCode;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "dutis-event-http",
+    version,
+    about = "Forward Dutis events to an HTTPS endpoint"
+)]
+struct Cli {
+    /// Validate environment configuration without sending an event
+    #[arg(long)]
+    check: bool,
+    /// Emit a machine-readable result; only valid with --check
+    #[arg(long, requires = "check")]
+    json: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match run(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("dutis-event-http: {error:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(cli: Cli) -> anyhow::Result<()> {
+    let config = HttpAdapterConfig::from_environment()?;
+    if cli.check {
+        let status = config.status();
+        if cli.json {
+            println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "api_version": "1",
+                    "command": "check",
+                    "data": status,
+                }))?
+            );
+        } else {
+            println!("HTTP event adapter configuration is valid.");
+            println!("Transport: {}", status.transport);
+            println!("Authentication: {}", status.authentication);
+            println!("Timeout: {} seconds", status.timeout_seconds);
+            println!("Retries: {}", status.retries);
+        }
+        return Ok(());
+    }
+    config.deliver(std::io::stdin().lock())
+}

--- a/src/http_adapter.rs
+++ b/src/http_adapter.rs
@@ -1,0 +1,437 @@
+use crate::events::{EventEnvelope, EVENT_SCHEMA_VERSION};
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+use serde_json::Value;
+use std::env;
+use std::fs::{self, DirBuilder, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const HTTP_ENDPOINT_ENV: &str = "DUTIS_HTTP_ENDPOINT";
+pub const HTTP_BEARER_TOKEN_ENV: &str = "DUTIS_HTTP_BEARER_TOKEN";
+pub const HTTP_TIMEOUT_ENV: &str = "DUTIS_HTTP_TIMEOUT_SECONDS";
+pub const HTTP_RETRIES_ENV: &str = "DUTIS_HTTP_RETRIES";
+pub const HTTP_CURL_ENV: &str = "DUTIS_HTTP_CURL";
+pub const MAX_EVENT_BYTES: u64 = 1024 * 1024;
+
+const DEFAULT_TIMEOUT_SECONDS: u64 = 10;
+const MAX_TIMEOUT_SECONDS: u64 = 300;
+const DEFAULT_RETRIES: u32 = 2;
+const MAX_RETRIES: u32 = 10;
+const DEFAULT_CURL_PATH: &str = "/usr/bin/curl";
+
+static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone)]
+pub struct HttpAdapterConfig {
+    endpoint: String,
+    bearer_token: Option<String>,
+    timeout_seconds: u64,
+    retries: u32,
+    curl: PathBuf,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct HttpAdapterStatus {
+    pub schema_version: u32,
+    pub transport: &'static str,
+    pub authentication: &'static str,
+    pub timeout_seconds: u64,
+    pub retries: u32,
+    pub curl_available: bool,
+}
+
+impl HttpAdapterConfig {
+    pub fn from_environment() -> Result<Self> {
+        let endpoint = required_environment_value(HTTP_ENDPOINT_ENV)?;
+        validate_endpoint(&endpoint)?;
+        let bearer_token = optional_environment_value(HTTP_BEARER_TOKEN_ENV);
+        if let Some(token) = &bearer_token {
+            validate_single_line_secret(HTTP_BEARER_TOKEN_ENV, token)?;
+        }
+        let timeout_seconds = numeric_environment_value(
+            HTTP_TIMEOUT_ENV,
+            DEFAULT_TIMEOUT_SECONDS,
+            1,
+            MAX_TIMEOUT_SECONDS,
+        )?;
+        let retries = numeric_environment_value(HTTP_RETRIES_ENV, DEFAULT_RETRIES, 0, MAX_RETRIES)?;
+        let curl = env::var_os(HTTP_CURL_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_CURL_PATH));
+        validate_curl(&curl)?;
+        Ok(Self {
+            endpoint,
+            bearer_token,
+            timeout_seconds,
+            retries,
+            curl,
+        })
+    }
+
+    pub fn status(&self) -> HttpAdapterStatus {
+        HttpAdapterStatus {
+            schema_version: 1,
+            transport: "https",
+            authentication: if self.bearer_token.is_some() {
+                "bearer"
+            } else {
+                "none"
+            },
+            timeout_seconds: self.timeout_seconds,
+            retries: self.retries,
+            curl_available: true,
+        }
+    }
+
+    pub fn deliver<R: Read>(&self, reader: R) -> Result<()> {
+        let (event, encoded) = read_event(reader)?;
+        let request = PrivateRequest::create(&encoded)?;
+        let curl_config = self.render_curl_config(&event, request.body())?;
+        request.write_config(curl_config.as_bytes())?;
+
+        let output = Command::new(&self.curl)
+            .arg("--disable")
+            .arg("--config")
+            .arg(request.config())
+            .env_remove(HTTP_ENDPOINT_ENV)
+            .env_remove(HTTP_BEARER_TOKEN_ENV)
+            .env_remove("DUTIS_APPROVAL_TOKEN")
+            .env_remove("DUTIS_MCP_APPROVAL_TOKEN")
+            .env_remove("DUTIS_WATCH_APPROVAL_TOKEN")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .context("failed to start the HTTP transport")?;
+        if !output.status.success() {
+            bail!(
+                "HTTP event delivery failed with transport status {}",
+                output.status
+            );
+        }
+        Ok(())
+    }
+
+    fn render_curl_config(&self, event: &EventEnvelope, body: &Path) -> Result<String> {
+        let event_type = serde_json::to_value(event.event_type)?;
+        let event_type = event_type
+            .as_str()
+            .context("event type did not serialize as a string")?;
+        let mut lines = vec![
+            config_line("url", &self.endpoint),
+            config_line("request", "POST"),
+            config_line("header", "Content-Type: application/json"),
+            config_line("header", "Accept: application/json"),
+            config_line("header", &format!("X-Dutis-Event-Id: {}", event.id)),
+            config_line("header", &format!("X-Dutis-Event-Type: {event_type}")),
+            config_line("header", &format!("Idempotency-Key: {}", event.id)),
+            config_line("data-binary", &format!("@{}", body.display())),
+            config_line(
+                "user-agent",
+                &format!("dutis-event-http/{}", env!("CARGO_PKG_VERSION")),
+            ),
+            config_line("connect-timeout", &self.timeout_seconds.min(5).to_string()),
+            config_line("max-time", &self.timeout_seconds.to_string()),
+            config_line("retry", &self.retries.to_string()),
+            config_line("retry-max-time", &self.timeout_seconds.to_string()),
+            config_line("proto", "=https"),
+            "fail".to_owned(),
+            "silent".to_owned(),
+            "show-error".to_owned(),
+            config_line("output", "/dev/null"),
+        ];
+        if let Some(token) = &self.bearer_token {
+            lines.insert(
+                7,
+                config_line("header", &format!("Authorization: Bearer {token}")),
+            );
+        }
+        lines.push(String::new());
+        Ok(lines.join("\n"))
+    }
+}
+
+fn required_environment_value(name: &str) -> Result<String> {
+    optional_environment_value(name).with_context(|| format!("{name} is required"))
+}
+
+fn optional_environment_value(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.trim().is_empty())
+}
+
+fn numeric_environment_value<T>(name: &str, default: T, minimum: T, maximum: T) -> Result<T>
+where
+    T: Copy + Ord + std::str::FromStr + std::fmt::Display,
+{
+    let Some(value) = optional_environment_value(name) else {
+        return Ok(default);
+    };
+    let parsed = value
+        .parse::<T>()
+        .map_err(|_| anyhow::anyhow!("{name} must be an integer"))?;
+    if parsed < minimum || parsed > maximum {
+        bail!("{name} must be between {minimum} and {maximum}");
+    }
+    Ok(parsed)
+}
+
+fn validate_endpoint(endpoint: &str) -> Result<()> {
+    validate_single_line_secret(HTTP_ENDPOINT_ENV, endpoint)?;
+    let authority = endpoint
+        .strip_prefix("https://")
+        .context("DUTIS_HTTP_ENDPOINT must be an absolute HTTPS URL")?;
+    if authority.is_empty()
+        || authority.starts_with('/')
+        || authority.chars().any(char::is_whitespace)
+    {
+        bail!("DUTIS_HTTP_ENDPOINT must be an absolute HTTPS URL");
+    }
+    Ok(())
+}
+
+fn validate_single_line_secret(name: &str, value: &str) -> Result<()> {
+    if value
+        .chars()
+        .any(|character| matches!(character, '\r' | '\n' | '\0'))
+    {
+        bail!("{name} must contain a single non-NUL line");
+    }
+    Ok(())
+}
+
+fn validate_curl(path: &Path) -> Result<()> {
+    if !path.is_absolute() || !path.is_file() {
+        bail!("DUTIS_HTTP_CURL must be an existing absolute executable");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if fs::metadata(path)?.permissions().mode() & 0o111 == 0 {
+            bail!("DUTIS_HTTP_CURL must be an existing absolute executable");
+        }
+    }
+    Ok(())
+}
+
+fn read_event<R: Read>(reader: R) -> Result<(EventEnvelope, Vec<u8>)> {
+    let mut encoded = Vec::new();
+    reader
+        .take(MAX_EVENT_BYTES + 1)
+        .read_to_end(&mut encoded)
+        .context("failed to read the event from stdin")?;
+    if encoded.len() as u64 > MAX_EVENT_BYTES {
+        bail!("event exceeds the {MAX_EVENT_BYTES}-byte input limit");
+    }
+    let value: Value =
+        serde_json::from_slice(&encoded).context("stdin must contain one JSON event")?;
+    let event: EventEnvelope =
+        serde_json::from_value(value.clone()).context("stdin is not a valid Dutis event")?;
+    if event.schema_version != EVENT_SCHEMA_VERSION {
+        bail!(
+            "unsupported event schema version {}; expected {}",
+            event.schema_version,
+            EVENT_SCHEMA_VERSION
+        );
+    }
+    validate_event_id(&event.id)?;
+    let mut canonical = serde_json::to_vec(&value).context("failed to encode the event")?;
+    canonical.push(b'\n');
+    Ok((event, canonical))
+}
+
+fn validate_event_id(id: &str) -> Result<()> {
+    if id.is_empty()
+        || id.len() > 256
+        || !id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        bail!(
+            "event ID must contain 1 to 256 ASCII letters, numbers, dots, underscores, or hyphens"
+        );
+    }
+    Ok(())
+}
+
+fn config_line(name: &str, value: &str) -> String {
+    format!("{name} = \"{}\"", escape_curl_config(value))
+}
+
+fn escape_curl_config(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+struct PrivateRequest {
+    directory: PathBuf,
+    body: PathBuf,
+    config: PathBuf,
+}
+
+impl PrivateRequest {
+    fn create(body: &[u8]) -> Result<Self> {
+        let directory = create_private_directory()?;
+        let request = Self {
+            body: directory.join("event.json"),
+            config: directory.join("curl.conf"),
+            directory,
+        };
+        write_private_file(&request.body, body)?;
+        Ok(request)
+    }
+
+    fn body(&self) -> &Path {
+        &self.body
+    }
+
+    fn config(&self) -> &Path {
+        &self.config
+    }
+
+    fn write_config(&self, contents: &[u8]) -> Result<()> {
+        write_private_file(&self.config, contents)
+    }
+}
+
+impl Drop for PrivateRequest {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.config);
+        let _ = fs::remove_file(&self.body);
+        let _ = fs::remove_dir(&self.directory);
+    }
+}
+
+fn create_private_directory() -> Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_nanos();
+    for _ in 0..128 {
+        let sequence = REQUEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let path = env::temp_dir().join(format!(
+            "dutis-event-http-{}-{timestamp}-{sequence}",
+            std::process::id()
+        ));
+        let mut builder = DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        match builder.create(&path) {
+            Ok(()) => return Ok(path),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).context("failed to create a private request directory");
+            }
+        }
+    }
+    bail!("failed to allocate a private request directory")
+}
+
+fn write_private_file(path: &Path, contents: &[u8]) -> Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| "failed to create a private request file")?;
+    file.write_all(contents)
+        .context("failed to write a private request file")?;
+    file.flush()
+        .context("failed to flush a private request file")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event_json(schema_version: u32) -> String {
+        format!(
+            r#"{{"schema_version":{schema_version},"id":"event-1","emitted_at":"2026-08-23T00:00:00Z","event_type":"drift.checked","source":"watcher","payload":{{"state":"in_sync"}}}}"#
+        )
+    }
+
+    #[test]
+    fn reads_one_supported_event_and_preserves_unknown_fields() {
+        let input = event_json(EVENT_SCHEMA_VERSION)
+            .replace("\"payload\"", "\"future_field\":true,\"payload\"");
+        let (event, encoded) = read_event(input.as_bytes()).unwrap();
+        assert_eq!(event.id, "event-1");
+        let value: Value = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(value["future_field"], true);
+    }
+
+    #[test]
+    fn rejects_unsupported_schema_and_oversized_input() {
+        assert!(read_event(event_json(99).as_bytes())
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported event schema"));
+        let oversized = vec![b' '; MAX_EVENT_BYTES as usize + 1];
+        assert!(read_event(oversized.as_slice())
+            .unwrap_err()
+            .to_string()
+            .contains("input limit"));
+    }
+
+    #[test]
+    fn rejects_event_id_header_injection() {
+        let input =
+            event_json(EVENT_SCHEMA_VERSION).replace("event-1", "event-1\\r\\nInjected: yes");
+        assert!(read_event(input.as_bytes())
+            .unwrap_err()
+            .to_string()
+            .contains("event ID"));
+    }
+
+    #[test]
+    fn escapes_curl_config_values() {
+        assert_eq!(escape_curl_config(r#"a\b"c"#), r#"a\\b\"c"#);
+    }
+
+    #[test]
+    fn endpoint_requires_https_and_rejects_line_breaks() {
+        assert!(validate_endpoint("http://example.com").is_err());
+        assert!(validate_endpoint("https://example.com\nheader: value").is_err());
+        assert!(validate_endpoint("https://example.com/hook").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn request_files_are_private_and_removed_on_drop() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory;
+        let body;
+        {
+            let request = PrivateRequest::create(b"{}\n").unwrap();
+            request.write_config(b"silent\n").unwrap();
+            directory = request.directory.clone();
+            body = request.body.clone();
+            assert_eq!(
+                fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(&body).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+            assert_eq!(
+                fs::metadata(request.config()).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        assert!(!body.exists());
+        assert!(!directory.exists());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod drift;
 pub mod events;
 pub mod governance;
+pub mod http_adapter;
 pub mod launch_agent;
 pub mod mcp;
 pub mod planner;

--- a/tests/http_adapter.rs
+++ b/tests/http_adapter.rs
@@ -1,0 +1,250 @@
+#![cfg(unix)]
+
+use serde_json::{json, Value};
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const ENDPOINT: &str = "https://hooks.example.invalid/private/path?key=endpoint-secret";
+const TOKEN: &str = "adapter-bearer-secret";
+
+fn adapter() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_dutis-event-http"))
+}
+
+fn dutis() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_dutis"))
+}
+
+fn temp_root(label: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "dutis-http-adapter-{label}-{}-{unique}",
+        std::process::id()
+    ));
+    fs::create_dir(&root).unwrap();
+    root
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+}
+
+fn event() -> Value {
+    json!({
+        "schema_version": 1,
+        "id": "event-123",
+        "emitted_at": "2026-08-23T00:00:00Z",
+        "event_type": "mutation.completed",
+        "source": "governance",
+        "payload": {"audit_id": "audit-123"}
+    })
+}
+
+#[test]
+fn forwards_event_without_exposing_transport_secrets_in_arguments_or_environment() {
+    let root = temp_root("success");
+    let fake_curl = root.join("curl");
+    let captured_arguments = root.join("arguments");
+    let captured_config = root.join("config");
+    let captured_body = root.join("body");
+    let captured_environment = root.join("environment");
+    write_executable(
+        &fake_curl,
+        concat!(
+            "#!/bin/sh\n",
+            "printf '%s\\n' \"$@\" > \"$DUTIS_CAPTURE_ARGUMENTS\"\n",
+            "/bin/cp \"$3\" \"$DUTIS_CAPTURE_CONFIG\"\n",
+            "body_path=$(/usr/bin/sed -n 's/^data-binary = \"@\\(.*\\)\"$/\\1/p' \"$3\")\n",
+            "/bin/cp \"$body_path\" \"$DUTIS_CAPTURE_BODY\"\n",
+            "printf '%s|%s' \"${DUTIS_HTTP_ENDPOINT-unset}\" \"${DUTIS_HTTP_BEARER_TOKEN-unset}\" > \"$DUTIS_CAPTURE_ENVIRONMENT\"\n",
+        ),
+    );
+    let input = serde_json::to_vec(&event()).unwrap();
+    let mut child = adapter()
+        .env("DUTIS_HTTP_ENDPOINT", ENDPOINT)
+        .env("DUTIS_HTTP_BEARER_TOKEN", TOKEN)
+        .env("DUTIS_HTTP_CURL", &fake_curl)
+        .env("DUTIS_CAPTURE_ARGUMENTS", &captured_arguments)
+        .env("DUTIS_CAPTURE_CONFIG", &captured_config)
+        .env("DUTIS_CAPTURE_BODY", &captured_body)
+        .env("DUTIS_CAPTURE_ENVIRONMENT", &captured_environment)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(&input).unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+
+    let arguments = fs::read_to_string(&captured_arguments).unwrap();
+    assert!(arguments.starts_with("--disable\n--config\n"));
+    assert!(!arguments.contains(ENDPOINT));
+    assert!(!arguments.contains(TOKEN));
+    let config_path = PathBuf::from(arguments.lines().nth(2).unwrap());
+    assert!(!config_path.exists());
+
+    let config = fs::read_to_string(&captured_config).unwrap();
+    assert!(config.contains(&format!("url = \"{ENDPOINT}\"")));
+    assert!(config.contains(&format!("Authorization: Bearer {TOKEN}")));
+    assert!(config.contains("X-Dutis-Event-Id: event-123"));
+    assert!(config.contains("Idempotency-Key: event-123"));
+    assert_eq!(
+        serde_json::from_slice::<Value>(&fs::read(&captured_body).unwrap()).unwrap(),
+        event()
+    );
+    assert_eq!(
+        fs::read_to_string(&captured_environment).unwrap(),
+        "unset|unset"
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn check_is_sanitized_and_delivery_failure_does_not_echo_secrets() {
+    let root = temp_root("sanitized");
+    let fake_curl = root.join("curl");
+    write_executable(
+        &fake_curl,
+        concat!(
+            "#!/bin/sh\n",
+            "printf 'https://leaked.example/private adapter-bearer-secret\\n' >&2\n",
+            "exit 22\n",
+        ),
+    );
+    let check = adapter()
+        .env("DUTIS_HTTP_ENDPOINT", ENDPOINT)
+        .env("DUTIS_HTTP_BEARER_TOKEN", TOKEN)
+        .env("DUTIS_HTTP_CURL", &fake_curl)
+        .args(["--check", "--json"])
+        .output()
+        .unwrap();
+    assert!(check.status.success());
+    let status: Value = serde_json::from_slice(&check.stdout).unwrap();
+    assert_eq!(status["data"]["transport"], "https");
+    assert_eq!(status["data"]["authentication"], "bearer");
+    let rendered = String::from_utf8(check.stdout).unwrap();
+    assert!(!rendered.contains(ENDPOINT));
+    assert!(!rendered.contains(TOKEN));
+
+    let mut child = adapter()
+        .env("DUTIS_HTTP_ENDPOINT", ENDPOINT)
+        .env("DUTIS_HTTP_BEARER_TOKEN", TOKEN)
+        .env("DUTIS_HTTP_CURL", &fake_curl)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(&serde_json::to_vec(&event()).unwrap())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("transport status"));
+    assert!(!stderr.contains(ENDPOINT));
+    assert!(!stderr.contains(TOKEN));
+    assert!(!stderr.contains("leaked.example"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn rejects_plain_http_before_starting_transport() {
+    let root = temp_root("https-only");
+    let fake_curl = root.join("curl");
+    let marker = root.join("called");
+    write_executable(&fake_curl, "#!/bin/sh\ntouch \"$DUTIS_CALLED\"\n");
+    let output = adapter()
+        .env("DUTIS_HTTP_ENDPOINT", "http://example.invalid/hook")
+        .env("DUTIS_HTTP_CURL", &fake_curl)
+        .env("DUTIS_CALLED", &marker)
+        .args(["--check"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(!marker.exists());
+    assert!(String::from_utf8(output.stderr)
+        .unwrap()
+        .contains("absolute HTTPS URL"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn watcher_event_flows_through_external_adapter_to_transport() {
+    let root = temp_root("full-chain");
+    let bin = root.join("bin");
+    fs::create_dir(&bin).unwrap();
+    let fake_duti = bin.join("duti");
+    write_executable(
+        &fake_duti,
+        concat!(
+            "#!/bin/sh\n",
+            "if [ \"$1\" = \"-V\" ]; then printf 'test-duti\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-x\" ]; then printf 'Other\\n/Applications/Other.app\\ncom.example.Other\\n'; exit 0; fi\n",
+            "exit 99\n",
+        ),
+    );
+    let fake_curl = root.join("curl");
+    write_executable(
+        &fake_curl,
+        concat!(
+            "#!/bin/sh\n",
+            "body_path=$(/usr/bin/sed -n 's/^data-binary = \"@\\(.*\\)\"$/\\1/p' \"$3\")\n",
+            "/bin/cp \"$body_path\" \"$DUTIS_CAPTURE_BODY\"\n",
+        ),
+    );
+    let config = root.join("dutis.toml");
+    fs::write(
+        &config,
+        "version = 1\n[associations]\nmd = 'com.apple.TextEdit'\n",
+    )
+    .unwrap();
+    let captured_body = root.join("body");
+
+    let output = dutis()
+        .env("PATH", &bin)
+        .env("DUTIS_STATE_DIR", root.join("state"))
+        .env("DUTIS_HTTP_ENDPOINT", ENDPOINT)
+        .env("DUTIS_HTTP_BEARER_TOKEN", TOKEN)
+        .env("DUTIS_HTTP_CURL", &fake_curl)
+        .env("DUTIS_CAPTURE_BODY", &captured_body)
+        .args([
+            "--event-command",
+            env!("CARGO_BIN_EXE_dutis-event-http"),
+            "watch",
+            config.to_str().unwrap(),
+            "--once",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let event: Value = serde_json::from_slice(&fs::read(captured_body).unwrap()).unwrap();
+    assert_eq!(event["event_type"], "drift.checked");
+    assert_eq!(event["source"], "watcher");
+    assert_eq!(event["payload"]["state"], "drift_detected");
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
## Summary
- ship `dutis-event-http` as an external HTTPS event-command adapter
- keep endpoint and Bearer credentials in adapter environment only, out of Dutis plans and audit records
- validate schema and event IDs, enforce a 1 MiB limit, HTTPS-only delivery, bounded timeouts/retries, and idempotency headers
- keep secrets out of curl arguments, child environment, check output, and delivery errors using private request files
- package both universal binaries and install both through Homebrew
- document foreground and Keychain-backed LaunchAgent setup

## Verification
- `cargo fmt --all -- --check`
- `cargo check --all-targets --locked --offline`
- `cargo clippy --all-targets --locked --offline -- -D warnings`
- `cargo test --all-targets --locked --offline` (112 passed)
- full chain: watcher -> command sink -> `dutis-event-http` -> fake curl
- `cargo build --release --bins --locked --offline`
- real `/usr/bin/curl` configuration check via `dutis-event-http --check --json`
- `cargo package --allow-dirty --locked --offline`
- Homebrew formula render validation
- `git diff --check`