### PR TITLE
feat: add durable event delivery replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.16.0"
+version = "2.17.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.16.0"
+version = "2.17.0"
 edition = "2021"
 rust-version = "1.88"
 default-run = "dutis"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 - 🔗 **Typed Associations**: Manage extensions, UTIs, MIME types, URL schemes, and Launch Services roles through one verified pipeline
 - 📡 **Event Sinks**: Stream versioned drift and mutation lifecycle events to private JSONL logs or trusted local commands
 - 🌐 **HTTPS Event Adapter**: Forward events with environment-only credentials, bounded retries, and idempotency headers
+- 📦 **Durable Event Replay**: Queue failed command deliveries locally and replay them without repeating the original mutation
 - 🍎 **Native Role Inspection**: Read separate viewer, editor, and shell defaults directly from macOS Launch Services
 
 ## Installation
@@ -222,8 +223,8 @@ dutis --event-command /absolute/path/to/event-handler apply dutis.toml \
 ```
 
 Event options are global and can appear before or after a subcommand. The same
-settings can be provided through `DUTIS_EVENT_LOG` and
-`DUTIS_EVENT_COMMAND`. See [event sinks](docs/event-sinks.md) for the schema,
+settings can be provided through `DUTIS_EVENT_LOG`, `DUTIS_EVENT_COMMAND`, and
+`DUTIS_EVENT_OUTBOX`. See [event sinks](docs/event-sinks.md) for the schema,
 command contract, LaunchAgent behavior, and delivery guarantees.
 
 To forward events over HTTPS without placing credentials in Dutis arguments,
@@ -235,7 +236,16 @@ export DUTIS_HTTP_ENDPOINT='https://events.example.com/hooks/dutis'
 export DUTIS_HTTP_BEARER_TOKEN='replace-with-a-scoped-token'
 export DUTIS_EVENT_COMMAND="$(command -v dutis-event-http)"
 dutis-event-http --check --json
+
+# Inspect and replay failed command deliveries
+dutis events pending --json
+dutis events replay --limit 100 --json
 ```
+
+Failed event-command deliveries are stored automatically under the Dutis state
+directory. Override that location with `--event-outbox` or
+`DUTIS_EVENT_OUTBOX`. Replay keeps the original event ID so remote consumers
+can deduplicate retries. See [durable event replay](docs/event-replay.md).
 
 All write paths enforce the same local policy before mutation and record the
 requester, reviewed plan, result, and verification. See the
@@ -247,7 +257,8 @@ Applications can be selected by exact bundle ID, exact application path, or an
 unambiguous application name. JSON responses use API version `1`. Exit codes are
 `0` for success, `2` for usage errors, `3` for no match, `4` for ambiguous
 selectors, `5` for an unavailable dependency, and `6` for operation failure.
-Declarative apply also uses `7` for a stale plan and `8` for partial failure.
+Declarative apply uses `7` for a stale plan. Apply and event replay use `8` for
+partial failure.
 Policy denial uses exit code `9`.
 
 The product and engineering sequence for declarative configuration, rollback,

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -259,11 +259,32 @@ Acceptance criteria:
 - An explicit backend override supports compatibility diagnostics without
   weakening mutation, policy, audit, or snapshot boundaries.
 
+## Phase 13: Durable event replay
+
+Status: implemented for v2.17.0
+
+Persist failed external event-command deliveries locally and let operators or
+agents retry them without re-running the originating association operation.
+
+Acceptance criteria:
+
+- Command-delivery failures are atomically queued with the original event ID,
+  payload, timestamps, and attempt count in owner-only local storage.
+- CLI commands list pending deliveries and replay a bounded oldest-first batch
+  through the currently configured command sink.
+- Successful deliveries are removed; failed deliveries remain queued and
+  increment their attempt count.
+- Replay retains the original event ID for receiver-side idempotency, validates
+  stored records before delivery, and rejects invalid IDs or non-regular queue
+  entries.
+- Queue failures and replay failures never change mutation, policy, audit,
+  snapshot, or drift outcomes.
+
 ## Near-term engineering sequence
 
-1. Release Phase 12 and validate native role results across supported macOS
-   releases and managed-device configurations.
-2. Add durable replay tooling for failed external event deliveries without
-   coupling observability failures to association mutations.
-3. Add policy-aware application recommendation inputs for teams and managed
+1. Release Phase 13 and validate outbox recovery with representative webhook
+   receivers and long-running LaunchAgents.
+2. Add policy-aware application recommendation inputs for teams and managed
    fleets without introducing a remote control plane.
+3. Add explicit queue retention and operator-approved dead-letter cleanup
+   after production replay behavior is established.

--- a/docs/drift-detection.md
+++ b/docs/drift-detection.md
@@ -61,10 +61,10 @@ watcher, and writes:
 ```
 
 If `DUTIS_STATE_DIR` is set while installing, logs and state use that directory.
-If `--event-log`, `--event-command`, `DUTIS_EVENT_LOG`, or
-`DUTIS_EVENT_COMMAND` is set while installing, the normalized sink paths are
-copied into the LaunchAgent environment. Reinstall the agent after changing a
-sink.
+If `--event-log`, `--event-command`, `--event-outbox`, `DUTIS_EVENT_LOG`,
+`DUTIS_EVENT_COMMAND`, or `DUTIS_EVENT_OUTBOX` is set while installing, the
+normalized sink paths are copied into the LaunchAgent environment. Reinstall
+the agent after changing a sink.
 The LaunchAgent plist is stored at:
 
 ```text

--- a/docs/event-replay.md
+++ b/docs/event-replay.md
@@ -1,0 +1,75 @@
+# Durable event replay
+
+Dutis v2.17 stores failed event-command deliveries in a local outbox. Replaying
+an event retries only the external delivery; it never repeats the drift check,
+association mutation, policy decision, snapshot, or audit operation that
+originally produced the event.
+
+## Storage
+
+When `DUTIS_EVENT_COMMAND` or `--event-command` is configured, the default
+outbox is:
+
+```text
+$DUTIS_STATE_DIR/event-outbox
+```
+
+Without `DUTIS_STATE_DIR`, Dutis uses:
+
+```text
+~/Library/Application Support/dutis/event-outbox
+```
+
+Set `--event-outbox <directory>` or `DUTIS_EVENT_OUTBOX` to override it. A
+custom outbox path is also preserved when installing the drift-monitoring
+LaunchAgent.
+
+Each failed delivery is written atomically as one JSON file. The directory is
+mode `0700` and records are mode `0600` on Unix. A record contains the original
+event, the first and most recent attempt timestamps, and an attempt count. It
+does not contain HTTP endpoint or credential configuration. Event payloads can
+still contain local paths, bundle identifiers, requester identity, and plans,
+so the directory should remain private.
+
+## Inspect pending events
+
+```bash
+dutis events pending
+dutis events pending --json
+```
+
+Pending events are ordered by their first failure time and event ID. Dutis
+validates the queue schema, embedded event schema, filename, size, and file
+type before returning or delivering a record. Malformed records fail closed
+and remain untouched for operator inspection.
+
+## Replay deliveries
+
+First confirm that the command sink and its credentials are healthy. Then run:
+
+```bash
+dutis --event-command /absolute/path/to/handler events replay
+dutis events replay --limit 25 --json
+```
+
+The second form uses `DUTIS_EVENT_COMMAND`. Replay attempts the oldest records
+first and processes at most 100 by default. `--limit` changes that bound.
+Successful deliveries are removed. Failed deliveries remain in the outbox and
+their attempt count increases. A mixed batch exits with partial-failure code
+`8`; its JSON error details contain the per-event results.
+
+The original event ID is preserved across every attempt. The bundled HTTP
+adapter sends it as both `X-Dutis-Event-Id` and `Idempotency-Key`, allowing a
+receiver to deduplicate deliveries.
+
+## Delivery guarantees
+
+Replay is explicit; Dutis does not start a background retry loop. Delivery is
+at least once because a process can terminate after the receiver accepts an
+event but before the local record is removed. Consumers should deduplicate by
+event ID, and operators should run only one replay process for an outbox at a
+time.
+
+If the outbox itself cannot be written, Dutis reports that failure with the
+event-command warning. The originating command keeps its original result:
+observability storage cannot authorize, undo, repeat, or relabel a mutation.

--- a/docs/event-sinks.md
+++ b/docs/event-sinks.md
@@ -20,6 +20,7 @@ LaunchAgents:
 ```bash
 export DUTIS_EVENT_LOG="$HOME/Library/Application Support/dutis/events.jsonl"
 export DUTIS_EVENT_COMMAND="/absolute/path/to/handler"
+export DUTIS_EVENT_OUTBOX="$HOME/Library/Application Support/dutis/event-outbox"
 ```
 
 Relative paths are resolved against the current working directory at startup.
@@ -110,3 +111,19 @@ failure prints a warning to stderr and does not:
 - stop a continuous watcher from performing later checks.
 
 When both sinks are configured, Dutis attempts both even if one fails.
+
+Failed command deliveries are stored atomically in the private event outbox.
+The default location is `event-outbox` inside `DUTIS_STATE_DIR`, or
+`~/Library/Application Support/dutis/event-outbox`. Use `--event-outbox` or
+`DUTIS_EVENT_OUTBOX` to select another directory. JSONL write failures are not
+queued because the outbox is specifically a command-delivery queue.
+
+Inspect and replay the oldest pending events with:
+
+```bash
+dutis events pending --json
+dutis --event-command /absolute/path/to/handler events replay --limit 100 --json
+```
+
+See [durable event replay](event-replay.md) for persistence, retry, and
+at-least-once delivery guarantees.

--- a/docs/http-event-adapter.md
+++ b/docs/http-event-adapter.md
@@ -88,5 +88,6 @@ names, not credentials.
 
 The adapter is synchronous and has no durable queue. A failure becomes the
 same best-effort warning as any other event-command failure; Dutis continues
-its primary operation. Use the JSONL sink alongside the adapter when local
-replay or durable delivery is required.
+its primary operation. Failed command deliveries are placed in the durable
+outbox and can be retried with `dutis events replay`. See
+[durable event replay](event-replay.md).

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -138,5 +138,7 @@ continues to use `DUTIS_STATE_DIR` when set.
 Start the server with global `--event-log` or `--event-command` options, or set
 their `DUTIS_EVENT_LOG` / `DUTIS_EVENT_COMMAND` environment variables, to emit
 `dutis_drift` checks and governed mutation lifecycle events. Event-command
-stdout is discarded and cannot corrupt the JSON-RPC stream. See
+stdout is discarded and cannot corrupt the JSON-RPC stream. Failed command
+deliveries enter the same durable outbox used by the CLI and can be recovered
+later with `dutis events pending` and `dutis events replay`. See
 [event sinks](event-sinks.md).

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -19,6 +19,8 @@ Use Dutis for macOS Launch Services associations. Preserve its
    When roles may differ, use `handler defaults` or
    `dutis_handler_defaults` to inspect the native Launch Services role matrix
    before planning a change.
+   If an event command reports a delivery failure, inspect `events pending`
+   and use `events replay` only after confirming the configured sink is healthy.
 2. If the user asks for a general setup or is unsure which application to use,
    inspect `dutis_profiles` / `dutis_profile`, then use `dutis_recommend` (or
    the equivalent CLI commands). Present candidate evidence and treat the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,9 @@ pub struct Cli {
     /// Pipe each event as JSON to this executable command
     #[arg(long, global = true, value_name = "PATH")]
     pub event_command: Option<PathBuf>,
+    /// Store failed command deliveries for later replay
+    #[arg(long, global = true, value_name = "DIRECTORY")]
+    pub event_outbox: Option<PathBuf>,
     #[command(subcommand)]
     pub command: Option<CliCommand>,
 }
@@ -54,6 +57,8 @@ pub enum CliCommand {
     Handler(HandlerArgs),
     /// Detect and optionally remediate drift from a declarative configuration
     Watch(WatchArgs),
+    /// Inspect or replay failed event-command deliveries
+    Events(EventsArgs),
     /// Manage the optional per-user drift monitoring LaunchAgent
     LaunchAgent(LaunchAgentArgs),
     /// Run the local Model Context Protocol server over stdio
@@ -322,6 +327,30 @@ pub struct WatchArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct EventsArgs {
+    #[command(subcommand)]
+    pub command: EventsCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EventsCommand {
+    /// List events waiting in the durable outbox
+    Pending(OutputArgs),
+    /// Deliver pending events through the configured event command
+    Replay(EventReplayArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct EventReplayArgs {
+    /// Maximum number of oldest pending events to attempt
+    #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u64).range(1..))]
+    pub limit: u64,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
 pub struct LaunchAgentArgs {
     #[command(subcommand)]
     pub command: LaunchAgentCommand,
@@ -446,6 +475,8 @@ mod tests {
             "--once",
             "--event-command",
             "/usr/local/bin/event-sink",
+            "--event-outbox",
+            "outbox",
         ])
         .unwrap();
         assert_eq!(cli.event_log, Some(PathBuf::from("events.jsonl")));
@@ -453,6 +484,29 @@ mod tests {
             cli.event_command,
             Some(PathBuf::from("/usr/local/bin/event-sink"))
         );
+        assert_eq!(cli.event_outbox, Some(PathBuf::from("outbox")));
+    }
+
+    #[test]
+    fn parses_event_outbox_commands() {
+        let cli = Cli::try_parse_from(["dutis", "events", "pending", "--json"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Events(EventsArgs {
+                command: EventsCommand::Pending(OutputArgs { json: true })
+            }))
+        ));
+        let cli =
+            Cli::try_parse_from(["dutis", "events", "replay", "--limit", "25", "--json"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Events(EventsArgs {
+                command: EventsCommand::Replay(EventReplayArgs {
+                    limit: 25,
+                    json: true
+                })
+            }))
+        ));
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -12,6 +12,10 @@ use time::OffsetDateTime;
 pub const EVENT_SCHEMA_VERSION: u32 = 1;
 pub const EVENT_LOG_ENV: &str = "DUTIS_EVENT_LOG";
 pub const EVENT_COMMAND_ENV: &str = "DUTIS_EVENT_COMMAND";
+pub const EVENT_OUTBOX_ENV: &str = "DUTIS_EVENT_OUTBOX";
+pub const PENDING_EVENT_SCHEMA_VERSION: u32 = 1;
+
+const MAX_PENDING_EVENT_BYTES: u64 = 2 * 1024 * 1024;
 
 static EVENT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -27,6 +31,18 @@ pub enum EventType {
     MutationFailed,
     #[serde(rename = "mutation.completed")]
     MutationCompleted,
+}
+
+impl EventType {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DriftChecked => "drift.checked",
+            Self::MutationPending => "mutation.pending",
+            Self::MutationDenied => "mutation.denied",
+            Self::MutationFailed => "mutation.failed",
+            Self::MutationCompleted => "mutation.completed",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -45,6 +61,44 @@ pub struct EventEnvelope {
     pub event_type: EventType,
     pub source: EventSource,
     pub payload: Value,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PendingEvent {
+    pub schema_version: u32,
+    pub queued_at: String,
+    pub last_attempted_at: String,
+    pub attempts: u64,
+    pub event: EventEnvelope,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct PendingEventSummary {
+    pub id: String,
+    pub event_type: EventType,
+    pub source: EventSource,
+    pub emitted_at: String,
+    pub queued_at: String,
+    pub last_attempted_at: String,
+    pub attempts: u64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ReplayResult {
+    pub id: String,
+    pub status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ReplayReport {
+    pub attempted: usize,
+    pub delivered: usize,
+    pub failed: usize,
+    pub remaining: usize,
+    pub results: Vec<ReplayResult>,
 }
 
 impl EventEnvelope {
@@ -76,6 +130,7 @@ impl EventEnvelope {
 pub struct EventDispatcher {
     log: Option<PathBuf>,
     command: Option<PathBuf>,
+    outbox: Option<EventOutbox>,
 }
 
 impl EventDispatcher {
@@ -86,16 +141,33 @@ impl EventDispatcher {
         let command = std::env::var_os(EVENT_COMMAND_ENV)
             .filter(|value| !value.is_empty())
             .map(PathBuf::from);
-        Self::new(log, command)
+        let outbox = if std::env::var_os(EVENT_OUTBOX_ENV).is_some() || command.is_some() {
+            Some(EventOutbox::from_environment()?)
+        } else {
+            None
+        };
+        Self::with_outbox(log, command, outbox)
     }
 
     pub fn new(log: Option<PathBuf>, command: Option<PathBuf>) -> Result<Self> {
+        Self::with_outbox(log, command, None)
+    }
+
+    pub fn with_outbox(
+        log: Option<PathBuf>,
+        command: Option<PathBuf>,
+        outbox: Option<EventOutbox>,
+    ) -> Result<Self> {
         let log = log.map(absolute_path).transpose()?;
         let command = command.map(absolute_path).transpose()?;
         if let Some(command) = &command {
             validate_command(command)?;
         }
-        Ok(Self { log, command })
+        Ok(Self {
+            log,
+            command,
+            outbox,
+        })
     }
 
     pub fn is_enabled(&self) -> bool {
@@ -108,6 +180,10 @@ impl EventDispatcher {
 
     pub fn command(&self) -> Option<&Path> {
         self.command.as_deref()
+    }
+
+    pub fn outbox(&self) -> Option<&EventOutbox> {
+        self.outbox.as_ref()
     }
 
     pub fn emit<T: Serialize>(
@@ -130,7 +206,19 @@ impl EventDispatcher {
         }
         if let Some(command) = &self.command {
             if let Err(error) = run_event_command(command, &event, &encoded) {
-                failures.push(format!("command sink {}: {error:#}", command.display()));
+                let mut failure = format!("command sink {}: {error:#}", command.display());
+                if let Some(outbox) = &self.outbox {
+                    match outbox.enqueue(&event) {
+                        Ok(_) => failure.push_str(&format!(
+                            "; event queued for replay in {}",
+                            outbox.directory().display()
+                        )),
+                        Err(queue_error) => failure.push_str(&format!(
+                            "; failed to queue event for replay: {queue_error:#}"
+                        )),
+                    }
+                }
+                failures.push(failure);
             }
         }
         if failures.is_empty() {
@@ -145,6 +233,14 @@ pub fn configure_process_sinks(
     log_override: Option<&Path>,
     command_override: Option<&Path>,
 ) -> Result<EventDispatcher> {
+    configure_process_sinks_with_outbox(log_override, command_override, None)
+}
+
+pub fn configure_process_sinks_with_outbox(
+    log_override: Option<&Path>,
+    command_override: Option<&Path>,
+    outbox_override: Option<&Path>,
+) -> Result<EventDispatcher> {
     if let Some(path) = log_override {
         let path = absolute_path(path.to_path_buf())?;
         std::env::set_var(EVENT_LOG_ENV, &path);
@@ -154,6 +250,10 @@ pub fn configure_process_sinks(
         validate_command(&path)?;
         std::env::set_var(EVENT_COMMAND_ENV, &path);
     }
+    if let Some(path) = outbox_override {
+        let path = absolute_path(path.to_path_buf())?;
+        std::env::set_var(EVENT_OUTBOX_ENV, &path);
+    }
     let dispatcher = EventDispatcher::from_environment()?;
     if let Some(path) = dispatcher.log() {
         std::env::set_var(EVENT_LOG_ENV, path);
@@ -161,7 +261,274 @@ pub fn configure_process_sinks(
     if let Some(path) = dispatcher.command() {
         std::env::set_var(EVENT_COMMAND_ENV, path);
     }
+    if let Some(outbox) = dispatcher.outbox() {
+        std::env::set_var(EVENT_OUTBOX_ENV, outbox.directory());
+    }
     Ok(dispatcher)
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct EventOutbox {
+    directory: PathBuf,
+}
+
+impl EventOutbox {
+    pub fn from_environment() -> Result<Self> {
+        let directory = if let Some(path) =
+            std::env::var_os(EVENT_OUTBOX_ENV).filter(|value| !value.is_empty())
+        {
+            PathBuf::from(path)
+        } else if let Some(path) =
+            std::env::var_os("DUTIS_STATE_DIR").filter(|value| !value.is_empty())
+        {
+            PathBuf::from(path).join("event-outbox")
+        } else {
+            let home = std::env::var_os("HOME").ok_or_else(|| {
+                anyhow!("HOME is not set; set DUTIS_EVENT_OUTBOX or DUTIS_STATE_DIR explicitly")
+            })?;
+            PathBuf::from(home).join("Library/Application Support/dutis/event-outbox")
+        };
+        Ok(Self::new(absolute_path(directory)?))
+    }
+
+    pub fn new(directory: impl Into<PathBuf>) -> Self {
+        Self {
+            directory: directory.into(),
+        }
+    }
+
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    pub fn enqueue(&self, event: &EventEnvelope) -> Result<PendingEvent> {
+        validate_event(event)?;
+        let now = current_timestamp()?;
+        let path = self.record_path(&event.id)?;
+        let existing = if path.is_file() {
+            Some(self.load_path(&path)?)
+        } else {
+            None
+        };
+        let pending = PendingEvent {
+            schema_version: PENDING_EVENT_SCHEMA_VERSION,
+            queued_at: existing
+                .as_ref()
+                .map_or_else(|| now.clone(), |record| record.queued_at.clone()),
+            last_attempted_at: now,
+            attempts: existing.map_or(1, |record| record.attempts.saturating_add(1)),
+            event: event.clone(),
+        };
+        self.store(&pending)?;
+        Ok(pending)
+    }
+
+    pub fn pending(&self) -> Result<Vec<PendingEventSummary>> {
+        Ok(self
+            .load_all()?
+            .into_iter()
+            .map(|pending| PendingEventSummary {
+                id: pending.event.id,
+                event_type: pending.event.event_type,
+                source: pending.event.source,
+                emitted_at: pending.event.emitted_at,
+                queued_at: pending.queued_at,
+                last_attempted_at: pending.last_attempted_at,
+                attempts: pending.attempts,
+            })
+            .collect())
+    }
+
+    pub fn replay(&self, command: &Path, limit: usize) -> Result<ReplayReport> {
+        validate_command(command)?;
+        if limit == 0 {
+            bail!("replay limit must be at least 1");
+        }
+        let pending = self.load_all()?;
+        let mut results = Vec::new();
+        let mut delivered = 0;
+        let mut failed = 0;
+        for mut record in pending.into_iter().take(limit) {
+            let mut encoded = serde_json::to_vec(&record.event)?;
+            encoded.push(b'\n');
+            match run_event_command(command, &record.event, &encoded) {
+                Ok(()) => {
+                    fs::remove_file(self.record_path(&record.event.id)?).with_context(|| {
+                        format!("failed to remove delivered event {}", record.event.id)
+                    })?;
+                    delivered += 1;
+                    results.push(ReplayResult {
+                        id: record.event.id,
+                        status: "delivered",
+                        error: None,
+                    });
+                }
+                Err(error) => {
+                    record.attempts = record.attempts.saturating_add(1);
+                    record.last_attempted_at = current_timestamp()?;
+                    self.store(&record)?;
+                    failed += 1;
+                    results.push(ReplayResult {
+                        id: record.event.id,
+                        status: "failed",
+                        error: Some(format!("{error:#}")),
+                    });
+                }
+            }
+        }
+        let remaining = self.load_all()?.len();
+        Ok(ReplayReport {
+            attempted: delivered + failed,
+            delivered,
+            failed,
+            remaining,
+            results,
+        })
+    }
+
+    fn load_all(&self) -> Result<Vec<PendingEvent>> {
+        if !self.directory.exists() {
+            return Ok(Vec::new());
+        }
+        let mut paths = Vec::new();
+        for entry in fs::read_dir(&self.directory)
+            .with_context(|| format!("failed to read {}", self.directory.display()))?
+        {
+            let path = entry
+                .with_context(|| format!("failed to read {}", self.directory.display()))?
+                .path();
+            if path
+                .extension()
+                .is_some_and(|extension| extension == "json")
+            {
+                paths.push(path);
+            }
+        }
+        paths.sort();
+        let mut pending = paths
+            .iter()
+            .map(|path| self.load_path(path))
+            .collect::<Result<Vec<_>>>()?;
+        pending.sort_by(|left, right| {
+            (&left.queued_at, &left.event.id).cmp(&(&right.queued_at, &right.event.id))
+        });
+        Ok(pending)
+    }
+
+    fn load_path(&self, path: &Path) -> Result<PendingEvent> {
+        let metadata = fs::symlink_metadata(path)
+            .with_context(|| format!("failed to inspect pending event {}", path.display()))?;
+        if !metadata.file_type().is_file() {
+            bail!("pending event is not a regular file: {}", path.display());
+        }
+        if metadata.len() > MAX_PENDING_EVENT_BYTES {
+            bail!("pending event {} exceeds the size limit", path.display());
+        }
+        let file = fs::File::open(path)
+            .with_context(|| format!("failed to open pending event {}", path.display()))?;
+        let pending: PendingEvent = serde_json::from_reader(BufReader::new(file))
+            .with_context(|| format!("failed to parse pending event {}", path.display()))?;
+        validate_pending_event(&pending)?;
+        let expected = self.record_path(&pending.event.id)?;
+        if expected != path {
+            bail!(
+                "pending event ID does not match its filename: {}",
+                path.display()
+            );
+        }
+        Ok(pending)
+    }
+
+    fn store(&self, pending: &PendingEvent) -> Result<()> {
+        validate_pending_event(pending)?;
+        create_private_directories(&self.directory)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&self.directory, fs::Permissions::from_mode(0o700))?;
+        }
+        let destination = self.record_path(&pending.event.id)?;
+        let sequence = EVENT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let temporary = self.directory.join(format!(
+            ".{}.{}.{}.tmp",
+            pending.event.id,
+            std::process::id(),
+            sequence
+        ));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options
+            .open(&temporary)
+            .with_context(|| format!("failed to create {}", temporary.display()))?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, pending)?;
+        writer.write_all(b"\n")?;
+        writer.flush()?;
+        writer.get_ref().sync_all()?;
+        fs::rename(&temporary, &destination)
+            .with_context(|| format!("failed to atomically store event {}", pending.event.id))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&destination, fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(())
+    }
+
+    fn record_path(&self, id: &str) -> Result<PathBuf> {
+        validate_event_id(id)?;
+        Ok(self.directory.join(format!("{id}.json")))
+    }
+}
+
+fn validate_pending_event(pending: &PendingEvent) -> Result<()> {
+    if pending.schema_version != PENDING_EVENT_SCHEMA_VERSION {
+        bail!(
+            "unsupported pending event schema version {}; expected {}",
+            pending.schema_version,
+            PENDING_EVENT_SCHEMA_VERSION
+        );
+    }
+    if pending.attempts == 0 {
+        bail!("pending event attempt count must be at least 1");
+    }
+    validate_event(&pending.event)
+}
+
+fn validate_event(event: &EventEnvelope) -> Result<()> {
+    if event.schema_version != EVENT_SCHEMA_VERSION {
+        bail!(
+            "unsupported event schema version {}; expected {}",
+            event.schema_version,
+            EVENT_SCHEMA_VERSION
+        );
+    }
+    validate_event_id(&event.id)
+}
+
+fn validate_event_id(id: &str) -> Result<()> {
+    if id.is_empty()
+        || id.len() > 256
+        || !id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        bail!(
+            "event ID must contain 1 to 256 ASCII letters, numbers, dots, underscores, or hyphens"
+        );
+    }
+    Ok(())
+}
+
+fn current_timestamp() -> Result<String> {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .context("failed to format event timestamp")
 }
 
 pub fn emit_best_effort<T: Serialize>(event_type: EventType, source: EventSource, payload: &T) {
@@ -252,14 +619,10 @@ fn create_private_directories(path: &Path) -> Result<()> {
 }
 
 fn run_event_command(command: &Path, event: &EventEnvelope, encoded: &[u8]) -> Result<()> {
-    let event_type = serde_json::to_value(event.event_type)?;
-    let event_type = event_type
-        .as_str()
-        .ok_or_else(|| anyhow!("event type did not serialize as a string"))?;
     let mut process = Command::new(command);
     process
         .env("DUTIS_EVENT_ID", &event.id)
-        .env("DUTIS_EVENT_TYPE", event_type)
+        .env("DUTIS_EVENT_TYPE", event.event_type.as_str())
         .env_remove("DUTIS_APPROVAL_TOKEN")
         .env_remove("DUTIS_MCP_APPROVAL_TOKEN")
         .env_remove("DUTIS_WATCH_APPROVAL_TOKEN")
@@ -433,6 +796,108 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("rejected"));
         assert_eq!(fs::read_to_string(log).unwrap().lines().count(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_command_events_are_persisted_and_replayed_until_delivered() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_root("outbox-replay");
+        fs::create_dir_all(&root).unwrap();
+        let failing = root.join("fail.sh");
+        fs::write(&failing, "#!/bin/sh\necho unavailable >&2\nexit 7\n").unwrap();
+        fs::set_permissions(&failing, fs::Permissions::from_mode(0o700)).unwrap();
+        let delivered = root.join("delivered.jsonl");
+        let succeeding = root.join("succeed.sh");
+        fs::write(
+            &succeeding,
+            "#!/bin/sh\n/bin/cat >> \"$DUTIS_TEST_EVENT_OUTPUT\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&succeeding, fs::Permissions::from_mode(0o700)).unwrap();
+        std::env::set_var("DUTIS_TEST_EVENT_OUTPUT", &delivered);
+
+        let outbox = EventOutbox::new(root.join("outbox"));
+        let dispatcher =
+            EventDispatcher::with_outbox(None, Some(failing.clone()), Some(outbox.clone()))
+                .unwrap();
+        let error = dispatcher
+            .emit(
+                EventType::MutationCompleted,
+                EventSource::Governance,
+                &json!({"audit_id": "audit-1"}),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("queued for replay"));
+        let pending = outbox.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].attempts, 1);
+        assert_eq!(
+            fs::metadata(outbox.directory())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+
+        let report = outbox.replay(&failing, 100).unwrap();
+        assert_eq!(
+            (report.delivered, report.failed, report.remaining),
+            (0, 1, 1)
+        );
+        assert_eq!(outbox.pending().unwrap()[0].attempts, 2);
+
+        let report = outbox.replay(&succeeding, 100).unwrap();
+        assert_eq!(
+            (report.delivered, report.failed, report.remaining),
+            (1, 0, 0)
+        );
+        let event: EventEnvelope =
+            serde_json::from_str(fs::read_to_string(&delivered).unwrap().trim()).unwrap();
+        assert_eq!(event.event_type, EventType::MutationCompleted);
+        assert!(outbox.pending().unwrap().is_empty());
+
+        std::env::remove_var("DUTIS_TEST_EVENT_OUTPUT");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn outbox_rejects_records_whose_filename_does_not_match_the_event_id() {
+        let root = temp_root("outbox-invalid");
+        let outbox = EventOutbox::new(root.join("outbox"));
+        let event = EventEnvelope::new(
+            EventType::DriftChecked,
+            EventSource::Watcher,
+            &json!({"state": "in_sync"}),
+        )
+        .unwrap();
+        let pending = outbox.enqueue(&event).unwrap();
+        let original = outbox.record_path(&pending.event.id).unwrap();
+        fs::rename(&original, outbox.directory().join("different.json")).unwrap();
+        assert!(outbox
+            .pending()
+            .unwrap_err()
+            .to_string()
+            .contains("does not match its filename"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn outbox_rejects_symlinked_records() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_root("outbox-symlink");
+        let directory = root.join("outbox");
+        fs::create_dir_all(&directory).unwrap();
+        let external = root.join("external.json");
+        fs::write(&external, b"{}\n").unwrap();
+        symlink(&external, directory.join("linked.json")).unwrap();
+        let error = EventOutbox::new(&directory).pending().unwrap_err();
+        assert!(error.to_string().contains("not a regular file"));
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{
-    ApplyArgs, Cli, CliCommand, ConfigArgs, ExtensionArgs, HandlerArgs, HandlerCommand,
-    HandlerDefaultsArgs, HandlerGetArgs, HandlerSetArgs, LaunchAgentArgs, LaunchAgentCommand,
-    LaunchAgentInstallArgs, McpArgs, OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand,
-    ProfileArgs, ProfileCommand, ProfileShowArgs, RecommendArgs, RollbackArgs, SetArgs,
-    SnapshotArgs, SnapshotCommand, SnapshotCreateArgs, WatchArgs,
+    ApplyArgs, Cli, CliCommand, ConfigArgs, EventReplayArgs, EventsArgs, EventsCommand,
+    ExtensionArgs, HandlerArgs, HandlerCommand, HandlerDefaultsArgs, HandlerGetArgs,
+    HandlerSetArgs, LaunchAgentArgs, LaunchAgentCommand, LaunchAgentInstallArgs, McpArgs,
+    OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand, ProfileArgs, ProfileCommand,
+    ProfileShowArgs, RecommendArgs, RollbackArgs, SetArgs, SnapshotArgs, SnapshotCommand,
+    SnapshotCreateArgs, WatchArgs,
 };
 use colored::*;
 use dutis::application::{
@@ -16,8 +17,8 @@ use dutis::association::{AssociationKind, AssociationTarget, HandlerRole};
 use dutis::config::DutisConfig;
 use dutis::drift::{send_macos_notification, DriftReport, DriftState, DriftTracker};
 use dutis::events::{
-    configure_process_sinks, emit_best_effort, EventSource, EventType, EVENT_COMMAND_ENV,
-    EVENT_LOG_ENV,
+    configure_process_sinks_with_outbox, emit_best_effort, EventDispatcher, EventOutbox,
+    EventSource, EventType, EVENT_COMMAND_ENV, EVENT_LOG_ENV, EVENT_OUTBOX_ENV,
 };
 use dutis::governance::{
     execute_governed_plan, ApprovalMode, AuditStore, GovernanceErrorKind, GovernedMutation,
@@ -241,9 +242,12 @@ fn main() -> ExitCode {
         .map(command_name)
         .unwrap_or("interactive");
     let json = cli.command.as_ref().is_some_and(command_uses_json);
-    let event_setup =
-        configure_process_sinks(cli.event_log.as_deref(), cli.event_command.as_deref())
-            .map_err(|error| CliError::usage(format!("invalid event sink: {error:#}")));
+    let event_setup = configure_process_sinks_with_outbox(
+        cli.event_log.as_deref(),
+        cli.event_command.as_deref(),
+        cli.event_outbox.as_deref(),
+    )
+    .map_err(|error| CliError::usage(format!("invalid event sink: {error:#}")));
 
     match event_setup.and_then(|_| dispatch(cli.command)) {
         Ok(()) => ExitCode::SUCCESS,
@@ -289,6 +293,7 @@ fn dispatch(command: Option<CliCommand>) -> Result<(), CliError> {
         Some(CliCommand::Recommend(args)) => run_recommend(args),
         Some(CliCommand::Handler(args)) => run_handler(args),
         Some(CliCommand::Watch(args)) => run_watch(args),
+        Some(CliCommand::Events(args)) => run_events(args),
         Some(CliCommand::LaunchAgent(args)) => run_launch_agent(args),
         Some(CliCommand::Mcp(args)) => run_mcp(args),
         Some(CliCommand::Doctor(args)) => run_doctor(args),
@@ -313,6 +318,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Recommend(_) => "recommend",
         CliCommand::Handler(_) => "handler",
         CliCommand::Watch(_) => "watch",
+        CliCommand::Events(_) => "events",
         CliCommand::LaunchAgent(_) => "launch-agent",
         CliCommand::Mcp(_) => "mcp",
         CliCommand::Doctor(_) => "doctor",
@@ -348,12 +354,89 @@ fn command_uses_json(command: &CliCommand) -> bool {
             HandlerCommand::Set(args) => args.json,
         },
         CliCommand::Watch(args) => args.json,
+        CliCommand::Events(args) => match &args.command {
+            EventsCommand::Pending(args) => args.json,
+            EventsCommand::Replay(args) => args.json,
+        },
         CliCommand::LaunchAgent(args) => match &args.command {
             LaunchAgentCommand::Install(args) => args.json,
             LaunchAgentCommand::Uninstall(args) | LaunchAgentCommand::Status(args) => args.json,
         },
         CliCommand::Mcp(_) => false,
     }
+}
+
+fn run_events(args: EventsArgs) -> Result<(), CliError> {
+    match args.command {
+        EventsCommand::Pending(args) => run_events_pending(args),
+        EventsCommand::Replay(args) => run_events_replay(args),
+    }
+}
+
+fn run_events_pending(args: OutputArgs) -> Result<(), CliError> {
+    let outbox = EventOutbox::from_environment().map_err(|error| {
+        CliError::operation(format!("failed to locate event outbox: {error:#}"))
+    })?;
+    let pending = outbox
+        .pending()
+        .map_err(|error| CliError::operation(format!("failed to read event outbox: {error:#}")))?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "events",
+            data: &pending,
+        })?;
+    } else if pending.is_empty() {
+        println!("No pending event deliveries.");
+    } else {
+        for event in pending {
+            println!(
+                "{}\t{}\tattempts={}\t{}",
+                event.id,
+                event.event_type.as_str(),
+                event.attempts,
+                event.last_attempted_at
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_events_replay(args: EventReplayArgs) -> Result<(), CliError> {
+    let dispatcher = EventDispatcher::from_environment()
+        .map_err(|error| CliError::usage(format!("invalid event sink: {error:#}")))?;
+    let command = dispatcher.command().ok_or_else(|| {
+        CliError::usage("events replay requires --event-command or DUTIS_EVENT_COMMAND")
+    })?;
+    let outbox = EventOutbox::from_environment().map_err(|error| {
+        CliError::operation(format!("failed to locate event outbox: {error:#}"))
+    })?;
+    let limit = usize::try_from(args.limit)
+        .map_err(|_| CliError::usage("event replay limit is too large for this platform"))?;
+    let report = outbox.replay(command, limit).map_err(|error| {
+        CliError::operation(format!("failed to replay pending events: {error:#}"))
+    })?;
+    if report.failed > 0 {
+        let details = serde_json::to_value(&report)
+            .map_err(|error| CliError::operation(format!("failed to serialize report: {error}")))?;
+        return Err(CliError::partial_failure(
+            format!("{} event deliveries failed", report.failed),
+            details,
+        ));
+    }
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "events",
+            data: report,
+        })?;
+    } else {
+        println!(
+            "Replayed {} event(s); {} remain pending.",
+            report.delivered, report.remaining
+        );
+    }
+    Ok(())
 }
 
 fn run_handler(args: HandlerArgs) -> Result<(), CliError> {
@@ -780,7 +863,7 @@ fn run_launch_agent_install(args: LaunchAgentInstallArgs) -> Result<(), CliError
             value.to_string_lossy().into_owned(),
         );
     }
-    for name in [EVENT_LOG_ENV, EVENT_COMMAND_ENV] {
+    for name in [EVENT_LOG_ENV, EVENT_COMMAND_ENV, EVENT_OUTBOX_ENV] {
         if let Some(value) = std::env::var_os(name).filter(|value| !value.is_empty()) {
             environment.insert(name.to_owned(), value.to_string_lossy().into_owned());
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,3 +1,4 @@
+use dutis::events::{EventEnvelope, EventOutbox, EventSource, EventType};
 use serde_json::Value;
 use std::fs;
 use std::io::Write;
@@ -117,6 +118,114 @@ fn history_is_empty_for_an_isolated_state_directory() {
     let response: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(response["command"], "history");
     assert_eq!(response["data"].as_array().unwrap().len(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn pending_events_can_be_inspected_and_replayed_from_the_cli() {
+    use serde_json::json;
+    use std::os::unix::fs::PermissionsExt;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "dutis-cli-event-replay-{}-{unique}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    let outbox_path = root.join("outbox");
+    let outbox = EventOutbox::new(&outbox_path);
+    let event = EventEnvelope::new(
+        EventType::DriftChecked,
+        EventSource::Watcher,
+        &json!({"state": "drift_detected"}),
+    )
+    .unwrap();
+    outbox.enqueue(&event).unwrap();
+
+    let pending = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "pending",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(pending.status.success());
+    let response: Value = serde_json::from_slice(&pending.stdout).unwrap();
+    assert_eq!(response["data"][0]["id"], event.id);
+    assert_eq!(response["data"][0]["attempts"], 1);
+
+    let missing_command = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "replay",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(missing_command.status.code(), Some(2));
+
+    let received = root.join("received.jsonl");
+    let command = root.join("sink.sh");
+    fs::write(&command, "#!/bin/sh\necho unavailable >&2\nexit 7\n").unwrap();
+    fs::set_permissions(&command, fs::Permissions::from_mode(0o700)).unwrap();
+    let failed_replay = dutis()
+        .args([
+            "--event-command",
+            command.to_str().unwrap(),
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "replay",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(failed_replay.status.code(), Some(8));
+    let response: Value = serde_json::from_slice(&failed_replay.stdout).unwrap();
+    assert_eq!(response["error"]["details"]["failed"], 1);
+    assert_eq!(response["error"]["details"]["remaining"], 1);
+    assert_eq!(outbox.pending().unwrap()[0].attempts, 2);
+
+    fs::write(
+        &command,
+        "#!/bin/sh\n/bin/cat >> \"$DUTIS_TEST_EVENT_OUTPUT\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&command, fs::Permissions::from_mode(0o700)).unwrap();
+    let replay = dutis()
+        .env("DUTIS_TEST_EVENT_OUTPUT", &received)
+        .args([
+            "--event-command",
+            command.to_str().unwrap(),
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "replay",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        replay.status.success(),
+        "{}",
+        String::from_utf8_lossy(&replay.stderr)
+    );
+    let response: Value = serde_json::from_slice(&replay.stdout).unwrap();
+    assert_eq!(response["data"]["delivered"], 1);
+    assert_eq!(response["data"]["remaining"], 0);
+    let delivered: Value =
+        serde_json::from_str(fs::read_to_string(received).unwrap().trim()).unwrap();
+    assert_eq!(delivered["id"], event.id);
+    assert!(outbox.pending().unwrap().is_empty());
+    fs::remove_dir_all(root).unwrap();
 }
 
 #[test]

--- a/tests/http_adapter.rs
+++ b/tests/http_adapter.rs
@@ -248,3 +248,101 @@ fn watcher_event_flows_through_external_adapter_to_transport() {
     assert_eq!(event["payload"]["state"], "drift_detected");
     fs::remove_dir_all(root).unwrap();
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+fn failed_http_delivery_is_durably_queued_and_replayed() {
+    let root = temp_root("outbox-replay");
+    let bin = root.join("bin");
+    fs::create_dir(&bin).unwrap();
+    let fake_duti = bin.join("duti");
+    write_executable(
+        &fake_duti,
+        concat!(
+            "#!/bin/sh\n",
+            "if [ \"$1\" = \"-V\" ]; then printf 'test-duti\\n'; exit 0; fi\n",
+            "if [ \"$1\" = \"-x\" ]; then printf 'Other\\n/Applications/Other.app\\ncom.example.Other\\n'; exit 0; fi\n",
+            "exit 99\n",
+        ),
+    );
+    let fake_curl = root.join("curl");
+    write_executable(
+        &fake_curl,
+        concat!(
+            "#!/bin/sh\n",
+            "if [ -e \"$DUTIS_FAIL_MARKER\" ]; then exit 22; fi\n",
+            "body_path=$(/usr/bin/sed -n 's/^data-binary = \"@\\(.*\\)\"$/\\1/p' \"$3\")\n",
+            "/bin/cp \"$body_path\" \"$DUTIS_CAPTURE_BODY\"\n",
+        ),
+    );
+    let config = root.join("dutis.toml");
+    fs::write(
+        &config,
+        "version = 1\n[associations]\nmd = 'com.apple.TextEdit'\n",
+    )
+    .unwrap();
+    let state = root.join("state");
+    let fail_marker = root.join("fail");
+    fs::write(&fail_marker, b"").unwrap();
+    let captured_body = root.join("body");
+
+    let watch = dutis()
+        .env("PATH", &bin)
+        .env("DUTIS_STATE_DIR", &state)
+        .env("DUTIS_HTTP_ENDPOINT", ENDPOINT)
+        .env("DUTIS_HTTP_BEARER_TOKEN", TOKEN)
+        .env("DUTIS_HTTP_CURL", &fake_curl)
+        .env("DUTIS_FAIL_MARKER", &fail_marker)
+        .env("DUTIS_CAPTURE_BODY", &captured_body)
+        .args([
+            "--event-command",
+            env!("CARGO_BIN_EXE_dutis-event-http"),
+            "watch",
+            config.to_str().unwrap(),
+            "--once",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(watch.status.success());
+    assert!(String::from_utf8_lossy(&watch.stderr).contains("queued for replay"));
+
+    let pending = dutis()
+        .env("DUTIS_STATE_DIR", &state)
+        .args(["events", "pending", "--json"])
+        .output()
+        .unwrap();
+    assert!(pending.status.success());
+    let response: Value = serde_json::from_slice(&pending.stdout).unwrap();
+    assert_eq!(response["data"].as_array().unwrap().len(), 1);
+    let event_id = response["data"][0]["id"].as_str().unwrap().to_owned();
+
+    fs::remove_file(&fail_marker).unwrap();
+    let replay = dutis()
+        .env("DUTIS_STATE_DIR", &state)
+        .env("DUTIS_HTTP_ENDPOINT", ENDPOINT)
+        .env("DUTIS_HTTP_BEARER_TOKEN", TOKEN)
+        .env("DUTIS_HTTP_CURL", &fake_curl)
+        .env("DUTIS_FAIL_MARKER", &fail_marker)
+        .env("DUTIS_CAPTURE_BODY", &captured_body)
+        .args([
+            "--event-command",
+            env!("CARGO_BIN_EXE_dutis-event-http"),
+            "events",
+            "replay",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        replay.status.success(),
+        "{}",
+        String::from_utf8_lossy(&replay.stderr)
+    );
+    let response: Value = serde_json::from_slice(&replay.stdout).unwrap();
+    assert_eq!(response["data"]["delivered"], 1);
+    assert_eq!(response["data"]["remaining"], 0);
+    let delivered: Value = serde_json::from_slice(&fs::read(&captured_body).unwrap()).unwrap();
+    assert_eq!(delivered["id"], event_id);
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
## Summary
- persist failed event-command deliveries atomically in a private local outbox
- add bounded oldest-first events pending and events replay CLI workflows
- retain event IDs and attempt counts for at-least-once, idempotent recovery
- propagate custom outbox paths to LaunchAgents and document recovery guarantees
- bump the release version to 2.17.0

## Safety
- replay retries only external delivery and never repeats the originating mutation
- malformed, oversized, mismatched, or symlinked queue records fail closed
- approval-token variables remain removed from event-command environments
- queue failures remain downstream of policy, audit, snapshots, and mutation outcomes

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline (123 tests)
- cargo build --release --bins --locked --offline
- cargo package --allow-dirty --locked --offline
- ruby -c scripts/render_homebrew_formula.rb
- end-to-end HTTP failure, durable queue, and recovery replay test