### PR TITLE
feat: add event outbox retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.18.0"
+version = "2.19.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.18.0"
+version = "2.19.0"
 edition = "2021"
 rust-version = "1.88"
 default-run = "dutis"
@@ -27,7 +27,7 @@ plist = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "parsing"] }
 toml = "0.8"
 
 # Terminal output formatting

--- a/README.md
+++ b/README.md
@@ -252,12 +252,19 @@ dutis-event-http --check --json
 # Inspect and replay failed command deliveries
 dutis events pending --json
 dutis events replay --limit 100 --json
+dutis events archive --max-attempts 5 --older-than-days 30 --json
+dutis events archive --max-attempts 5 --older-than-days 30 --yes
+dutis events dead-letters --json
+dutis events purge --older-than-days 90 --json
+dutis events purge --older-than-days 90 --yes
 ```
 
 Failed event-command deliveries are stored automatically under the Dutis state
 directory. Override that location with `--event-outbox` or
 `DUTIS_EVENT_OUTBOX`. Replay keeps the original event ID so remote consumers
 can deduplicate retries. See [durable event replay](docs/event-replay.md).
+Archive and purge commands are previews unless `--yes` is present, so pending
+deliveries are never removed by an implicit retention policy.
 
 All write paths enforce the same local policy before mutation and record the
 requester, reviewed plan, result, and verification. See the

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -303,9 +303,32 @@ Acceptance criteria:
 
 ## Near-term engineering sequence
 
-1. Release Phase 14 and validate managed policy deployment across representative
-   developer and design fleets.
-2. Add explicit queue retention and operator-approved dead-letter cleanup
-   after production replay behavior is established.
-3. Extend recommendation preferences to typed UTI, MIME, and URL-scheme
+## Phase 15: Event retention and dead-letter cleanup
+
+Status: implemented for v2.19.0
+
+Add explicit lifecycle controls for delivery failures while keeping recovery
+safe, local, and operator initiated.
+
+Acceptance criteria:
+
+- Pending events can be selected by delivery-attempt count, queue age, or
+  either threshold in a combined retention rule.
+- Archive and purge are preview-only by default and require `--yes` before
+  changing local state.
+- Archiving atomically preserves the complete pending record, original event
+  ID, timestamps, attempt count, and matching reasons in private dead-letter
+  storage.
+- Purge permanently removes only dead letters older than an explicit positive
+  retention period; it never deletes pending deliveries.
+- Malformed, oversized, mismatched, or non-regular records fail closed, and no
+  maintenance command is exposed through MCP.
+
+## Near-term engineering sequence
+
+1. Release Phase 15 and validate retention thresholds against production-like
+   event volumes and operator runbooks.
+2. Extend recommendation preferences to typed UTI, MIME, and URL-scheme
    associations after gathering fleet usage evidence.
+3. Add optional metrics summaries for event delivery health without exposing
+   payload contents.

--- a/docs/event-replay.md
+++ b/docs/event-replay.md
@@ -1,6 +1,6 @@
 # Durable event replay
 
-Dutis v2.17 stores failed event-command deliveries in a local outbox. Replaying
+Dutis stores failed event-command deliveries in a local outbox. Replaying
 an event retries only the external delivery; it never repeats the drift check,
 association mutation, policy decision, snapshot, or audit operation that
 originally produced the event.
@@ -73,3 +73,40 @@ time.
 If the outbox itself cannot be written, Dutis reports that failure with the
 event-command warning. The originating command keeps its original result:
 observability storage cannot authorize, undo, repeat, or relabel a mutation.
+
+## Retention and dead letters
+
+Dutis never expires pending deliveries automatically. Preview which events
+meet an attempt-count or age threshold:
+
+```bash
+dutis events archive --max-attempts 5 --json
+dutis events archive --older-than-days 30 --json
+dutis events archive --max-attempts 5 --older-than-days 30 --json
+```
+
+When both thresholds are supplied, an event matches if either threshold is
+met. Add `--yes` to move matched records into the private `dead-letter`
+subdirectory:
+
+```bash
+dutis events archive --max-attempts 5 --older-than-days 30 --yes --json
+dutis events dead-letters --json
+```
+
+Archiving preserves the complete pending record, failure timestamps, attempt
+count, original event ID, and the reasons that matched. Archived events are no
+longer included in replay batches.
+
+Permanent cleanup is a separate preview-first operation and always requires a
+positive retention age:
+
+```bash
+dutis events purge --older-than-days 90 --json
+dutis events purge --older-than-days 90 --yes --json
+```
+
+Only dead letters are eligible for purge; pending deliveries cannot be deleted
+by this command. Without `--yes`, both archive and purge report matches without
+changing any file. These maintenance commands are intentionally CLI-only and
+are not exposed as MCP tools.

--- a/docs/event-sinks.md
+++ b/docs/event-sinks.md
@@ -126,4 +126,4 @@ dutis --event-command /absolute/path/to/handler events replay --limit 100 --json
 ```
 
 See [durable event replay](event-replay.md) for persistence, retry, and
-at-least-once delivery guarantees.
+at-least-once delivery guarantees, dead-letter retention, and explicit cleanup.

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -21,6 +21,8 @@ Use Dutis for macOS Launch Services associations. Preserve its
    before planning a change.
    If an event command reports a delivery failure, inspect `events pending`
    and use `events replay` only after confirming the configured sink is healthy.
+   Preview `events archive` and `events purge` before using `--yes`; purge is
+   permanent and applies only to events already moved into dead-letter storage.
 2. If the user asks for a general setup or is unsure which application to use,
    inspect `dutis_profiles` / `dutis_profile`, then use `dutis_recommend` (or
    the equivalent CLI commands). Present candidate evidence and treat the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -338,6 +338,12 @@ pub enum EventsCommand {
     Pending(OutputArgs),
     /// Deliver pending events through the configured event command
     Replay(EventReplayArgs),
+    /// Preview or archive pending events that exceed retention thresholds
+    Archive(EventArchiveArgs),
+    /// List events retained in the dead-letter archive
+    DeadLetters(OutputArgs),
+    /// Preview or permanently delete expired dead-letter events
+    Purge(EventPurgeArgs),
 }
 
 #[derive(Debug, Args)]
@@ -345,6 +351,35 @@ pub struct EventReplayArgs {
     /// Maximum number of oldest pending events to attempt
     #[arg(long, default_value_t = 100, value_parser = clap::value_parser!(u64).range(1..))]
     pub limit: u64,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct EventArchiveArgs {
+    /// Match events with at least this many delivery attempts
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    pub max_attempts: Option<u64>,
+    /// Match events queued for at least this many days
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    pub older_than_days: Option<u64>,
+    /// Apply the archive operation; omission produces a preview
+    #[arg(long)]
+    pub yes: bool,
+    /// Emit stable machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct EventPurgeArgs {
+    /// Delete dead letters retained for at least this many days
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+    pub older_than_days: u64,
+    /// Apply permanent deletion; omission produces a preview
+    #[arg(long)]
+    pub yes: bool,
     /// Emit stable machine-readable JSON
     #[arg(long)]
     pub json: bool,
@@ -496,6 +531,40 @@ mod tests {
                 command: EventsCommand::Pending(OutputArgs { json: true })
             }))
         ));
+        let cli = Cli::try_parse_from([
+            "dutis",
+            "events",
+            "archive",
+            "--max-attempts",
+            "5",
+            "--older-than-days",
+            "30",
+            "--yes",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Events(EventsArgs {
+                command: EventsCommand::Archive(EventArchiveArgs {
+                    max_attempts: Some(5),
+                    older_than_days: Some(30),
+                    yes: true,
+                    json: true
+                })
+            }))
+        ));
+        assert!(Cli::try_parse_from(["dutis", "events", "dead-letters", "--json"]).is_ok());
+        assert!(Cli::try_parse_from([
+            "dutis",
+            "events",
+            "purge",
+            "--older-than-days",
+            "30",
+            "--yes",
+            "--json"
+        ])
+        .is_ok());
         let cli =
             Cli::try_parse_from(["dutis", "events", "replay", "--limit", "25", "--json"]).unwrap();
         assert!(matches!(

--- a/src/events.rs
+++ b/src/events.rs
@@ -14,8 +14,9 @@ pub const EVENT_LOG_ENV: &str = "DUTIS_EVENT_LOG";
 pub const EVENT_COMMAND_ENV: &str = "DUTIS_EVENT_COMMAND";
 pub const EVENT_OUTBOX_ENV: &str = "DUTIS_EVENT_OUTBOX";
 pub const PENDING_EVENT_SCHEMA_VERSION: u32 = 1;
+pub const DEAD_LETTER_SCHEMA_VERSION: u32 = 1;
 
-const MAX_PENDING_EVENT_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_EVENT_RECORD_BYTES: u64 = 4 * 1024 * 1024;
 
 static EVENT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -99,6 +100,43 @@ pub struct ReplayReport {
     pub failed: usize,
     pub remaining: usize,
     pub results: Vec<ReplayResult>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeadLetterEvent {
+    pub schema_version: u32,
+    pub dead_lettered_at: String,
+    pub reasons: Vec<String>,
+    pub pending: PendingEvent,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct DeadLetterSummary {
+    pub id: String,
+    pub event_type: EventType,
+    pub source: EventSource,
+    pub emitted_at: String,
+    pub queued_at: String,
+    pub dead_lettered_at: String,
+    pub attempts: u64,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct OutboxMaintenanceItem {
+    pub id: String,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct OutboxMaintenanceReport {
+    pub operation: &'static str,
+    pub applied: bool,
+    pub matched: usize,
+    pub pending: usize,
+    pub dead_letters: usize,
+    pub events: Vec<OutboxMaintenanceItem>,
 }
 
 impl EventEnvelope {
@@ -339,6 +377,119 @@ impl EventOutbox {
             .collect())
     }
 
+    pub fn dead_letters(&self) -> Result<Vec<DeadLetterSummary>> {
+        Ok(self
+            .load_all_dead_letters()?
+            .into_iter()
+            .map(|record| DeadLetterSummary {
+                id: record.pending.event.id,
+                event_type: record.pending.event.event_type,
+                source: record.pending.event.source,
+                emitted_at: record.pending.event.emitted_at,
+                queued_at: record.pending.queued_at,
+                dead_lettered_at: record.dead_lettered_at,
+                attempts: record.pending.attempts,
+                reasons: record.reasons,
+            })
+            .collect())
+    }
+
+    pub fn archive(
+        &self,
+        max_attempts: Option<u64>,
+        older_than_days: Option<u64>,
+        apply: bool,
+    ) -> Result<OutboxMaintenanceReport> {
+        if max_attempts.is_none() && older_than_days.is_none() {
+            bail!("archive requires --max-attempts or --older-than-days");
+        }
+        if max_attempts == Some(0) {
+            bail!("maximum attempts must be at least 1");
+        }
+        let queued_before = older_than_days.map(cutoff_from_days).transpose()?;
+        let pending = self.load_all()?;
+        let mut matched = Vec::new();
+        for record in pending {
+            let mut reasons = Vec::new();
+            if let Some(maximum) = max_attempts {
+                if record.attempts >= maximum {
+                    reasons.push(format!("attempts_gte_{maximum}"));
+                }
+            }
+            if let Some(cutoff) = queued_before {
+                let queued_at = parse_timestamp(&record.queued_at, "queued_at")?;
+                if queued_at <= cutoff {
+                    reasons.push(format!(
+                        "queued_at_least_{}_days",
+                        older_than_days.expect("cutoff has a retention age")
+                    ));
+                }
+            }
+            if reasons.is_empty() {
+                continue;
+            }
+            if apply {
+                let dead_letter = DeadLetterEvent {
+                    schema_version: DEAD_LETTER_SCHEMA_VERSION,
+                    dead_lettered_at: current_timestamp()?,
+                    reasons: reasons.clone(),
+                    pending: record.clone(),
+                };
+                self.store_dead_letter(&dead_letter)?;
+                fs::remove_file(self.record_path(&record.event.id)?).with_context(|| {
+                    format!("failed to remove archived event {}", record.event.id)
+                })?;
+            }
+            matched.push(OutboxMaintenanceItem {
+                id: record.event.id,
+                reasons,
+            });
+        }
+        Ok(OutboxMaintenanceReport {
+            operation: "archive",
+            applied: apply,
+            matched: matched.len(),
+            pending: self.load_all()?.len(),
+            dead_letters: self.load_all_dead_letters()?.len(),
+            events: matched,
+        })
+    }
+
+    pub fn purge(&self, older_than_days: u64, apply: bool) -> Result<OutboxMaintenanceReport> {
+        let cutoff = cutoff_from_days(older_than_days)?;
+        let dead_letters = self.load_all_dead_letters()?;
+        let mut matched = Vec::new();
+        for record in dead_letters {
+            let dead_lettered_at = parse_timestamp(&record.dead_lettered_at, "dead_lettered_at")?;
+            if dead_lettered_at > cutoff {
+                continue;
+            }
+            let reasons = vec![format!("dead_lettered_at_least_{older_than_days}_days")];
+            if apply {
+                fs::remove_file(self.dead_letter_path(&record.pending.event.id)?).with_context(
+                    || {
+                        format!(
+                            "failed to purge dead-letter event {}",
+                            record.pending.event.id
+                        )
+                    },
+                )?;
+            }
+            matched.push(OutboxMaintenanceItem {
+                id: record.pending.event.id,
+                reasons,
+            });
+        }
+        Ok(OutboxMaintenanceReport {
+            operation: "purge",
+            applied: apply,
+            matched: matched.len(),
+            pending: self.load_all()?.len(),
+            dead_letters: self.load_all_dead_letters()?.len(),
+            events: matched,
+        })
+    }
+
     pub fn replay(&self, command: &Path, limit: usize) -> Result<ReplayReport> {
         validate_command(command)?;
         if limit == 0 {
@@ -415,15 +566,42 @@ impl EventOutbox {
         Ok(pending)
     }
 
+    fn load_all_dead_letters(&self) -> Result<Vec<DeadLetterEvent>> {
+        let directory = self.dead_letter_directory();
+        if !directory.exists() {
+            return Ok(Vec::new());
+        }
+        let mut paths = json_files(&directory)?;
+        paths.sort();
+        let mut dead_letters = paths
+            .iter()
+            .map(|path| self.load_dead_letter(path))
+            .collect::<Result<Vec<_>>>()?;
+        dead_letters.sort_by(|left, right| {
+            (&left.dead_lettered_at, &left.pending.event.id)
+                .cmp(&(&right.dead_lettered_at, &right.pending.event.id))
+        });
+        Ok(dead_letters)
+    }
+
+    fn load_dead_letter(&self, path: &Path) -> Result<DeadLetterEvent> {
+        validate_regular_json_file(path)?;
+        let file = fs::File::open(path)
+            .with_context(|| format!("failed to open dead-letter event {}", path.display()))?;
+        let record: DeadLetterEvent = serde_json::from_reader(BufReader::new(file))
+            .with_context(|| format!("failed to parse dead-letter event {}", path.display()))?;
+        validate_dead_letter(&record)?;
+        if self.dead_letter_path(&record.pending.event.id)? != path {
+            bail!(
+                "dead-letter event ID does not match its filename: {}",
+                path.display()
+            );
+        }
+        Ok(record)
+    }
+
     fn load_path(&self, path: &Path) -> Result<PendingEvent> {
-        let metadata = fs::symlink_metadata(path)
-            .with_context(|| format!("failed to inspect pending event {}", path.display()))?;
-        if !metadata.file_type().is_file() {
-            bail!("pending event is not a regular file: {}", path.display());
-        }
-        if metadata.len() > MAX_PENDING_EVENT_BYTES {
-            bail!("pending event {} exceeds the size limit", path.display());
-        }
+        validate_regular_json_file(path)?;
         let file = fs::File::open(path)
             .with_context(|| format!("failed to open pending event {}", path.display()))?;
         let pending: PendingEvent = serde_json::from_reader(BufReader::new(file))
@@ -480,10 +658,116 @@ impl EventOutbox {
         Ok(())
     }
 
+    fn store_dead_letter(&self, record: &DeadLetterEvent) -> Result<()> {
+        validate_dead_letter(record)?;
+        let directory = self.dead_letter_directory();
+        create_private_directories(&directory)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
+        }
+        let destination = self.dead_letter_path(&record.pending.event.id)?;
+        let sequence = EVENT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let temporary = directory.join(format!(
+            ".{}.{}.{}.tmp",
+            record.pending.event.id,
+            std::process::id(),
+            sequence
+        ));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options
+            .open(&temporary)
+            .with_context(|| format!("failed to create {}", temporary.display()))?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, record)?;
+        writer.write_all(b"\n")?;
+        writer.flush()?;
+        writer.get_ref().sync_all()?;
+        fs::rename(&temporary, &destination).with_context(|| {
+            format!(
+                "failed to atomically store dead-letter event {}",
+                record.pending.event.id
+            )
+        })?;
+        Ok(())
+    }
+
     fn record_path(&self, id: &str) -> Result<PathBuf> {
         validate_event_id(id)?;
         Ok(self.directory.join(format!("{id}.json")))
     }
+
+    fn dead_letter_directory(&self) -> PathBuf {
+        self.directory.join("dead-letter")
+    }
+
+    fn dead_letter_path(&self, id: &str) -> Result<PathBuf> {
+        validate_event_id(id)?;
+        Ok(self.dead_letter_directory().join(format!("{id}.json")))
+    }
+}
+
+fn json_files(directory: &Path) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(directory)
+        .with_context(|| format!("failed to read {}", directory.display()))?
+    {
+        let path = entry
+            .with_context(|| format!("failed to read {}", directory.display()))?
+            .path();
+        if path
+            .extension()
+            .is_some_and(|extension| extension == "json")
+        {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+fn validate_regular_json_file(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect event record {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!("event record is not a regular file: {}", path.display());
+    }
+    if metadata.len() > MAX_EVENT_RECORD_BYTES {
+        bail!("event record {} exceeds the size limit", path.display());
+    }
+    Ok(())
+}
+
+fn validate_dead_letter(record: &DeadLetterEvent) -> Result<()> {
+    if record.schema_version != DEAD_LETTER_SCHEMA_VERSION {
+        bail!(
+            "unsupported dead-letter schema version {}; expected {}",
+            record.schema_version,
+            DEAD_LETTER_SCHEMA_VERSION
+        );
+    }
+    if record.reasons.is_empty() || record.reasons.iter().any(|reason| reason.trim().is_empty()) {
+        bail!("dead-letter event must include at least one non-empty reason");
+    }
+    parse_timestamp(&record.dead_lettered_at, "dead_lettered_at")?;
+    validate_pending_event(&record.pending)
+}
+
+fn cutoff_from_days(days: u64) -> Result<OffsetDateTime> {
+    let days = i64::try_from(days).context("retention period is too large")?;
+    OffsetDateTime::now_utc()
+        .checked_sub(time::Duration::days(days))
+        .context("retention period is too large")
+}
+
+fn parse_timestamp(value: &str, field: &str) -> Result<OffsetDateTime> {
+    OffsetDateTime::parse(value, &Rfc3339).with_context(|| format!("invalid {field} timestamp"))
 }
 
 fn validate_pending_event(pending: &PendingEvent) -> Result<()> {
@@ -497,6 +781,8 @@ fn validate_pending_event(pending: &PendingEvent) -> Result<()> {
     if pending.attempts == 0 {
         bail!("pending event attempt count must be at least 1");
     }
+    parse_timestamp(&pending.queued_at, "queued_at")?;
+    parse_timestamp(&pending.last_attempted_at, "last_attempted_at")?;
     validate_event(&pending.event)
 }
 
@@ -508,6 +794,7 @@ fn validate_event(event: &EventEnvelope) -> Result<()> {
             EVENT_SCHEMA_VERSION
         );
     }
+    parse_timestamp(&event.emitted_at, "emitted_at")?;
     validate_event_id(&event.id)
 }
 
@@ -899,5 +1186,78 @@ mod tests {
         let error = EventOutbox::new(&directory).pending().unwrap_err();
         assert!(error.to_string().contains("not a regular file"));
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn archive_and_purge_are_preview_first_and_preserve_dead_letters() {
+        let root = temp_root("outbox-retention");
+        let outbox = EventOutbox::new(root.join("outbox"));
+        let first = EventEnvelope::new(
+            EventType::DriftChecked,
+            EventSource::Watcher,
+            &json!({"sequence": 1}),
+        )
+        .unwrap();
+        let second = EventEnvelope::new(
+            EventType::MutationFailed,
+            EventSource::Governance,
+            &json!({"sequence": 2}),
+        )
+        .unwrap();
+        outbox.enqueue(&first).unwrap();
+        outbox.enqueue(&second).unwrap();
+        outbox.enqueue(&second).unwrap();
+
+        let preview = outbox.archive(Some(2), None, false).unwrap();
+        assert!(!preview.applied);
+        assert_eq!(
+            (preview.matched, preview.pending, preview.dead_letters),
+            (1, 2, 0)
+        );
+
+        let archived = outbox.archive(Some(2), None, true).unwrap();
+        assert!(archived.applied);
+        assert_eq!(
+            (archived.matched, archived.pending, archived.dead_letters),
+            (1, 1, 1)
+        );
+        let dead_letters = outbox.dead_letters().unwrap();
+        assert_eq!(dead_letters[0].id, second.id);
+        assert_eq!(dead_letters[0].attempts, 2);
+        assert!(dead_letters[0].reasons[0].contains("attempts"));
+
+        let mut old = outbox
+            .load_path(&outbox.record_path(&first.id).unwrap())
+            .unwrap();
+        old.queued_at = "2020-01-01T00:00:00Z".to_owned();
+        outbox.store(&old).unwrap();
+        let archived = outbox.archive(None, Some(1), true).unwrap();
+        assert_eq!(
+            (archived.matched, archived.pending, archived.dead_letters),
+            (1, 0, 2)
+        );
+
+        let preview = outbox.purge(0, false).unwrap();
+        assert!(!preview.applied);
+        assert_eq!(
+            (preview.matched, preview.pending, preview.dead_letters),
+            (2, 0, 2)
+        );
+        let purged = outbox.purge(0, true).unwrap();
+        assert!(purged.applied);
+        assert_eq!(
+            (purged.matched, purged.pending, purged.dead_letters),
+            (2, 0, 0)
+        );
+        assert!(outbox.dead_letters().unwrap().is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn archive_requires_a_retention_threshold() {
+        let outbox = EventOutbox::new(temp_root("outbox-missing-retention"));
+        assert!(outbox.archive(None, None, false).is_err());
+        assert!(outbox.archive(Some(0), None, false).is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{
-    ApplyArgs, Cli, CliCommand, ConfigArgs, EventReplayArgs, EventsArgs, EventsCommand,
-    ExtensionArgs, HandlerArgs, HandlerCommand, HandlerDefaultsArgs, HandlerGetArgs,
-    HandlerSetArgs, LaunchAgentArgs, LaunchAgentCommand, LaunchAgentInstallArgs, McpArgs,
-    OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand, ProfileArgs, ProfileCommand,
+    ApplyArgs, Cli, CliCommand, ConfigArgs, EventArchiveArgs, EventPurgeArgs, EventReplayArgs,
+    EventsArgs, EventsCommand, ExtensionArgs, HandlerArgs, HandlerCommand, HandlerDefaultsArgs,
+    HandlerGetArgs, HandlerSetArgs, LaunchAgentArgs, LaunchAgentCommand, LaunchAgentInstallArgs,
+    McpArgs, OutputArgs, PolicyArgs, PolicyCheckArgs, PolicyCommand, ProfileArgs, ProfileCommand,
     ProfileShowArgs, RecommendArgs, RollbackArgs, SetArgs, SnapshotArgs, SnapshotCommand,
     SnapshotCreateArgs, WatchArgs,
 };
@@ -359,6 +359,9 @@ fn command_uses_json(command: &CliCommand) -> bool {
         CliCommand::Events(args) => match &args.command {
             EventsCommand::Pending(args) => args.json,
             EventsCommand::Replay(args) => args.json,
+            EventsCommand::Archive(args) => args.json,
+            EventsCommand::DeadLetters(args) => args.json,
+            EventsCommand::Purge(args) => args.json,
         },
         CliCommand::LaunchAgent(args) => match &args.command {
             LaunchAgentCommand::Install(args) => args.json,
@@ -372,13 +375,14 @@ fn run_events(args: EventsArgs) -> Result<(), CliError> {
     match args.command {
         EventsCommand::Pending(args) => run_events_pending(args),
         EventsCommand::Replay(args) => run_events_replay(args),
+        EventsCommand::Archive(args) => run_events_archive(args),
+        EventsCommand::DeadLetters(args) => run_events_dead_letters(args),
+        EventsCommand::Purge(args) => run_events_purge(args),
     }
 }
 
 fn run_events_pending(args: OutputArgs) -> Result<(), CliError> {
-    let outbox = EventOutbox::from_environment().map_err(|error| {
-        CliError::operation(format!("failed to locate event outbox: {error:#}"))
-    })?;
+    let outbox = event_outbox()?;
     let pending = outbox
         .pending()
         .map_err(|error| CliError::operation(format!("failed to read event outbox: {error:#}")))?;
@@ -410,9 +414,7 @@ fn run_events_replay(args: EventReplayArgs) -> Result<(), CliError> {
     let command = dispatcher.command().ok_or_else(|| {
         CliError::usage("events replay requires --event-command or DUTIS_EVENT_COMMAND")
     })?;
-    let outbox = EventOutbox::from_environment().map_err(|error| {
-        CliError::operation(format!("failed to locate event outbox: {error:#}"))
-    })?;
+    let outbox = event_outbox()?;
     let limit = usize::try_from(args.limit)
         .map_err(|_| CliError::usage("event replay limit is too large for this platform"))?;
     let report = outbox.replay(command, limit).map_err(|error| {
@@ -437,6 +439,89 @@ fn run_events_replay(args: EventReplayArgs) -> Result<(), CliError> {
             "Replayed {} event(s); {} remain pending.",
             report.delivered, report.remaining
         );
+    }
+    Ok(())
+}
+
+fn run_events_archive(args: EventArchiveArgs) -> Result<(), CliError> {
+    if args.max_attempts.is_none() && args.older_than_days.is_none() {
+        return Err(CliError::usage(
+            "events archive requires --max-attempts or --older-than-days",
+        ));
+    }
+    let report = event_outbox()?
+        .archive(args.max_attempts, args.older_than_days, args.yes)
+        .map_err(|error| CliError::operation(format!("failed to archive events: {error:#}")))?;
+    print_outbox_maintenance(report, args.json)
+}
+
+fn run_events_dead_letters(args: OutputArgs) -> Result<(), CliError> {
+    let dead_letters = event_outbox()?
+        .dead_letters()
+        .map_err(|error| CliError::operation(format!("failed to read dead letters: {error:#}")))?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "events",
+            data: &dead_letters,
+        })?;
+    } else if dead_letters.is_empty() {
+        println!("No dead-letter events.");
+    } else {
+        for event in dead_letters {
+            println!(
+                "{}\t{}\tattempts={}\t{}\t{}",
+                event.id,
+                event.event_type.as_str(),
+                event.attempts,
+                event.dead_lettered_at,
+                event.reasons.join(",")
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_events_purge(args: EventPurgeArgs) -> Result<(), CliError> {
+    let report = event_outbox()?
+        .purge(args.older_than_days, args.yes)
+        .map_err(|error| CliError::operation(format!("failed to purge dead letters: {error:#}")))?;
+    print_outbox_maintenance(report, args.json)
+}
+
+fn event_outbox() -> Result<EventOutbox, CliError> {
+    EventOutbox::from_environment()
+        .map_err(|error| CliError::operation(format!("failed to locate event outbox: {error:#}")))
+}
+
+fn print_outbox_maintenance(
+    report: dutis::events::OutboxMaintenanceReport,
+    json: bool,
+) -> Result<(), CliError> {
+    if json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "events",
+            data: report,
+        })?;
+    } else {
+        println!(
+            "{} {} event(s); pending={}, dead_letters={}.",
+            if report.applied {
+                "Processed"
+            } else {
+                "Matched"
+            },
+            report.matched,
+            report.pending,
+            report.dead_letters
+        );
+        if !report.applied && report.matched > 0 {
+            println!(
+                "Preview only; rerun with --yes to apply {}.",
+                report.operation
+            );
+        }
     }
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -229,6 +229,137 @@ fn pending_events_can_be_inspected_and_replayed_from_the_cli() {
 }
 
 #[test]
+fn event_archive_and_purge_require_explicit_confirmation() {
+    use serde_json::json;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "dutis-cli-event-retention-{}-{unique}",
+        std::process::id()
+    ));
+    let outbox_path = root.join("outbox");
+    let outbox = EventOutbox::new(&outbox_path);
+    let event = EventEnvelope::new(
+        EventType::MutationFailed,
+        EventSource::Governance,
+        &json!({"audit_id": "audit-1"}),
+    )
+    .unwrap();
+    outbox.enqueue(&event).unwrap();
+    outbox.enqueue(&event).unwrap();
+
+    let missing_threshold = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "archive",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(missing_threshold.status.code(), Some(2));
+
+    let archive_preview = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "archive",
+            "--max-attempts",
+            "2",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(archive_preview.status.success());
+    let response: Value = serde_json::from_slice(&archive_preview.stdout).unwrap();
+    assert_eq!(response["data"]["applied"], false);
+    assert_eq!(response["data"]["matched"], 1);
+    assert_eq!(outbox.pending().unwrap().len(), 1);
+
+    let archive = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "archive",
+            "--max-attempts",
+            "2",
+            "--yes",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(archive.status.success());
+    assert!(outbox.pending().unwrap().is_empty());
+
+    let dead_letters = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "dead-letters",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let response: Value = serde_json::from_slice(&dead_letters.stdout).unwrap();
+    assert_eq!(response["data"].as_array().unwrap().len(), 1);
+
+    let dead_letter_path = fs::read_dir(outbox_path.join("dead-letter"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let mut record: Value = serde_json::from_slice(&fs::read(&dead_letter_path).unwrap()).unwrap();
+    record["dead_lettered_at"] = Value::String("2020-01-01T00:00:00Z".to_owned());
+    fs::write(
+        &dead_letter_path,
+        serde_json::to_vec_pretty(&record).unwrap(),
+    )
+    .unwrap();
+
+    let purge_preview = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "purge",
+            "--older-than-days",
+            "1",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let response: Value = serde_json::from_slice(&purge_preview.stdout).unwrap();
+    assert_eq!(response["data"]["applied"], false);
+    assert_eq!(response["data"]["matched"], 1);
+    assert!(dead_letter_path.exists());
+
+    let purge = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "purge",
+            "--older-than-days",
+            "1",
+            "--yes",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(purge.status.success());
+    assert!(!dead_letter_path.exists());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn profile_list_and_show_are_available_without_duti() {
     let list = dutis()
         .env("PATH", "")


### PR DESCRIPTION
## Summary
- add preview-first pending event archive selection by attempts and age
- preserve archived records in private dead-letter storage and add inspection commands
- add operator-approved age-based purge with explicit --yes
- document the retention workflow and update the roadmap

## Safety
- archive and purge are no-ops without --yes
- purge only operates on dead letters, never pending records
- malformed, mismatched, oversized, and non-regular records are rejected
- no MCP mutation surface is exposed

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline (132 passed)
- cargo build --release --bins --locked --offline
- cargo package --allow-dirty --locked --offline
- ruby -c scripts/render_homebrew_formula.rb
- git diff --check