### PR TITLE
feat: add policy-aware recommendations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.17.0"
+version = "2.18.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.17.0"
+version = "2.18.0"
 edition = "2021"
 rust-version = "1.88"
 default-run = "dutis"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 - 🔌 **Local MCP Server**: Give agents read-only discovery and planning tools with separately gated writes
 - 🛡️ **Policy and Audit**: Enforce local allowlists and approvals with durable, verified mutation records
 - 💡 **Explainable Profiles**: Generate evidence-backed developer, designer, media, or minimal proposals without changing the system
+- 🏢 **Fleet-Aware Recommendations**: Apply local allowlists, protected targets, and ordered team preferences before proposing applications
 - 👀 **Drift Monitoring**: Detect association changes continuously, notify through macOS, and optionally remediate through snapshots and policy
 - 🔗 **Typed Associations**: Manage extensions, UTIs, MIME types, URL schemes, and Launch Services roles through one verified pipeline
 - 📡 **Event Sinks**: Stream versioned drift and mutation lifecycle events to private JSONL logs or trusted local commands
@@ -188,9 +189,20 @@ dutis profile show developer --json
 dutis recommend developer --json
 ```
 
-Recommendations show ordered candidates, installed paths, declared extension
-support, the current handler, the proposed TOML, a deterministic plan digest,
-and the effective policy assessment. They never change system associations.
+Recommendations use the effective local policy before selecting a target.
+Teams can deploy preferences without a remote control plane:
+
+```toml
+[recommendations]
+preferred_applications = ["com.microsoft.VSCode"]
+
+[recommendations.extensions]
+md = ["com.microsoft.VSCode", "com.apple.TextEdit"]
+```
+
+Results show each candidate's source, policy eligibility, installed paths,
+declared extension support, the proposed TOML, a deterministic plan digest, and
+the effective policy assessment. They never change system associations.
 Review [profiles and recommendations](docs/profiles-and-recommendations.md) for
 selection rules and the safe path from a proposal to an approved apply.
 

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -280,11 +280,32 @@ Acceptance criteria:
 - Queue failures and replay failures never change mutation, policy, audit,
   snapshot, or drift outcomes.
 
+## Phase 14: Policy-aware fleet recommendations
+
+Status: implemented for v2.18.0
+
+Use locally deployed team preferences and existing mutation constraints while
+ranking profile candidates, without adding a remote policy service.
+
+Acceptance criteria:
+
+- The version-one policy schema accepts ordered global and per-extension
+  recommendation preferences while remaining backward compatible.
+- Recommendation ranking honors protected targets, application/extension/kind
+  allowlists, extension preferences, and global preferences before profile
+  defaults.
+- Candidate evidence reports its source, policy eligibility, and concrete
+  exclusion reasons; blocked associations never enter proposed configuration.
+- CLI and MCP use the same effective local policy and return a plan that can be
+  independently rechecked by the existing governed workflow.
+- MCP callers cannot inject or replace policy, and no network control plane or
+  new mutation path is introduced.
+
 ## Near-term engineering sequence
 
-1. Release Phase 13 and validate outbox recovery with representative webhook
-   receivers and long-running LaunchAgents.
-2. Add policy-aware application recommendation inputs for teams and managed
-   fleets without introducing a remote control plane.
-3. Add explicit queue retention and operator-approved dead-letter cleanup
+1. Release Phase 14 and validate managed policy deployment across representative
+   developer and design fleets.
+2. Add explicit queue retention and operator-approved dead-letter cleanup
    after production replay behavior is established.
+3. Extend recommendation preferences to typed UTI, MIME, and URL-scheme
+   associations after gathering fleet usage evidence.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -32,7 +32,7 @@ The server advertises these read tools:
   definitions.
 - `dutis_profiles`: list built-in profiles and ordered candidates.
 - `dutis_profile`: inspect one profile by its `profile` name.
-- `dutis_recommend`: generate an explainable proposal, plan digest, and policy assessment by `profile` name.
+- `dutis_recommend`: generate an explainable policy-aware proposal, plan digest, and policy assessment by `profile` name.
 - `dutis_drift`: check inline TOML for drift and return a timestamped report with policy assessment.
 - `dutis_query`: find installed handlers for one extension.
 - `dutis_get`: inspect the current default handler.
@@ -62,6 +62,9 @@ extension and MIME queries. See
 
 Profile recommendations are also read-only. A recommendation is evidence, not
 approval: it does not register a mutation tool call or change an association.
+Candidate ordering uses the server's effective local policy, including
+recommendation preferences, allowlists, and protected associations. Callers
+cannot supply or replace fleet policy through the tool request.
 To use one, review its `proposed_toml`, rebuild it with `dutis_diff`, run
 `dutis_policy_check`, and follow the normal write approval flow.
 

--- a/docs/policy-and-audit.md
+++ b/docs/policy-and-audit.md
@@ -32,6 +32,12 @@ allowed_extensions = ["md", "txt"]
 allowed_kinds = ["extension", "uti", "mime", "url_scheme"]
 allowed_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
 
+[recommendations]
+preferred_applications = ["com.microsoft.VSCode"]
+
+[recommendations.extensions]
+md = ["com.microsoft.VSCode", "com.apple.TextEdit"]
+
 [protected_associations]
 pdf = "com.apple.Preview"
 
@@ -49,6 +55,12 @@ application = "com.apple.TextEdit"
   allow all four kinds; use an empty list to deny all kinds.
 - `allowed_applications` limits target bundle identifiers with the same
   omitted-versus-empty behavior.
+- `recommendations.preferred_applications` is an ordered fleet-wide preference
+  list. It reorders matching candidates already present in a built-in profile.
+- `recommendations.extensions` supplies ordered preferences for individual
+  extensions and may introduce a team-standard application that is not in the
+  built-in profile. Preferences remain constrained by all allowlists and
+  protected associations.
 - `protected_associations` permits an extension only when the target is the
   configured bundle identifier. This allows restoration to the protected value
   while denying changes away from it.

--- a/docs/profiles-and-recommendations.md
+++ b/docs/profiles-and-recommendations.md
@@ -24,20 +24,42 @@ dutis recommend developer --json
 ```
 
 Recommendation scans installed applications and reads current handlers. It
-does not change Launch Services. For each extension, Dutis:
+does not change Launch Services. It loads the effective local policy before
+ranking candidates. For each extension, Dutis:
 
-1. Keeps the current handler when it is a profile candidate with exactly one
-   installed application, minimizing unnecessary changes.
-2. Otherwise selects the first candidate with exactly one installed path.
-3. Marks the extension unavailable when every candidate is missing or a bundle
-   ID resolves to multiple paths. Unavailable entries are excluded from the
-   proposed configuration and plan.
+1. Honors a protected association as the required target.
+2. Applies ordered extension-specific preferences, then global preferences
+   that match candidates in the selected profile.
+3. Removes candidates excluded by kind, extension, or application allowlists.
+4. Keeps the current eligible profile candidate when no installed policy
+   preference takes precedence, minimizing unnecessary changes.
+5. Otherwise selects the first eligible candidate with one installed path.
+6. Marks an extension `policy_blocked` when installed candidates exist but are
+   excluded, or `unavailable` when no uniquely installed eligible candidate
+   exists. Neither result enters the proposed configuration or plan.
 
-Each result includes the candidate order, installed paths, whether the app
-declares support for the extension, the selected target, current handler, and
-a human-readable reason. The complete response also includes proposed TOML, a
-deterministic `AssociationPlan` and digest, and assessment against the current
-local policy.
+Each result includes candidate source (`profile`, `global_preference`,
+`extension_preference`, or `protected_policy`), policy eligibility and reasons,
+installed paths, declared extension support, selected target, current handler,
+and a human-readable explanation. The complete response also includes proposed
+TOML, a deterministic `AssociationPlan` and digest, and assessment against the
+same local policy.
+
+Configure recommendation inputs in the local policy file:
+
+```toml
+[recommendations]
+preferred_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
+
+[recommendations.extensions]
+md = ["com.microsoft.VSCode"]
+txt = ["com.apple.TextEdit", "com.microsoft.VSCode"]
+```
+
+`DUTIS_POLICY_FILE` selects the policy file. Otherwise Dutis uses
+`$DUTIS_STATE_DIR/policy.toml` or the normal per-user state directory. Teams can
+deploy that file with their existing device-management tooling; Dutis does not
+fetch policy or accept recommendation overrides from a remote service.
 
 Declared extension support is evidence rather than the only selector. Some
 applications accept formats that are not present in all versions of their
@@ -64,7 +86,8 @@ the resulting handlers.
 
 Read-only MCP servers advertise `dutis_profiles`, `dutis_profile`, and
 `dutis_recommend`. `dutis_recommend` accepts `{ "profile": "developer" }` and
-returns the same evidence, proposed configuration, plan, and policy assessment
-as the CLI. Agents must still use `dutis_diff` and `dutis_policy_check`, obtain
-explicit approval, and provide the freshly reviewed digest before calling a
-write tool.
+returns the same policy-aware evidence, proposed configuration, plan, and
+policy assessment as the CLI. It uses the server's effective local policy and
+does not accept caller-supplied policy. Agents must still use `dutis_diff` and
+`dutis_policy_check`, obtain explicit approval, and provide the freshly
+reviewed digest before calling a write tool.

--- a/dutis.policy.example.toml
+++ b/dutis.policy.example.toml
@@ -6,6 +6,16 @@ allowed_extensions = ["md", "txt", "json"]
 allowed_kinds = ["extension", "uti", "mime", "url_scheme"]
 allowed_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
 
+# Optional ordered inputs for profile recommendations. Global preferences only
+# reorder applications already in a profile. Extension preferences may add a
+# team-standard application to that extension's candidate list.
+[recommendations]
+preferred_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
+
+[recommendations.extensions]
+md = ["com.microsoft.VSCode"]
+txt = ["com.apple.TextEdit", "com.microsoft.VSCode"]
+
 # A protected extension may only remain on, or be restored to, this bundle ID.
 [protected_associations]
 pdf = "com.apple.Preview"

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -25,6 +25,9 @@ Use Dutis for macOS Launch Services associations. Preserve its
    inspect `dutis_profiles` / `dutis_profile`, then use `dutis_recommend` (or
    the equivalent CLI commands). Present candidate evidence and treat the
    recommendation strictly as a proposal, never as approval.
+   Treat candidate `policy_eligible`, `policy_reasons`, and `source` fields as
+   required evidence; do not substitute caller-provided preferences for the
+   effective local policy.
 3. Express multi-target changes as version 2 TOML. Build a fresh plan and
    run the policy check. Treat unresolved selectors or policy violations as a
    stop condition.

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -160,7 +160,9 @@ fn escape_applescript(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::governance::{ApprovalMode, PolicyAssessment, PolicySummary};
+    use crate::governance::{
+        ApprovalMode, PolicyAssessment, PolicySummary, RecommendationPreferences,
+    };
     use crate::planner::{assemble_plan, PlanEntry};
     use std::collections::BTreeMap;
     use std::path::PathBuf;
@@ -179,6 +181,7 @@ mod tests {
                 allowed_applications: None,
                 protected_associations: BTreeMap::new(),
                 protected_handlers: Vec::new(),
+                recommendations: RecommendationPreferences::default(),
             },
             PolicyAssessment {
                 allowed: true,

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -39,8 +39,15 @@ pub struct Policy {
     pub allowed_applications: Option<BTreeSet<String>>,
     pub protected_associations: BTreeMap<String, String>,
     pub protected_handlers: Vec<ProtectedHandler>,
+    pub recommendations: RecommendationPreferences,
     #[serde(skip_serializing)]
     approval_token_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize)]
+pub struct RecommendationPreferences {
+    pub preferred_applications: Vec<String>,
+    pub extensions: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -56,7 +63,18 @@ struct RawPolicy {
     protected_associations: BTreeMap<String, String>,
     #[serde(default)]
     protected_handlers: Vec<ProtectedHandler>,
+    #[serde(default)]
+    recommendations: RawRecommendationPreferences,
     approval_token_sha256: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRecommendationPreferences {
+    #[serde(default)]
+    preferred_applications: Vec<String>,
+    #[serde(default)]
+    extensions: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -79,6 +97,7 @@ impl Default for Policy {
             allowed_applications: None,
             protected_associations: BTreeMap::new(),
             protected_handlers: Vec::new(),
+            recommendations: RecommendationPreferences::default(),
             approval_token_sha256: None,
         }
     }
@@ -102,6 +121,7 @@ impl Policy {
             .allowed_applications
             .map(|values| normalize_nonempty_set(values, "allowed application"))
             .transpose()?;
+        let recommendations = normalize_recommendation_preferences(raw.recommendations)?;
         let allowed_kinds = raw.allowed_kinds.map(|values| values.into_iter().collect());
         let mut protected_associations = BTreeMap::new();
         for (input_extension, input_bundle_id) in raw.protected_associations {
@@ -167,6 +187,7 @@ impl Policy {
             allowed_applications,
             protected_associations,
             protected_handlers,
+            recommendations,
             approval_token_sha256: raw
                 .approval_token_sha256
                 .map(|digest| digest.to_ascii_lowercase()),
@@ -341,6 +362,7 @@ impl LoadedPolicy {
             allowed_applications: self.policy.allowed_applications.clone(),
             protected_associations: self.policy.protected_associations.clone(),
             protected_handlers: self.policy.protected_handlers.clone(),
+            recommendations: self.policy.recommendations.clone(),
         }
     }
 }
@@ -358,6 +380,7 @@ pub struct PolicySummary {
     pub allowed_applications: Option<BTreeSet<String>>,
     pub protected_associations: BTreeMap<String, String>,
     pub protected_handlers: Vec<ProtectedHandler>,
+    pub recommendations: RecommendationPreferences,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -783,6 +806,46 @@ fn normalize_nonempty_set(values: Vec<String>, label: &str) -> Result<BTreeSet<S
     Ok(normalized)
 }
 
+fn normalize_recommendation_preferences(
+    raw: RawRecommendationPreferences,
+) -> Result<RecommendationPreferences> {
+    let preferred_applications = normalize_nonempty_ordered(
+        raw.preferred_applications,
+        "preferred recommendation application",
+    )?;
+    let mut extensions = BTreeMap::new();
+    for (input_extension, applications) in raw.extensions {
+        let extension = normalize_extension(&input_extension)?;
+        let applications = normalize_nonempty_ordered(
+            applications,
+            &format!("recommendation application for .{extension}"),
+        )?;
+        if extensions.insert(extension.clone(), applications).is_some() {
+            bail!("duplicate recommendation extension .{extension}");
+        }
+    }
+    Ok(RecommendationPreferences {
+        preferred_applications,
+        extensions,
+    })
+}
+
+fn normalize_nonempty_ordered(values: Vec<String>, label: &str) -> Result<Vec<String>> {
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::with_capacity(values.len());
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() {
+            bail!("{label} cannot be empty");
+        }
+        if !seen.insert(value.to_owned()) {
+            bail!("duplicate {label} '{value}'");
+        }
+        normalized.push(value.to_owned());
+    }
+    Ok(normalized)
+}
+
 fn validate_record_id(id: &str) -> Result<()> {
     if id.is_empty()
         || !id
@@ -882,11 +945,41 @@ mod tests {
 
                 [protected_associations]
                 ".PDF" = "com.apple.Preview"
+
+                [recommendations]
+                preferred_applications = [" com.example.Editor "]
+
+                [recommendations.extensions]
+                ".MD" = ["com.example.TeamEditor", "com.example.Editor"]
             "#,
         )
         .unwrap();
         assert!(policy.allowed_extensions.unwrap().contains("md"));
         assert_eq!(policy.protected_associations["pdf"], "com.apple.Preview");
+        assert_eq!(
+            policy.recommendations.preferred_applications,
+            ["com.example.Editor"]
+        );
+        assert_eq!(
+            policy.recommendations.extensions["md"],
+            ["com.example.TeamEditor", "com.example.Editor"]
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_or_empty_recommendation_preferences() {
+        assert!(Policy::parse(
+            "version = 1\n[recommendations]\npreferred_applications = ['com.example.App', 'com.example.App']\n"
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("duplicate preferred recommendation application"));
+        assert!(
+            Policy::parse("version = 1\n[recommendations.extensions]\nmd = ['   ']\n")
+                .unwrap_err()
+                .to_string()
+                .contains("cannot be empty")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,9 @@ use dutis::planner::{
     assemble_plan, build_plan, AssociationPlan, PlanAction, PlanEntry, PlanSummary,
     PlannedApplication,
 };
-use dutis::profiles::{find_profile, profiles, recommend_profile, ProfileRecommendation};
+use dutis::profiles::{
+    find_profile, profiles, recommend_profile_with_policy, ProfileRecommendation,
+};
 use dutis::snapshot::{
     build_rollback_plan, capture_targets, SnapshotReason, SnapshotStore, SnapshotSummary,
 };
@@ -995,12 +997,15 @@ fn run_recommend(args: RecommendArgs) -> Result<(), CliError> {
     let catalog = scan_catalog()?;
     report_metadata_failures(catalog.metadata_failures);
     system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
-    let recommendation =
-        recommend_profile(&profile, &catalog.applications, system::query_default_app).map_err(
-            |error| CliError::operation(format!("failed to build recommendation: {error:#}")),
-        )?;
     let policy = LoadedPolicy::from_environment()
         .map_err(|error| CliError::usage(format!("failed to load policy: {error:#}")))?;
+    let recommendation = recommend_profile_with_policy(
+        &profile,
+        &catalog.applications,
+        system::query_default_app,
+        &policy.policy,
+    )
+    .map_err(|error| CliError::operation(format!("failed to build recommendation: {error:#}")))?;
     let result = RecommendResult {
         metadata_failures: catalog.metadata_failures,
         assessment: policy.policy.assess(&recommendation.plan),
@@ -1034,11 +1039,18 @@ fn run_recommend(args: RecommendArgs) -> Result<(), CliError> {
                     .map(|path| path.display().to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
+                let policy_status = if candidate.policy_eligible {
+                    "eligible".to_owned()
+                } else {
+                    format!("blocked: {}", candidate.policy_reasons.join(", "))
+                };
                 println!(
-                    "  {}. {} [{}; installed={}; declares_extension={}]{}",
+                    "  {}. {} [{}; source={}; policy={}; installed={}; declares_extension={}]{}",
                     candidate.priority,
                     candidate.bundle_id,
                     status,
+                    candidate.source.as_str(),
+                    policy_status,
                     candidate.installed_paths.len(),
                     candidate.declares_extension,
                     if paths.is_empty() {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -11,7 +11,7 @@ use crate::governance::{
 };
 use crate::launch_services;
 use crate::planner::{build_plan, AssociationPlan};
-use crate::profiles::{find_profile, profiles, recommend_profile};
+use crate::profiles::{find_profile, profiles, recommend_profile_with_policy};
 use crate::snapshot::{build_rollback_plan, SnapshotReason, SnapshotStore};
 use crate::system;
 use anyhow::{anyhow, Context, Result};
@@ -129,9 +129,13 @@ impl McpBackend for SystemBackend {
         let profile = find_profile(name).ok_or_else(|| anyhow!("unknown profile '{name}'"))?;
         let catalog = ApplicationCatalog::scan()?;
         system::duti_version()?;
-        let recommendation =
-            recommend_profile(&profile, &catalog.applications, system::query_default_app)?;
         let policy = LoadedPolicy::from_environment()?;
+        let recommendation = recommend_profile_with_policy(
+            &profile,
+            &catalog.applications,
+            system::query_default_app,
+            &policy.policy,
+        )?;
         Ok(json!({
             "metadata_failures": catalog.metadata_failures,
             "assessment": policy.policy.assess(&recommendation.plan),
@@ -801,7 +805,7 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
         ),
         tool_definition(
             "dutis_recommend",
-            "Generate an explainable profile proposal, deterministic plan, and policy assessment without changing the system.",
+            "Generate an explainable policy-aware profile proposal and deterministic plan without changing the system.",
             profile_schema,
             read_annotations.clone(),
         ),

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,6 +1,7 @@
 use crate::application::Application;
 use crate::association::{AssociationKind, HandlerRole};
 use crate::config::{DutisConfig, CONFIG_VERSION};
+use crate::governance::Policy;
 use crate::planner::{assemble_plan, AssociationPlan, PlanAction, PlanEntry, PlannedApplication};
 use crate::system::DefaultApplication;
 use anyhow::Result;
@@ -32,15 +33,39 @@ pub struct ProfileCandidate {
 pub enum RecommendationAction {
     Change,
     KeepCurrent,
+    PolicyBlocked,
     Unavailable,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CandidateSource {
+    ProtectedPolicy,
+    ExtensionPreference,
+    GlobalPreference,
+    Profile,
+}
+
+impl CandidateSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ProtectedPolicy => "protected_policy",
+            Self::ExtensionPreference => "extension_preference",
+            Self::GlobalPreference => "global_preference",
+            Self::Profile => "profile",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct CandidateEvidence {
     pub bundle_id: String,
     pub priority: usize,
+    pub source: CandidateSource,
     pub installed_paths: Vec<PathBuf>,
     pub declares_extension: bool,
+    pub policy_eligible: bool,
+    pub policy_reasons: Vec<String>,
     pub selected: bool,
     pub rationale: String,
 }
@@ -61,6 +86,7 @@ pub struct RecommendationSummary {
     pub available: usize,
     pub changes: usize,
     pub kept_current: usize,
+    pub policy_blocked: usize,
     pub unavailable: usize,
 }
 
@@ -98,26 +124,61 @@ pub fn recommend_profile<F>(
 where
     F: FnMut(&str) -> Result<Option<DefaultApplication>>,
 {
+    recommend_profile_internal(profile, applications, &mut query_default, None)
+}
+
+pub fn recommend_profile_with_policy<F>(
+    profile: &ProfileDefinition,
+    applications: &[Application],
+    mut query_default: F,
+    policy: &Policy,
+) -> Result<ProfileRecommendation>
+where
+    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+{
+    recommend_profile_internal(profile, applications, &mut query_default, Some(policy))
+}
+
+fn recommend_profile_internal<F>(
+    profile: &ProfileDefinition,
+    applications: &[Application],
+    query_default: &mut F,
+    policy: Option<&Policy>,
+) -> Result<ProfileRecommendation>
+where
+    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+{
     let mut proposed_associations = BTreeMap::new();
     let mut plan_entries = Vec::new();
     let mut recommendations = Vec::with_capacity(profile.associations.len());
 
     for association in &profile.associations {
         let current = query_default(association.extension)?;
-        let candidates = association
-            .candidates
-            .iter()
+        let required =
+            policy.and_then(|policy| required_application(policy, association.extension));
+        let candidates = ordered_candidates(association, policy, required);
+        let candidates = candidates
+            .into_iter()
             .enumerate()
             .map(|(index, candidate)| {
                 let matches = applications
                     .iter()
                     .filter(|application| {
-                        application.bundle_id.as_deref() == Some(candidate.bundle_id)
+                        application.bundle_id.as_deref() == Some(candidate.bundle_id.as_str())
                     })
                     .collect::<Vec<_>>();
+                let policy_reasons = policy.map_or_else(Vec::new, |policy| {
+                    policy_reasons(
+                        policy,
+                        association.extension,
+                        &candidate.bundle_id,
+                        required,
+                    )
+                });
                 CandidateEvidence {
-                    bundle_id: candidate.bundle_id.to_owned(),
+                    bundle_id: candidate.bundle_id,
                     priority: index + 1,
+                    source: candidate.source,
                     installed_paths: matches
                         .iter()
                         .map(|application| application.path.clone())
@@ -128,66 +189,95 @@ where
                             .iter()
                             .any(|extension| extension.eq_ignore_ascii_case(association.extension))
                     }),
+                    policy_eligible: policy_reasons.is_empty(),
+                    policy_reasons,
                     selected: false,
-                    rationale: candidate.rationale.to_owned(),
+                    rationale: candidate.rationale,
                 }
             })
             .collect::<Vec<_>>();
 
         let current_candidate = current.as_ref().and_then(|current| {
-            association
-                .candidates
+            candidates
                 .iter()
                 .position(|candidate| candidate.bundle_id == current.bundle_id)
         });
-        let selected_index = current_candidate
-            .filter(|index| candidates[*index].installed_paths.len() == 1)
+        let selected_index = candidates
+            .iter()
+            .position(|candidate| {
+                candidate.source != CandidateSource::Profile
+                    && candidate.policy_eligible
+                    && candidate.installed_paths.len() == 1
+            })
             .or_else(|| {
-                candidates
-                    .iter()
-                    .position(|candidate| candidate.installed_paths.len() == 1)
+                current_candidate.filter(|index| {
+                    candidates[*index].policy_eligible
+                        && candidates[*index].installed_paths.len() == 1
+                })
+            })
+            .or_else(|| {
+                candidates.iter().position(|candidate| {
+                    candidate.policy_eligible && candidate.installed_paths.len() == 1
+                })
             });
         let mut evidence = candidates;
 
         let (action, target, explanation) = if let Some(index) = selected_index {
             evidence[index].selected = true;
-            let selected = &association.candidates[index];
+            let selected = &evidence[index];
             let application = applications
                 .iter()
                 .find(|application| {
-                    application.bundle_id.as_deref() == Some(selected.bundle_id)
+                    application.bundle_id.as_deref() == Some(selected.bundle_id.as_str())
                         && application.path == evidence[index].installed_paths[0]
                 })
-                .expect("selected profile candidate has one installed application");
+                .expect("selected recommendation candidate has one installed application");
             let target = PlannedApplication::from_application(application)
-                .expect("profile candidates have bundle identifiers");
-            let keep_current =
-                current.as_ref().map(|value| value.bundle_id.as_str()) == Some(selected.bundle_id);
+                .expect("recommendation candidates have bundle identifiers");
+            let keep_current = current.as_ref().map(|value| value.bundle_id.as_str())
+                == Some(selected.bundle_id.as_str());
             let action = if keep_current {
                 RecommendationAction::KeepCurrent
             } else {
                 RecommendationAction::Change
             };
             let explanation = if keep_current {
-                format!(
-                    "Keep {} because the current handler is compatible with the {} profile.",
-                    application.name, profile.name
-                )
+                if policy.is_some() {
+                    format!(
+                        "Keep {} because the current handler is compatible with the {} profile and local policy.",
+                        application.name, profile.name
+                    )
+                } else {
+                    format!(
+                        "Keep {} because the current handler is compatible with the {} profile.",
+                        application.name, profile.name
+                    )
+                }
             } else {
-                format!(
-                    "Recommend {} because it is the highest-priority uniquely installed candidate for .{}: {}",
-                    application.name, association.extension, selected.rationale
-                )
+                match selected.source {
+                    CandidateSource::ProtectedPolicy => format!(
+                        "Recommend {} because local policy requires .{} to use {}.",
+                        application.name, association.extension, selected.bundle_id
+                    ),
+                    CandidateSource::ExtensionPreference | CandidateSource::GlobalPreference => {
+                        format!(
+                            "Recommend {} because it is the highest-priority uniquely installed local-policy preference for .{}.",
+                            application.name, association.extension
+                        )
+                    }
+                    CandidateSource::Profile => format!(
+                        "Recommend {} because it is the highest-priority uniquely installed candidate for .{}: {}",
+                        application.name, association.extension, selected.rationale
+                    ),
+                }
             };
-            proposed_associations.insert(
-                association.extension.to_owned(),
-                selected.bundle_id.to_owned(),
-            );
+            proposed_associations
+                .insert(association.extension.to_owned(), selected.bundle_id.clone());
             plan_entries.push(PlanEntry {
                 kind: AssociationKind::Extension,
                 role: HandlerRole::All,
                 extension: association.extension.to_owned(),
-                selector: selected.bundle_id.to_owned(),
+                selector: selected.bundle_id.clone(),
                 current: current.clone(),
                 target: Some(target.clone()),
                 action: if keep_current {
@@ -199,14 +289,26 @@ where
             });
             (action, Some(target), explanation)
         } else {
-            (
-                RecommendationAction::Unavailable,
-                None,
+            let blocked = evidence.iter().any(|candidate| {
+                candidate.installed_paths.len() == 1 && !candidate.policy_eligible
+            });
+            let action = if blocked {
+                RecommendationAction::PolicyBlocked
+            } else {
+                RecommendationAction::Unavailable
+            };
+            let explanation = if blocked {
                 format!(
-                    "No uniquely installed candidate is available for .{}; no change is proposed.",
+                    "Installed candidates for .{} are excluded by local policy; no change is proposed.",
                     association.extension
-                ),
-            )
+                )
+            } else {
+                format!(
+                    "No uniquely installed policy-eligible candidate is available for .{}; no change is proposed.",
+                    association.extension
+                )
+            };
+            (action, None, explanation)
         };
 
         recommendations.push(AssociationRecommendation {
@@ -240,6 +342,10 @@ where
             .iter()
             .filter(|recommendation| recommendation.action == RecommendationAction::KeepCurrent)
             .count(),
+        policy_blocked: recommendations
+            .iter()
+            .filter(|recommendation| recommendation.action == RecommendationAction::PolicyBlocked)
+            .count(),
         unavailable: recommendations
             .iter()
             .filter(|recommendation| recommendation.action == RecommendationAction::Unavailable)
@@ -255,6 +361,126 @@ where
         proposed_toml,
         plan,
     })
+}
+
+#[derive(Debug)]
+struct OrderedCandidate {
+    bundle_id: String,
+    source: CandidateSource,
+    rationale: String,
+}
+
+fn ordered_candidates(
+    association: &ProfileAssociation,
+    policy: Option<&Policy>,
+    required: Option<&str>,
+) -> Vec<OrderedCandidate> {
+    let mut candidates = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    let mut push = |bundle_id: &str, source: CandidateSource, rationale: String| {
+        if seen.insert(bundle_id.to_owned()) {
+            candidates.push(OrderedCandidate {
+                bundle_id: bundle_id.to_owned(),
+                source,
+                rationale,
+            });
+        }
+    };
+    if let Some(bundle_id) = required {
+        push(
+            bundle_id,
+            CandidateSource::ProtectedPolicy,
+            "Required by the local protected-association policy.".to_owned(),
+        );
+    }
+    if let Some(policy) = policy {
+        if let Some(preferences) = policy.recommendations.extensions.get(association.extension) {
+            for bundle_id in preferences {
+                push(
+                    bundle_id,
+                    CandidateSource::ExtensionPreference,
+                    format!("Preferred by local policy for .{}.", association.extension),
+                );
+            }
+        }
+        for bundle_id in &policy.recommendations.preferred_applications {
+            if association
+                .candidates
+                .iter()
+                .any(|candidate| candidate.bundle_id == bundle_id)
+            {
+                push(
+                    bundle_id,
+                    CandidateSource::GlobalPreference,
+                    "Preferred by local policy among profile candidates.".to_owned(),
+                );
+            }
+        }
+    }
+    for candidate in &association.candidates {
+        push(
+            candidate.bundle_id,
+            CandidateSource::Profile,
+            candidate.rationale.to_owned(),
+        );
+    }
+    candidates
+}
+
+fn required_application<'a>(policy: &'a Policy, extension: &str) -> Option<&'a str> {
+    policy
+        .protected_associations
+        .get(extension)
+        .map(String::as_str)
+        .or_else(|| {
+            policy
+                .protected_handlers
+                .iter()
+                .find(|handler| {
+                    handler.kind == AssociationKind::Extension
+                        && handler.identifier == extension
+                        && handler.role == HandlerRole::All
+                })
+                .map(|handler| handler.application.as_str())
+        })
+}
+
+fn policy_reasons(
+    policy: &Policy,
+    extension: &str,
+    bundle_id: &str,
+    required: Option<&str>,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if policy
+        .allowed_kinds
+        .as_ref()
+        .is_some_and(|kinds| !kinds.contains(&AssociationKind::Extension))
+    {
+        reasons.push("extension associations are not allowed".to_owned());
+    }
+    if policy
+        .allowed_extensions
+        .as_ref()
+        .is_some_and(|extensions| !extensions.contains(extension))
+    {
+        reasons.push(format!("extension .{extension} is not allowed"));
+    }
+    if policy
+        .allowed_applications
+        .as_ref()
+        .is_some_and(|applications| !applications.contains(bundle_id))
+    {
+        reasons.push(format!("application {bundle_id} is not allowed"));
+    }
+    if let Some(required) = required {
+        if required != bundle_id {
+            reasons.push(format!(
+                "protected association .{extension} requires {required}"
+            ));
+        }
+    }
+    reasons
 }
 
 fn developer_profile() -> ProfileDefinition {
@@ -570,5 +796,176 @@ mod tests {
         assert_eq!(recommendation.summary.unavailable, 1);
         assert_eq!(recommendation.plan.summary.total, 0);
         assert!(recommendation.proposed_config.associations.is_empty());
+    }
+
+    #[test]
+    fn extension_policy_preference_overrides_profile_order_and_current_handler() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: vec![ProfileAssociation {
+                extension: "md",
+                candidates: vec![
+                    candidate("com.example.First", "profile first"),
+                    candidate("com.example.Current", "current"),
+                ],
+            }],
+        };
+        let applications = vec![
+            app("First", "com.example.First", &["md"]),
+            app("Current", "com.example.Current", &["md"]),
+            app("Team", "com.example.Team", &["md"]),
+        ];
+        let policy =
+            Policy::parse("version = 1\n[recommendations.extensions]\nmd = ['com.example.Team']\n")
+                .unwrap();
+        let recommendation = recommend_profile_with_policy(
+            &profile,
+            &applications,
+            |extension| {
+                Ok(Some(DefaultApplication {
+                    kind: AssociationKind::Extension,
+                    role: HandlerRole::All,
+                    extension: extension.to_owned(),
+                    name: Some("Current".to_owned()),
+                    path: Some("/Applications/Current.app".to_owned()),
+                    bundle_id: "com.example.Current".to_owned(),
+                }))
+            },
+            &policy,
+        )
+        .unwrap();
+        let result = &recommendation.recommendations[0];
+        assert_eq!(result.action, RecommendationAction::Change);
+        assert_eq!(
+            result.target.as_ref().unwrap().bundle_id,
+            "com.example.Team"
+        );
+        assert_eq!(
+            result.evidence[0].source,
+            CandidateSource::ExtensionPreference
+        );
+        assert!(result.evidence[0].selected);
+        assert_eq!(recommendation.plan.summary.changes, 1);
+    }
+
+    #[test]
+    fn application_allowlist_skips_disallowed_profile_candidates() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: vec![ProfileAssociation {
+                extension: "md",
+                candidates: vec![
+                    candidate("com.example.Denied", "first"),
+                    candidate("com.example.Allowed", "second"),
+                ],
+            }],
+        };
+        let applications = vec![
+            app("Denied", "com.example.Denied", &["md"]),
+            app("Allowed", "com.example.Allowed", &["md"]),
+        ];
+        let policy =
+            Policy::parse("version = 1\nallowed_applications = ['com.example.Allowed']\n").unwrap();
+        let recommendation =
+            recommend_profile_with_policy(&profile, &applications, |_| Ok(None), &policy).unwrap();
+        let result = &recommendation.recommendations[0];
+        assert_eq!(
+            result.target.as_ref().unwrap().bundle_id,
+            "com.example.Allowed"
+        );
+        assert!(!result.evidence[0].policy_eligible);
+        assert!(result.evidence[0].policy_reasons[0].contains("not allowed"));
+        assert!(result.evidence[1].selected);
+        assert!(policy.assess(&recommendation.plan).allowed);
+    }
+
+    #[test]
+    fn global_policy_preference_reorders_existing_profile_candidates() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: vec![ProfileAssociation {
+                extension: "md",
+                candidates: vec![
+                    candidate("com.example.First", "first"),
+                    candidate("com.example.Standard", "standard"),
+                ],
+            }],
+        };
+        let applications = vec![
+            app("First", "com.example.First", &["md"]),
+            app("Standard", "com.example.Standard", &["md"]),
+        ];
+        let policy = Policy::parse(
+            "version = 1\n[recommendations]\npreferred_applications = ['com.example.Standard']\n",
+        )
+        .unwrap();
+        let recommendation =
+            recommend_profile_with_policy(&profile, &applications, |_| Ok(None), &policy).unwrap();
+        let result = &recommendation.recommendations[0];
+        assert_eq!(
+            result.target.as_ref().unwrap().bundle_id,
+            "com.example.Standard"
+        );
+        assert_eq!(result.evidence[0].source, CandidateSource::GlobalPreference);
+    }
+
+    #[test]
+    fn protected_association_introduces_and_selects_the_required_application() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: vec![ProfileAssociation {
+                extension: "md",
+                candidates: vec![candidate("com.example.Profile", "profile")],
+            }],
+        };
+        let applications = vec![
+            app("Profile", "com.example.Profile", &["md"]),
+            app("Required", "com.example.Required", &["md"]),
+        ];
+        let policy =
+            Policy::parse("version = 1\n[protected_associations]\nmd = 'com.example.Required'\n")
+                .unwrap();
+        let recommendation =
+            recommend_profile_with_policy(&profile, &applications, |_| Ok(None), &policy).unwrap();
+        let result = &recommendation.recommendations[0];
+        assert_eq!(
+            result.target.as_ref().unwrap().bundle_id,
+            "com.example.Required"
+        );
+        assert_eq!(result.evidence[0].source, CandidateSource::ProtectedPolicy);
+        assert!(!result.evidence[1].policy_eligible);
+        assert!(policy.assess(&recommendation.plan).allowed);
+    }
+
+    #[test]
+    fn reports_policy_blocked_when_only_installed_candidate_is_disallowed() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: vec![ProfileAssociation {
+                extension: "md",
+                candidates: vec![candidate("com.example.Editor", "candidate")],
+            }],
+        };
+        let policy =
+            Policy::parse("version = 1\nallowed_applications = ['com.example.Other']\n").unwrap();
+        let recommendation = recommend_profile_with_policy(
+            &profile,
+            &[app("Editor", "com.example.Editor", &["md"])],
+            |_| Ok(None),
+            &policy,
+        )
+        .unwrap();
+        assert_eq!(
+            recommendation.recommendations[0].action,
+            RecommendationAction::PolicyBlocked
+        );
+        assert_eq!(recommendation.summary.policy_blocked, 1);
+        assert_eq!(recommendation.summary.unavailable, 0);
+        assert_eq!(recommendation.plan.summary.total, 0);
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -799,7 +799,9 @@ fn policy_show_redacts_token_hash_and_audit_starts_empty() {
     let secret_hash = "a".repeat(64);
     fs::write(
         &policy_path,
-        format!("version = 1\napproval_mode = 'token'\napproval_token_sha256 = '{secret_hash}'\n"),
+        format!(
+            "version = 1\napproval_mode = 'token'\napproval_token_sha256 = '{secret_hash}'\n[recommendations]\npreferred_applications = ['com.example.TeamEditor']\n[recommendations.extensions]\nmd = ['com.example.Markdown']\n"
+        ),
     )
     .unwrap();
 
@@ -812,6 +814,14 @@ fn policy_show_redacts_token_hash_and_audit_starts_empty() {
     let policy: Value = serde_json::from_slice(&policy_output.stdout).unwrap();
     assert_eq!(policy["data"]["approval_mode"], "token");
     assert_eq!(policy["data"]["approval_token_configured"], true);
+    assert_eq!(
+        policy["data"]["recommendations"]["preferred_applications"][0],
+        "com.example.TeamEditor"
+    );
+    assert_eq!(
+        policy["data"]["recommendations"]["extensions"]["md"][0],
+        "com.example.Markdown"
+    );
     assert!(!String::from_utf8(policy_output.stdout)
         .unwrap()
         .contains(&secret_hash));


### PR DESCRIPTION
## Summary
- add backward-compatible global and per-extension recommendation preferences to policy v1
- rank candidates using protected targets, allowlists, local team preferences, and profile defaults
- expose candidate source, policy eligibility, and concrete exclusion reasons
- use the same effective local policy in CLI and MCP recommendations without caller policy injection
- bump the release version to 2.18.0

## Safety
- recommendations remain read-only proposals
- policy-blocked candidates never enter proposed configuration or plans
- no remote policy service or new mutation path is introduced
- generated plans still require independent policy checks, approval, snapshots, audit, and verification

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline (129 tests)
- cargo build --release --bins --locked --offline
- cargo package --allow-dirty --locked --offline
- ruby -c scripts/render_homebrew_formula.rb