### PR TITLE
feat: add native role-aware handler reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
       - name: Check packaging scripts
         run: |
           ruby -c scripts/render_homebrew_formula.rb
+          package_version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
           ruby scripts/render_homebrew_formula.rb \
-            2.15.0 \
+            "${package_version}" \
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
-            https://github.com/tsonglew/dutis/releases/download/v2.15.0/dutis-v2.15.0-macos-universal.tar.gz \
+            "https://github.com/tsonglew/dutis/releases/download/v${package_version}/dutis-v${package_version}-macos-universal.tar.gz" \
             "${RUNNER_TEMP}/dutis.rb"
           grep -F 'bin.install "dutis", "dutis-event-http"' "${RUNNER_TEMP}/dutis.rb"
           bash -n scripts/get_app_extensions.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.15.0"
+version = "2.16.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.15.0"
+version = "2.16.0"
 edition = "2021"
 rust-version = "1.88"
 default-run = "dutis"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 - 🔗 **Typed Associations**: Manage extensions, UTIs, MIME types, URL schemes, and Launch Services roles through one verified pipeline
 - 📡 **Event Sinks**: Stream versioned drift and mutation lifecycle events to private JSONL logs or trusted local commands
 - 🌐 **HTTPS Event Adapter**: Forward events with environment-only credentials, bounded retries, and idempotency headers
+- 🍎 **Native Role Inspection**: Read separate viewer, editor, and shell defaults directly from macOS Launch Services
 
 ## Installation
 
@@ -100,6 +101,7 @@ dutis handler query url-scheme https
 dutis handler get uti public.plain-text --role viewer
 dutis handler get mime text/plain --role editor
 dutis handler get url-scheme https
+dutis handler defaults extension txt --json
 
 # Emit a versioned JSON response
 dutis query json --json
@@ -139,6 +141,10 @@ Info.plist declarations. Full `list --json` output also includes each
 application's registered handlers and imported/exported type definitions. See
 [application metadata](docs/application-metadata.md) for evidence and role
 matching rules.
+
+Role-specific `handler get` queries and verification use native macOS Launch
+Services reads. `handler defaults` returns the complete role matrix. See
+[native Launch Services reads](docs/native-launch-services.md).
 
 Create, inspect, and restore local snapshots:
 

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -240,11 +240,30 @@ Acceptance criteria:
 - Release archives and the Homebrew formula install both universal binaries;
   fake-transport tests cover success, sanitization, and rejection paths.
 
+## Phase 12: Native role-aware reads
+
+Status: implemented for v2.16.0
+
+Use macOS Launch Services directly where `duti` cannot distinguish default
+handlers by role, while retaining `duti` as the mutation backend.
+
+Acceptance criteria:
+
+- Resolve extensions and MIME types to UTIs through Core Services and query
+  content defaults for `all`, `viewer`, `editor`, and `shell` roles.
+- Query URL-scheme defaults through the native Launch Services API.
+- CLI and MCP expose a read-only default-role matrix with explicit null values
+  for roles that have no registered default.
+- Role-specific get, planning, drift, snapshot, and post-write verification use
+  native reads by default so verification observes the requested role.
+- An explicit backend override supports compatibility diagnostics without
+  weakening mutation, policy, audit, or snapshot boundaries.
+
 ## Near-term engineering sequence
 
-1. Release Phase 11 and validate HTTPS delivery against representative webhook
-   receivers and long-running LaunchAgents.
-2. Explore native Launch Services read APIs for richer role-specific default
-   verification where `duti` exposes only a single default handler.
-3. Add durable replay tooling for failed external event deliveries without
+1. Release Phase 12 and validate native role results across supported macOS
+   releases and managed-device configurations.
+2. Add durable replay tooling for failed external event deliveries without
    coupling observability failures to association mutations.
+3. Add policy-aware application recommendation inputs for teams and managed
+   fleets without introducing a remote control plane.

--- a/docs/application-metadata.md
+++ b/docs/application-metadata.md
@@ -15,6 +15,11 @@ dutis handler query mime text/plain --role editor --json
 dutis handler query url-scheme https --json
 ```
 
+Declared capability and the current default are different facts. Use
+`dutis handler defaults <kind> <identifier> --json` to inspect the native
+role-specific defaults described in
+[native Launch Services reads](native-launch-services.md).
+
 The MCP equivalent is `dutis_handler_query`, with `kind`, `identifier`, and an
 optional `role`. Identifiers use the same normalization and validation as
 planning and mutation commands.

--- a/docs/declarative-configuration.md
+++ b/docs/declarative-configuration.md
@@ -110,6 +110,10 @@ per-entry result, and exits with code `8` when any item fails. Entries already
 in the desired state are skipped, so reapplying a converged configuration is a
 no-op.
 
+On macOS, entries with a specific `viewer`, `editor`, or `shell` role are read
+back through native Launch Services rather than the role-insensitive `duti -d`
+query. See [native Launch Services reads](native-launch-services.md).
+
 Before the first mutation, Dutis evaluates the plan against the effective local
 policy and creates a persistent pending audit record. Policy denial uses exit
 code `9` and no association is changed. See

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -40,6 +40,8 @@ The server advertises these read tools:
   extension, UTI, MIME type, URL scheme, and compatible role.
 - `dutis_handler_get`: inspect an extension, UTI, MIME type, or URL scheme with
   an optional `all`, `viewer`, `editor`, or `shell` role.
+- `dutis_handler_defaults`: read the complete role-specific default matrix
+  directly from macOS Launch Services.
 - `dutis_diff`: parse inline versioned TOML and return a deterministic plan.
 - `dutis_history`: list local safety snapshots.
 - `dutis_rollback_plan`: preview a snapshot rollback and return its digest.
@@ -52,6 +54,11 @@ optional `role` fields. The kind uses `url_scheme` in JSON; URL schemes accept
 only the default `all` role. `dutis_diff` accepts `config_toml` rather than a
 filesystem path. This keeps the MCP surface independent from unrestricted file
 access and makes the exact input part of the reviewed tool call.
+
+`dutis_handler_defaults` accepts `kind` and `identifier` without a role. It
+returns every applicable native role and the resolved content type for
+extension and MIME queries. See
+[native Launch Services reads](native-launch-services.md).
 
 Profile recommendations are also read-only. A recommendation is evidence, not
 approval: it does not register a mutation tool call or change an association.

--- a/docs/native-launch-services.md
+++ b/docs/native-launch-services.md
@@ -1,0 +1,82 @@
+# Native Launch Services reads
+
+Dutis v2.16 reads role-specific default handlers directly from macOS Launch
+Services. This closes an important gap in `duti`: a single `duti -d` response
+cannot distinguish viewer, editor, and shell defaults.
+
+## Inspect every role
+
+Use `handler defaults` to query the native registration database without
+requiring `duti`:
+
+```bash
+dutis handler defaults extension txt --json
+dutis handler defaults uti public.plain-text --json
+dutis handler defaults mime text/plain --json
+dutis handler defaults url-scheme https --json
+```
+
+For extensions and MIME types, Dutis first resolves the identifier to its
+preferred UTI. The response includes that `content_type` plus separate `all`,
+`viewer`, `editor`, and `shell` results. A missing registration is represented
+by `null`. URL schemes have one role-free `all` result.
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "extension",
+  "identifier": "txt",
+  "content_type": "public.plain-text",
+  "defaults": [
+    { "role": "all", "bundle_id": "com.apple.TextEdit" },
+    { "role": "viewer", "bundle_id": "com.example.Viewer" },
+    { "role": "editor", "bundle_id": "com.apple.TextEdit" },
+    { "role": "shell", "bundle_id": null }
+  ]
+}
+```
+
+The MCP equivalent is the read-only `dutis_handler_defaults` tool with `kind`
+and `identifier` arguments.
+
+## Role-aware reads and verification
+
+`dutis handler get ... --role viewer|editor|shell` now uses the native API by
+default. Declarative plans, drift checks, snapshots, and post-write
+verification use the same native read whenever a specific role is requested.
+This prevents a role-insensitive default from being mistaken for successful
+verification.
+
+Role `all` keeps the existing `duti` read path for backward-compatible output,
+including application name and path for filename extensions. Mutations still
+use `duti`; the native integration is read-only.
+
+## Backend selection
+
+The default backend mode is `auto`:
+
+- specific content roles use native Launch Services on macOS;
+- role `all` and URL-scheme reads use `duti` for compatibility;
+- non-macOS builds retain the `duti` path and report that native queries are
+  unavailable when requested explicitly.
+
+For diagnostics, `DUTIS_HANDLER_READ_BACKEND=native` forces native reads and
+`DUTIS_HANDLER_READ_BACKEND=duti` forces the compatibility path. Invalid
+values fail closed. This setting changes only reads and verification; it never
+enables a write.
+
+`handler defaults` always uses the native API so its role matrix cannot
+silently fall back to a role-insensitive source.
+
+## Compatibility and safety
+
+The implementation uses the stable Core Foundation and Launch Services C ABI
+available across supported macOS releases. Owned Core Foundation values are
+released exactly once, null results become `null`, and all input identifiers
+pass through the same normalization used by the rest of Dutis.
+
+Native reads do not execute shell commands, alter Launch Services, or require
+mutation approval. Existing plan, policy, audit, snapshot, and rollback
+boundaries remain unchanged.

--- a/docs/snapshots-and-rollback.md
+++ b/docs/snapshots-and-rollback.md
@@ -14,7 +14,7 @@ Snapshots are JSON files stored at:
 Set `DUTIS_STATE_DIR` to use another state directory, which is useful for CI,
 isolated agent runs, or backups. Files are written atomically with owner-only
 permissions on Unix. They contain normalized association kinds, identifiers,
-roles, bundle identifiers, application paths reported by `duti`, timestamps,
+roles, bundle identifiers, any application paths reported by the read backend, timestamps,
 and plan digests. They do not contain tokens or credentials. Older extension-
 only snapshots remain readable; missing kind and role fields default to
 `extension` and `all`.

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -16,6 +16,9 @@ Use Dutis for macOS Launch Services associations. Preserve its
    defaults. Use `handler query` or `dutis_handler_query` to discover apps that
    explicitly register the requested kind and compatible role. Treat imported
    or exported UTI definitions as type evidence, not handler capability.
+   When roles may differ, use `handler defaults` or
+   `dutis_handler_defaults` to inspect the native Launch Services role matrix
+   before planning a change.
 2. If the user asks for a general setup or is unsure which application to use,
    inspect `dutis_profiles` / `dutis_profile`, then use `dutis_recommend` (or
    the equivalent CLI commands). Present candidate evidence and treat the

--- a/src/association.rs
+++ b/src/association.rs
@@ -15,6 +15,17 @@ pub enum AssociationKind {
     UrlScheme,
 }
 
+impl fmt::Display for AssociationKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Extension => "extension",
+            Self::Uti => "uti",
+            Self::Mime => "mime",
+            Self::UrlScheme => "url_scheme",
+        })
+    }
+}
+
 #[derive(
     Debug, Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, ValueEnum,
 )]
@@ -35,6 +46,12 @@ impl HandlerRole {
             Self::Editor => "editor",
             Self::Shell => "shell",
         }
+    }
+}
+
+impl fmt::Display for HandlerRole {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_duti_argument())
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,8 +235,22 @@ pub enum HandlerCommand {
     Query(HandlerGetArgs),
     /// Read the current handler for an extension, UTI, MIME type, or URL scheme
     Get(HandlerGetArgs),
+    /// Read every role-specific default directly from macOS Launch Services
+    Defaults(HandlerDefaultsArgs),
     /// Set a handler for an extension, UTI, MIME type, or URL scheme
     Set(HandlerSetArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct HandlerDefaultsArgs {
+    /// Association kind
+    #[arg(value_enum)]
+    pub kind: AssociationKind,
+    /// Extension, UTI, MIME type, or URL scheme
+    pub identifier: String,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -365,6 +379,20 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(CliCommand::Query(ExtensionArgs { json: true, .. }))
+        ));
+
+        let cli =
+            Cli::try_parse_from(["dutis", "handler", "defaults", "extension", "md", "--json"])
+                .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Handler(HandlerArgs {
+                command: HandlerCommand::Defaults(HandlerDefaultsArgs {
+                    kind: AssociationKind::Extension,
+                    json: true,
+                    ..
+                })
+            }))
         ));
 
         let cli = Cli::try_parse_from([

--- a/src/launch_services.rs
+++ b/src/launch_services.rs
@@ -1,0 +1,369 @@
+use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
+use anyhow::{bail, Result};
+use serde::Serialize;
+
+pub const NATIVE_DEFAULTS_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct NativeDefaultHandler {
+    pub bundle_id: String,
+    pub content_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct NativeRoleDefault {
+    pub role: HandlerRole,
+    pub bundle_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct NativeDefaultsReport {
+    pub schema_version: u32,
+    pub kind: AssociationKind,
+    pub identifier: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    pub defaults: Vec<NativeRoleDefault>,
+}
+
+pub fn query_default_handler(
+    association: &AssociationTarget,
+) -> Result<Option<NativeDefaultHandler>> {
+    platform::query_default_handler(association)
+}
+
+pub fn query_role_defaults(
+    kind: AssociationKind,
+    identifier: &str,
+) -> Result<NativeDefaultsReport> {
+    let target = AssociationTarget::new(kind, identifier, HandlerRole::All)?;
+    platform::query_role_defaults(&target)
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::*;
+    use anyhow::{Context, Result};
+    use std::ffi::{c_char, c_void, CStr};
+    use std::ptr;
+
+    type CFIndex = isize;
+    type CFStringEncoding = u32;
+    type CFStringRef = *const c_void;
+    type LSRolesMask = u32;
+
+    const K_CF_STRING_ENCODING_UTF8: CFStringEncoding = 0x0800_0100;
+    const K_LS_ROLES_VIEWER: LSRolesMask = 0x0000_0002;
+    const K_LS_ROLES_EDITOR: LSRolesMask = 0x0000_0004;
+    const K_LS_ROLES_SHELL: LSRolesMask = 0x0000_0008;
+    const K_LS_ROLES_ALL: LSRolesMask = 0xffff_ffff;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringCreateWithBytes(
+            allocator: *const c_void,
+            bytes: *const u8,
+            num_bytes: CFIndex,
+            encoding: CFStringEncoding,
+            is_external_representation: u8,
+        ) -> CFStringRef;
+        fn CFStringGetLength(string: CFStringRef) -> CFIndex;
+        fn CFStringGetMaximumSizeForEncoding(
+            length: CFIndex,
+            encoding: CFStringEncoding,
+        ) -> CFIndex;
+        fn CFStringGetCString(
+            string: CFStringRef,
+            buffer: *mut c_char,
+            buffer_size: CFIndex,
+            encoding: CFStringEncoding,
+        ) -> u8;
+        fn CFRelease(value: *const c_void);
+    }
+
+    #[link(name = "CoreServices", kind = "framework")]
+    extern "C" {
+        static kUTTagClassFilenameExtension: CFStringRef;
+        static kUTTagClassMIMEType: CFStringRef;
+
+        fn UTTypeCreatePreferredIdentifierForTag(
+            tag_class: CFStringRef,
+            tag: CFStringRef,
+            conforming_to: CFStringRef,
+        ) -> CFStringRef;
+        fn LSCopyDefaultRoleHandlerForContentType(
+            content_type: CFStringRef,
+            role: LSRolesMask,
+        ) -> CFStringRef;
+        fn LSCopyDefaultHandlerForURLScheme(scheme: CFStringRef) -> CFStringRef;
+    }
+
+    struct OwnedCfString(CFStringRef);
+
+    impl OwnedCfString {
+        fn new(value: &str) -> Result<Self> {
+            let length = CFIndex::try_from(value.len()).context("string is too long")?;
+            // SAFETY: The byte pointer is valid for `length` bytes for the duration of the call.
+            // Core Foundation copies the UTF-8 bytes into the returned owned string.
+            let string = unsafe {
+                CFStringCreateWithBytes(
+                    ptr::null(),
+                    value.as_ptr(),
+                    length,
+                    K_CF_STRING_ENCODING_UTF8,
+                    0,
+                )
+            };
+            Self::from_create_rule(string).context("Core Foundation could not create a string")
+        }
+
+        fn from_create_rule(value: CFStringRef) -> Option<Self> {
+            (!value.is_null()).then(|| Self(value))
+        }
+
+        fn as_ptr(&self) -> CFStringRef {
+            self.0
+        }
+
+        fn to_string(&self) -> Result<String> {
+            cf_string_to_string(self.0)
+        }
+    }
+
+    impl Drop for OwnedCfString {
+        fn drop(&mut self) {
+            // SAFETY: This wrapper only contains values returned under Core Foundation's create
+            // rule, and it releases each value exactly once.
+            unsafe { CFRelease(self.0) };
+        }
+    }
+
+    fn cf_string_to_string(string: CFStringRef) -> Result<String> {
+        // SAFETY: Callers provide a live CFStringRef.
+        let length = unsafe { CFStringGetLength(string) };
+        // SAFETY: The encoding constant is valid and `length` came from the same string.
+        let maximum =
+            unsafe { CFStringGetMaximumSizeForEncoding(length, K_CF_STRING_ENCODING_UTF8) };
+        let capacity = maximum
+            .checked_add(1)
+            .context("Core Foundation string is too large")?;
+        let mut buffer = vec![0_u8; usize::try_from(capacity)?];
+        // SAFETY: The allocated buffer has `capacity` bytes and the API writes a NUL-terminated
+        // UTF-8 representation when it returns true.
+        let converted = unsafe {
+            CFStringGetCString(
+                string,
+                buffer.as_mut_ptr().cast(),
+                capacity,
+                K_CF_STRING_ENCODING_UTF8,
+            )
+        };
+        if converted == 0 {
+            bail!("Core Foundation could not encode a string as UTF-8");
+        }
+        // SAFETY: A successful CFStringGetCString call guarantees NUL termination.
+        Ok(unsafe { CStr::from_ptr(buffer.as_ptr().cast()) }
+            .to_str()
+            .context("Core Foundation returned invalid UTF-8")?
+            .to_owned())
+    }
+
+    pub(super) fn query_default_handler(
+        association: &AssociationTarget,
+    ) -> Result<Option<NativeDefaultHandler>> {
+        if association.kind == AssociationKind::UrlScheme {
+            let scheme = OwnedCfString::new(&association.identifier)?;
+            // SAFETY: `scheme` is a valid CFStringRef for the duration of the call. A non-null
+            // result follows the create rule and is transferred into OwnedCfString.
+            let result = unsafe { LSCopyDefaultHandlerForURLScheme(scheme.as_ptr()) };
+            return owned_string_value(result).map(|bundle_id| {
+                bundle_id.map(|bundle_id| NativeDefaultHandler {
+                    bundle_id,
+                    content_type: None,
+                })
+            });
+        }
+
+        let content_type = content_type_for(association)?;
+        let content_type_name = content_type.to_string()?;
+        query_content_type_handler(&content_type, association.role).map(|bundle_id| {
+            bundle_id.map(|bundle_id| NativeDefaultHandler {
+                bundle_id,
+                content_type: Some(content_type_name),
+            })
+        })
+    }
+
+    pub(super) fn query_role_defaults(
+        association: &AssociationTarget,
+    ) -> Result<NativeDefaultsReport> {
+        let roles: &[HandlerRole] = if association.kind == AssociationKind::UrlScheme {
+            &[HandlerRole::All]
+        } else {
+            &[
+                HandlerRole::All,
+                HandlerRole::Viewer,
+                HandlerRole::Editor,
+                HandlerRole::Shell,
+            ]
+        };
+        let (content_type, defaults) = if association.kind == AssociationKind::UrlScheme {
+            let result = query_default_handler(association)?;
+            (
+                None,
+                vec![NativeRoleDefault {
+                    role: HandlerRole::All,
+                    bundle_id: result.map(|handler| handler.bundle_id),
+                }],
+            )
+        } else {
+            let content_type = content_type_for(association)?;
+            let content_type_name = content_type.to_string()?;
+            let defaults = roles
+                .iter()
+                .map(|role| {
+                    Ok(NativeRoleDefault {
+                        role: *role,
+                        bundle_id: query_content_type_handler(&content_type, *role)?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            (Some(content_type_name), defaults)
+        };
+        Ok(NativeDefaultsReport {
+            schema_version: NATIVE_DEFAULTS_SCHEMA_VERSION,
+            kind: association.kind,
+            identifier: association.identifier.clone(),
+            content_type,
+            defaults,
+        })
+    }
+
+    fn query_content_type_handler(
+        content_type: &OwnedCfString,
+        role: HandlerRole,
+    ) -> Result<Option<String>> {
+        // SAFETY: `content_type` is valid for the duration of the call. A non-null result follows
+        // the create rule and is transferred into OwnedCfString.
+        let result = unsafe {
+            LSCopyDefaultRoleHandlerForContentType(content_type.as_ptr(), role_mask(role))
+        };
+        owned_string_value(result)
+    }
+
+    fn content_type_for(association: &AssociationTarget) -> Result<OwnedCfString> {
+        match association.kind {
+            AssociationKind::Uti => OwnedCfString::new(&association.identifier),
+            AssociationKind::Extension | AssociationKind::Mime => {
+                let tag = OwnedCfString::new(&association.identifier)?;
+                let data_type = OwnedCfString::new("public.data")?;
+                // SAFETY: Framework constants and `tag` are valid CFStringRefs. A non-null result
+                // follows the create rule and is transferred into OwnedCfString.
+                let content_type = unsafe {
+                    let tag_class = match association.kind {
+                        AssociationKind::Extension => kUTTagClassFilenameExtension,
+                        AssociationKind::Mime => kUTTagClassMIMEType,
+                        AssociationKind::Uti | AssociationKind::UrlScheme => unreachable!(),
+                    };
+                    UTTypeCreatePreferredIdentifierForTag(
+                        tag_class,
+                        tag.as_ptr(),
+                        data_type.as_ptr(),
+                    )
+                };
+                OwnedCfString::from_create_rule(content_type)
+                    .context("Launch Services could not resolve the identifier to a content type")
+            }
+            AssociationKind::UrlScheme => {
+                unreachable!("URL schemes do not use content type queries")
+            }
+        }
+    }
+
+    fn owned_string_value(value: CFStringRef) -> Result<Option<String>> {
+        let Some(value) = OwnedCfString::from_create_rule(value) else {
+            return Ok(None);
+        };
+        let value = value.to_string()?;
+        Ok((!value.is_empty()).then_some(value))
+    }
+
+    fn role_mask(role: HandlerRole) -> LSRolesMask {
+        match role {
+            HandlerRole::All => K_LS_ROLES_ALL,
+            HandlerRole::Viewer => K_LS_ROLES_VIEWER,
+            HandlerRole::Editor => K_LS_ROLES_EDITOR,
+            HandlerRole::Shell => K_LS_ROLES_SHELL,
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn core_foundation_string_round_trips_utf8() {
+            let value = OwnedCfString::new("public.plain-text").unwrap();
+            assert_eq!(value.to_string().unwrap(), "public.plain-text");
+        }
+
+        #[test]
+        fn resolves_filename_extension_to_content_type() {
+            // SAFETY: The framework exports this process-lifetime CFString constant.
+            let tag_class = unsafe { kUTTagClassFilenameExtension };
+            assert_eq!(
+                cf_string_to_string(tag_class).unwrap(),
+                "public.filename-extension"
+            );
+            let target = AssociationTarget::extension("txt").unwrap();
+            let content_type = content_type_for(&target).unwrap().to_string().unwrap();
+            assert!(!content_type.is_empty());
+        }
+
+        #[test]
+        fn returns_complete_role_shapes_when_defaults_are_absent() {
+            let report =
+                query_role_defaults(&AssociationTarget::extension("txt").unwrap()).unwrap();
+            assert_eq!(report.kind, AssociationKind::Extension);
+            assert_eq!(report.identifier, "txt");
+            assert!(report.content_type.is_some());
+            assert_eq!(
+                report
+                    .defaults
+                    .iter()
+                    .map(|entry| entry.role)
+                    .collect::<Vec<_>>(),
+                [
+                    HandlerRole::All,
+                    HandlerRole::Viewer,
+                    HandlerRole::Editor,
+                    HandlerRole::Shell,
+                ]
+            );
+
+            let url = AssociationTarget::new(AssociationKind::UrlScheme, "https", HandlerRole::All)
+                .unwrap();
+            let report = query_role_defaults(&url).unwrap();
+            assert_eq!(report.defaults.len(), 1);
+            assert_eq!(report.defaults[0].role, HandlerRole::All);
+            assert!(report.content_type.is_none());
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    use super::*;
+
+    pub(super) fn query_default_handler(
+        _association: &AssociationTarget,
+    ) -> Result<Option<NativeDefaultHandler>> {
+        bail!("native Launch Services queries are available only on macOS")
+    }
+
+    pub(super) fn query_role_defaults(
+        _association: &AssociationTarget,
+    ) -> Result<NativeDefaultsReport> {
+        bail!("native Launch Services queries are available only on macOS")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod events;
 pub mod governance;
 pub mod http_adapter;
 pub mod launch_agent;
+pub mod launch_services;
 pub mod mcp;
 pub mod planner;
 pub mod plist_parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{
     ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, HandlerArgs, HandlerCommand,
-    HandlerGetArgs, HandlerSetArgs, LaunchAgentArgs, LaunchAgentCommand, LaunchAgentInstallArgs,
-    McpArgs, OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand, ProfileArgs, ProfileCommand,
-    ProfileShowArgs, RecommendArgs, RollbackArgs, SetArgs, SnapshotArgs, SnapshotCommand,
-    SnapshotCreateArgs, WatchArgs,
+    HandlerDefaultsArgs, HandlerGetArgs, HandlerSetArgs, LaunchAgentArgs, LaunchAgentCommand,
+    LaunchAgentInstallArgs, McpArgs, OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand,
+    ProfileArgs, ProfileCommand, ProfileShowArgs, RecommendArgs, RollbackArgs, SetArgs,
+    SnapshotArgs, SnapshotCommand, SnapshotCreateArgs, WatchArgs,
 };
 use colored::*;
 use dutis::application::{
@@ -24,6 +24,7 @@ use dutis::governance::{
     LoadedPolicy, MutationChannel, MutationOperation, MutationRequest, PolicyAssessment,
 };
 use dutis::launch_agent::{LaunchAgentManager, LaunchAgentSpec, LaunchAgentStatus};
+use dutis::launch_services;
 use dutis::planner::{
     assemble_plan, build_plan, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
     PlannedApplication,
@@ -343,6 +344,7 @@ fn command_uses_json(command: &CliCommand) -> bool {
         CliCommand::Handler(args) => match &args.command {
             HandlerCommand::Query(args) => args.json,
             HandlerCommand::Get(args) => args.json,
+            HandlerCommand::Defaults(args) => args.json,
             HandlerCommand::Set(args) => args.json,
         },
         CliCommand::Watch(args) => args.json,
@@ -358,8 +360,37 @@ fn run_handler(args: HandlerArgs) -> Result<(), CliError> {
     match args.command {
         HandlerCommand::Query(args) => run_handler_query(args),
         HandlerCommand::Get(args) => run_handler_get(args),
+        HandlerCommand::Defaults(args) => run_handler_defaults(args),
         HandlerCommand::Set(args) => run_handler_set(args),
     }
+}
+
+fn run_handler_defaults(args: HandlerDefaultsArgs) -> Result<(), CliError> {
+    let report = launch_services::query_role_defaults(args.kind, &args.identifier)
+        .map_err(|error| CliError::operation(format!("{error:#}")))?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "handler",
+            data: report,
+        })?;
+    } else {
+        println!(
+            "Native Launch Services defaults for {} {}:",
+            report.kind, report.identifier
+        );
+        if let Some(content_type) = report.content_type {
+            println!("Resolved content type: {content_type}");
+        }
+        for default in report.defaults {
+            println!(
+                "{}\t{}",
+                default.role,
+                default.bundle_id.as_deref().unwrap_or("<none>")
+            );
+        }
+    }
+    Ok(())
 }
 
 fn run_handler_query(args: HandlerGetArgs) -> Result<(), CliError> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -9,6 +9,7 @@ use crate::governance::{
     execute_governed_plan, AuditStore, GovernanceError, GovernanceErrorKind, LoadedPolicy,
     MutationChannel, MutationOperation, MutationRequest,
 };
+use crate::launch_services;
 use crate::planner::{build_plan, AssociationPlan};
 use crate::profiles::{find_profile, profiles, recommend_profile};
 use crate::snapshot::{build_rollback_plan, SnapshotReason, SnapshotStore};
@@ -89,6 +90,7 @@ trait McpBackend {
     fn get(&mut self, extension: &str) -> Result<Value>;
     fn query_handler(&mut self, association: &AssociationTarget) -> Result<Value>;
     fn get_handler(&mut self, association: &AssociationTarget) -> Result<Value>;
+    fn handler_defaults(&mut self, association: &AssociationTarget) -> Result<Value>;
     fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan>;
     fn apply(
         &mut self,
@@ -176,6 +178,14 @@ impl McpBackend for SystemBackend {
     fn get_handler(&mut self, association: &AssociationTarget) -> Result<Value> {
         let default = system::get_default_handler(association)?;
         Ok(json!({"association": association, "default": default}))
+    }
+
+    fn handler_defaults(&mut self, association: &AssociationTarget) -> Result<Value> {
+        serde_json::to_value(launch_services::query_role_defaults(
+            association.kind,
+            &association.identifier,
+        )?)
+        .context("failed to serialize native handler defaults")
     }
 
     fn plan(&mut self, config: &DutisConfig) -> Result<AssociationPlan> {
@@ -403,6 +413,12 @@ impl<B: McpBackend> McpServer<B> {
                     .query_handler(&association)
                     .map_err(operation_error)
             }
+            "dutis_handler_defaults" => {
+                let association = parse_handler_identity(arguments)?;
+                self.backend
+                    .handler_defaults(&association)
+                    .map_err(operation_error)
+            }
             "dutis_diff" => {
                 let config = parse_config(arguments)?;
                 let plan = self.backend.plan(&config).map_err(operation_error)?;
@@ -558,18 +574,7 @@ fn argument_string<'a>(
 fn parse_association(
     arguments: &Map<String, Value>,
 ) -> std::result::Result<AssociationTarget, ToolError> {
-    let kind = match argument_string(arguments, "kind")? {
-        "extension" => AssociationKind::Extension,
-        "uti" => AssociationKind::Uti,
-        "mime" => AssociationKind::Mime,
-        "url_scheme" => AssociationKind::UrlScheme,
-        value => {
-            return Err(ToolError::new(
-                "invalid_arguments",
-                format!("unsupported association kind '{value}'"),
-            ))
-        }
-    };
+    let kind = parse_association_kind(arguments)?;
     let role = match arguments
         .get("role")
         .and_then(Value::as_str)
@@ -588,6 +593,34 @@ fn parse_association(
     };
     AssociationTarget::new(kind, argument_string(arguments, "identifier")?, role)
         .map_err(|error| ToolError::new("invalid_arguments", error.to_string()))
+}
+
+fn parse_handler_identity(
+    arguments: &Map<String, Value>,
+) -> std::result::Result<AssociationTarget, ToolError> {
+    AssociationTarget::new(
+        parse_association_kind(arguments)?,
+        argument_string(arguments, "identifier")?,
+        HandlerRole::All,
+    )
+    .map_err(|error| ToolError::new("invalid_arguments", error.to_string()))
+}
+
+fn parse_association_kind(
+    arguments: &Map<String, Value>,
+) -> std::result::Result<AssociationKind, ToolError> {
+    Ok(match argument_string(arguments, "kind")? {
+        "extension" => AssociationKind::Extension,
+        "uti" => AssociationKind::Uti,
+        "mime" => AssociationKind::Mime,
+        "url_scheme" => AssociationKind::UrlScheme,
+        value => {
+            return Err(ToolError::new(
+                "invalid_arguments",
+                format!("unsupported association kind '{value}'"),
+            ))
+        }
+    })
 }
 
 fn parse_config(arguments: &Map<String, Value>) -> std::result::Result<DutisConfig, ToolError> {
@@ -714,6 +747,15 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
         "required": ["kind", "identifier"],
         "additionalProperties": false,
     });
+    let handler_identity_schema = json!({
+        "type": "object",
+        "properties": {
+            "kind": {"type": "string", "enum": ["extension", "uti", "mime", "url_scheme"]},
+            "identifier": {"type": "string", "minLength": 1}
+        },
+        "required": ["kind", "identifier"],
+        "additionalProperties": false,
+    });
     let config_schema = json!({
         "type": "object",
         "properties": {"config_toml": {"type": "string", "minLength": 1}},
@@ -791,6 +833,12 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
             "dutis_handler_get",
             "Read the current handler for an extension, UTI, MIME type, or URL scheme.",
             handler_schema,
+            read_annotations.clone(),
+        ),
+        tool_definition(
+            "dutis_handler_defaults",
+            "Read all role-specific defaults directly from macOS Launch Services.",
+            handler_identity_schema,
             read_annotations.clone(),
         ),
         tool_definition(
@@ -1011,6 +1059,19 @@ mod tests {
             Ok(json!({"association": association, "default": null}))
         }
 
+        fn handler_defaults(&mut self, association: &AssociationTarget) -> Result<Value> {
+            Ok(json!({
+                "schema_version": 1,
+                "kind": association.kind,
+                "identifier": association.identifier,
+                "content_type": "public.text",
+                "defaults": [
+                    {"role": "viewer", "bundle_id": "com.example.Viewer"},
+                    {"role": "editor", "bundle_id": "com.example.Editor"}
+                ]
+            }))
+        }
+
         fn plan(&mut self, _config: &DutisConfig) -> Result<AssociationPlan> {
             Ok(self.plan.clone())
         }
@@ -1094,6 +1155,7 @@ mod tests {
         assert!(names.contains(&"dutis_drift"));
         assert!(names.contains(&"dutis_handler_get"));
         assert!(names.contains(&"dutis_handler_query"));
+        assert!(names.contains(&"dutis_handler_defaults"));
         assert!(names.contains(&"dutis_policy_check"));
         assert!(names.contains(&"dutis_audit"));
         assert!(!names.contains(&"dutis_apply"));
@@ -1206,6 +1268,25 @@ mod tests {
         assert_eq!(
             response["result"]["structuredContent"]["data"]["association"]["kind"],
             "mime"
+        );
+        assert_eq!(outcome.audit.unwrap().access, "read");
+    }
+
+    #[test]
+    fn native_handler_defaults_are_exposed_as_a_read_only_tool() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let outcome = server.handle(request(
+            11,
+            "tools/call",
+            json!({
+                "name": "dutis_handler_defaults",
+                "arguments": {"kind": "extension", "identifier": "txt"}
+            }),
+        ));
+        let response = outcome.response.unwrap();
+        assert_eq!(
+            response["result"]["structuredContent"]["data"]["defaults"][1]["role"],
+            "editor"
         );
         assert_eq!(outcome.audit.unwrap().access, "read");
     }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,8 +1,17 @@
 use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
+use crate::launch_services;
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::process::Command;
+
+pub const HANDLER_READ_BACKEND_ENV: &str = "DUTIS_HANDLER_READ_BACKEND";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum HandlerReadBackend {
+    Duti,
+    Native,
+}
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DefaultApplication {
@@ -46,8 +55,11 @@ pub fn get_default_app(extension: &str) -> Result<Option<DefaultApplication>> {
 }
 
 pub fn get_default_handler(association: &AssociationTarget) -> Result<Option<DefaultApplication>> {
-    duti_version()?;
-    query_default_handler(association)
+    let backend = handler_read_backend(association)?;
+    if backend == HandlerReadBackend::Duti {
+        duti_version()?;
+    }
+    query_default_handler_with_backend(association, backend)
 }
 
 pub fn query_default_app(extension: &str) -> Result<Option<DefaultApplication>> {
@@ -56,6 +68,37 @@ pub fn query_default_app(extension: &str) -> Result<Option<DefaultApplication>> 
 }
 
 pub fn query_default_handler(
+    association: &AssociationTarget,
+) -> Result<Option<DefaultApplication>> {
+    query_default_handler_with_backend(association, handler_read_backend(association)?)
+}
+
+fn query_default_handler_with_backend(
+    association: &AssociationTarget,
+    backend: HandlerReadBackend,
+) -> Result<Option<DefaultApplication>> {
+    match backend {
+        HandlerReadBackend::Duti => query_default_handler_with_duti(association),
+        HandlerReadBackend::Native => query_default_handler_with_launch_services(association),
+    }
+}
+
+fn query_default_handler_with_launch_services(
+    association: &AssociationTarget,
+) -> Result<Option<DefaultApplication>> {
+    Ok(
+        launch_services::query_default_handler(association)?.map(|default| DefaultApplication {
+            kind: association.kind,
+            role: association.role,
+            extension: association.identifier.clone(),
+            name: None,
+            path: None,
+            bundle_id: default.bundle_id,
+        }),
+    )
+}
+
+fn query_default_handler_with_duti(
     association: &AssociationTarget,
 ) -> Result<Option<DefaultApplication>> {
     let mut command = Command::new("duti");
@@ -102,6 +145,36 @@ pub fn query_default_handler(
             path: None,
             bundle_id,
         }))
+    }
+}
+
+fn handler_read_backend(association: &AssociationTarget) -> Result<HandlerReadBackend> {
+    parse_handler_read_backend(
+        std::env::var(HANDLER_READ_BACKEND_ENV).ok().as_deref(),
+        association,
+    )
+}
+
+fn parse_handler_read_backend(
+    configured: Option<&str>,
+    association: &AssociationTarget,
+) -> Result<HandlerReadBackend> {
+    match configured.map(str::trim).filter(|value| !value.is_empty()) {
+        None | Some("auto") => {
+            if cfg!(target_os = "macos")
+                && association.kind != AssociationKind::UrlScheme
+                && association.role != HandlerRole::All
+            {
+                Ok(HandlerReadBackend::Native)
+            } else {
+                Ok(HandlerReadBackend::Duti)
+            }
+        }
+        Some("duti") => Ok(HandlerReadBackend::Duti),
+        Some("native") => Ok(HandlerReadBackend::Native),
+        Some(value) => bail!(
+            "invalid {HANDLER_READ_BACKEND_ENV} value '{value}'; expected auto, native, or duti"
+        ),
     }
 }
 
@@ -211,5 +284,33 @@ mod tests {
             duti_set_arguments(&scheme, "com.example.Browser"),
             ["-s", "com.example.Browser", "https"]
         );
+    }
+
+    #[test]
+    fn selects_native_backend_for_role_specific_content_queries() {
+        let viewer =
+            AssociationTarget::new(AssociationKind::Uti, "public.text", HandlerRole::Viewer)
+                .unwrap();
+        let all =
+            AssociationTarget::new(AssociationKind::Uti, "public.text", HandlerRole::All).unwrap();
+        let expected = if cfg!(target_os = "macos") {
+            HandlerReadBackend::Native
+        } else {
+            HandlerReadBackend::Duti
+        };
+        assert_eq!(parse_handler_read_backend(None, &viewer).unwrap(), expected);
+        assert_eq!(
+            parse_handler_read_backend(None, &all).unwrap(),
+            HandlerReadBackend::Duti
+        );
+        assert_eq!(
+            parse_handler_read_backend(Some("duti"), &viewer).unwrap(),
+            HandlerReadBackend::Duti
+        );
+        assert_eq!(
+            parse_handler_read_backend(Some("native"), &all).unwrap(),
+            HandlerReadBackend::Native
+        );
+        assert!(parse_handler_read_backend(Some("unknown"), &all).is_err());
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -188,6 +188,7 @@ fn typed_handler_get_uses_duti_default_handler_query() {
     let calls = root.join("duti-calls.log");
     let output = dutis()
         .env("PATH", &bin)
+        .env("DUTIS_HANDLER_READ_BACKEND", "duti")
         .env("DUTI_CALL_LOG", &calls)
         .args([
             "handler",
@@ -291,6 +292,7 @@ fn typed_config_dry_run_and_apply_cover_every_duti_argument_shape() {
     let configure = |command: &mut Command| {
         command
             .env("PATH", &bin)
+            .env("DUTIS_HANDLER_READ_BACKEND", "duti")
             .env("DUTI_CALL_LOG", &calls)
             .env("DUTI_FAKE_STATE", &fake_state)
             .env("DUTIS_STATE_DIR", &state);
@@ -633,6 +635,9 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
     assert!(tools
         .iter()
         .any(|tool| tool["name"] == "dutis_handler_query"));
+    assert!(tools
+        .iter()
+        .any(|tool| tool["name"] == "dutis_handler_defaults"));
     assert!(!tools.iter().any(|tool| tool["name"] == "dutis_apply"));
     assert_eq!(
         responses[3]["result"]["structuredContent"]["data"]["approval_mode"],


### PR DESCRIPTION
## Summary
- query macOS Launch Services directly for role-specific handler defaults
- add CLI and read-only MCP surfaces for native default matrices
- use native role reads for planning, drift, snapshots, and verification while retaining duti for writes
- document backend selection and bump the release version to 2.16.0

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline (117 tests)
- cargo build --release --bins --locked --offline
- cargo package --allow-dirty --locked --offline
- ruby -c scripts/render_homebrew_formula.rb
- read-only native CLI and MCP smoke tests on macOS