### PR TITLE
feat: add typed recommendation preferences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.19.0"
+version = "2.20.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.19.0"
+version = "2.20.0"
 edition = "2021"
 rust-version = "1.88"
 default-run = "dutis"

--- a/README.md
+++ b/README.md
@@ -198,11 +198,24 @@ preferred_applications = ["com.microsoft.VSCode"]
 
 [recommendations.extensions]
 md = ["com.microsoft.VSCode", "com.apple.TextEdit"]
+
+[[recommendations.handlers]]
+kind = "uti"
+identifier = "public.plain-text"
+role = "viewer"
+applications = ["com.apple.TextEdit", "com.microsoft.VSCode"]
+
+[[recommendations.handlers]]
+kind = "url_scheme"
+identifier = "vscode"
+applications = ["com.microsoft.VSCode"]
 ```
 
 Results show each candidate's source, policy eligibility, installed paths,
-declared extension support, the proposed TOML, a deterministic plan digest, and
-the effective policy assessment. They never change system associations.
+declared target support, the proposed TOML, a deterministic plan digest, and
+the effective policy assessment. Typed UTI, MIME, and URL-scheme preferences
+require an exact compatible declaration from the installed application. They
+never change system associations.
 Review [profiles and recommendations](docs/profiles-and-recommendations.md) for
 selection rules and the safe path from a proposal to an approved apply.
 

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -301,8 +301,6 @@ Acceptance criteria:
 - MCP callers cannot inject or replace policy, and no network control plane or
   new mutation path is introduced.
 
-## Near-term engineering sequence
-
 ## Phase 15: Event retention and dead-letter cleanup
 
 Status: implemented for v2.19.0
@@ -324,11 +322,34 @@ Acceptance criteria:
 - Malformed, oversized, mismatched, or non-regular records fail closed, and no
   maintenance command is exposed through MCP.
 
+## Phase 16: Typed fleet recommendation preferences
+
+Status: implemented for v2.20.0
+
+Extend locally deployed recommendation preferences across every association
+kind without creating a remote policy or mutation path.
+
+Acceptance criteria:
+
+- The version-one policy schema accepts ordered UTI, MIME, and URL-scheme
+  recommendation handlers with normalized identifiers and roles while
+  remaining backward compatible.
+- Typed preferences participate in the same protected-target, kind, and
+  application allowlists as extension recommendations.
+- A typed candidate must be uniquely installed and explicitly declare the
+  requested handler and compatible role before it can enter a proposal.
+- CLI and MCP query current defaults through the role-aware backend and return
+  typed proposed configuration, deterministic plan, candidate evidence, and
+  policy assessment without adding a write capability.
+- Recommendation JSON retains its legacy `extension` identifier and
+  `declares_extension` fields while additive typed fields identify every target
+  consistently.
+
 ## Near-term engineering sequence
 
-1. Release Phase 15 and validate retention thresholds against production-like
-   event volumes and operator runbooks.
-2. Extend recommendation preferences to typed UTI, MIME, and URL-scheme
-   associations after gathering fleet usage evidence.
-3. Add optional metrics summaries for event delivery health without exposing
+1. Release Phase 16 and validate typed preference declarations against a
+   representative fleet application catalog.
+2. Add optional metrics summaries for event delivery health without exposing
    payload contents.
+3. Add configurable profile overlays only after typed preference usage shows
+   which reusable association groups are stable across fleets.

--- a/docs/policy-and-audit.md
+++ b/docs/policy-and-audit.md
@@ -38,6 +38,23 @@ preferred_applications = ["com.microsoft.VSCode"]
 [recommendations.extensions]
 md = ["com.microsoft.VSCode", "com.apple.TextEdit"]
 
+[[recommendations.handlers]]
+kind = "uti"
+identifier = "public.plain-text"
+role = "viewer"
+applications = ["com.apple.TextEdit", "com.microsoft.VSCode"]
+
+[[recommendations.handlers]]
+kind = "mime"
+identifier = "text/plain"
+role = "editor"
+applications = ["com.microsoft.VSCode"]
+
+[[recommendations.handlers]]
+kind = "url_scheme"
+identifier = "vscode"
+applications = ["com.microsoft.VSCode"]
+
 [protected_associations]
 pdf = "com.apple.Preview"
 
@@ -61,13 +78,18 @@ application = "com.apple.TextEdit"
   extensions and may introduce a team-standard application that is not in the
   built-in profile. Preferences remain constrained by all allowlists and
   protected associations.
+- `recommendations.handlers` supplies ordered preferences for normalized UTI,
+  MIME, and URL-scheme targets. `role` defaults to `all`; URL schemes accept
+  only `all`. These typed targets are included in every profile recommendation,
+  but an application must be uniquely installed and explicitly declare the
+  requested handler and a compatible role before it can be proposed.
 - `protected_associations` permits an extension only when the target is the
   configured bundle identifier. This allows restoration to the protected value
   while denying changes away from it.
 - `protected_handlers` applies the same protection to a typed kind, identifier,
   and role tuple. The role defaults to `all`; URL schemes accept only `all`.
-- Unknown fields, invalid identifiers or roles, duplicate normalized targets,
-  and unknown versions fail closed.
+- Unknown fields, invalid identifiers or roles, empty or duplicate ordered
+  preferences, duplicate normalized targets, and unknown versions fail closed.
 
 Check a configuration against the current system state and policy without
 changing anything:

--- a/docs/profiles-and-recommendations.md
+++ b/docs/profiles-and-recommendations.md
@@ -25,25 +25,31 @@ dutis recommend developer --json
 
 Recommendation scans installed applications and reads current handlers. It
 does not change Launch Services. It loads the effective local policy before
-ranking candidates. For each extension, Dutis:
+ranking candidates. Built-in profiles contribute extension targets; local
+policy can additionally contribute typed UTI, MIME, and URL-scheme targets.
+For each target, Dutis:
 
 1. Honors a protected association as the required target.
-2. Applies ordered extension-specific preferences, then global preferences
-   that match candidates in the selected profile.
+2. Applies ordered target-specific preferences, then global preferences that
+   match candidates in the selected profile.
 3. Removes candidates excluded by kind, extension, or application allowlists.
 4. Keeps the current eligible profile candidate when no installed policy
    preference takes precedence, minimizing unnecessary changes.
 5. Otherwise selects the first eligible candidate with one installed path.
-6. Marks an extension `policy_blocked` when installed candidates exist but are
+6. Requires typed candidates to explicitly declare the normalized handler and
+   a compatible Launch Services role.
+7. Marks a target `policy_blocked` when installed candidates exist but are
    excluded, or `unavailable` when no uniquely installed eligible candidate
    exists. Neither result enters the proposed configuration or plan.
 
 Each result includes candidate source (`profile`, `global_preference`,
-`extension_preference`, or `protected_policy`), policy eligibility and reasons,
-installed paths, declared extension support, selected target, current handler,
-and a human-readable explanation. The complete response also includes proposed
-TOML, a deterministic `AssociationPlan` and digest, and assessment against the
-same local policy.
+`extension_preference`, `handler_preference`, or `protected_policy`), policy
+eligibility and reasons, installed paths, exact target declaration evidence,
+selected target, current handler, and a human-readable explanation. Results
+retain the legacy `extension` identifier and `declares_extension` fields, while
+the additive `association` and `declares_target` fields carry typed semantics.
+The complete response also includes proposed TOML, a deterministic
+`AssociationPlan` and digest, and assessment against the same local policy.
 
 Configure recommendation inputs in the local policy file:
 
@@ -54,6 +60,23 @@ preferred_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
 [recommendations.extensions]
 md = ["com.microsoft.VSCode"]
 txt = ["com.apple.TextEdit", "com.microsoft.VSCode"]
+
+[[recommendations.handlers]]
+kind = "uti"
+identifier = "public.plain-text"
+role = "viewer"
+applications = ["com.apple.TextEdit", "com.microsoft.VSCode"]
+
+[[recommendations.handlers]]
+kind = "mime"
+identifier = "text/plain"
+role = "editor"
+applications = ["com.microsoft.VSCode"]
+
+[[recommendations.handlers]]
+kind = "url_scheme"
+identifier = "vscode"
+applications = ["com.microsoft.VSCode"]
 ```
 
 `DUTIS_POLICY_FILE` selects the policy file. Otherwise Dutis uses
@@ -61,10 +84,11 @@ txt = ["com.apple.TextEdit", "com.microsoft.VSCode"]
 deploy that file with their existing device-management tooling; Dutis does not
 fetch policy or accept recommendation overrides from a remote service.
 
-Declared extension support is evidence rather than the only selector. Some
-applications accept formats that are not present in all versions of their
-bundle metadata, so the ordered built-in profile remains the source of the
-preference while the evidence stays visible for review.
+Declared extension support is evidence rather than the only selector for
+curated built-in profile candidates. Typed policy preferences are stricter:
+the installed bundle metadata must explicitly declare the requested target and
+compatible role. This prevents fleet policy from proposing a typed handler that
+the local application does not advertise.
 
 ## Review and apply
 

--- a/dutis.policy.example.toml
+++ b/dutis.policy.example.toml
@@ -16,6 +16,26 @@ preferred_applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
 md = ["com.microsoft.VSCode"]
 txt = ["com.apple.TextEdit", "com.microsoft.VSCode"]
 
+# Typed preferences apply to every profile recommendation. A candidate is only
+# proposed when the installed application declares the exact handler and a
+# compatible role. URL schemes omit role because only "all" is valid.
+[[recommendations.handlers]]
+kind = "uti"
+identifier = "public.plain-text"
+role = "viewer"
+applications = ["com.apple.TextEdit", "com.microsoft.VSCode"]
+
+[[recommendations.handlers]]
+kind = "mime"
+identifier = "text/plain"
+role = "editor"
+applications = ["com.microsoft.VSCode", "com.apple.TextEdit"]
+
+[[recommendations.handlers]]
+kind = "url_scheme"
+identifier = "vscode"
+applications = ["com.microsoft.VSCode"]
+
 # A protected extension may only remain on, or be restored to, this bundle ID.
 [protected_associations]
 pdf = "com.apple.Preview"

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -29,7 +29,9 @@ Use Dutis for macOS Launch Services associations. Preserve its
    recommendation strictly as a proposal, never as approval.
    Treat candidate `policy_eligible`, `policy_reasons`, and `source` fields as
    required evidence; do not substitute caller-provided preferences for the
-   effective local policy.
+   effective local policy. For UTI, MIME, and URL-scheme recommendations,
+   require `declares_target = true`; typed fleet preferences apply to every
+   profile recommendation but never authorize a mutation.
 3. Express multi-target changes as version 2 TOML. Build a fresh plan and
    run the policy check. Treat unresolved selectors or policy violations as a
    stop condition.

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -48,6 +48,17 @@ pub struct Policy {
 pub struct RecommendationPreferences {
     pub preferred_applications: Vec<String>,
     pub extensions: BTreeMap<String, Vec<String>>,
+    pub handlers: Vec<HandlerRecommendationPreference>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HandlerRecommendationPreference {
+    pub kind: AssociationKind,
+    pub identifier: String,
+    #[serde(default)]
+    pub role: HandlerRole,
+    pub applications: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -75,6 +86,8 @@ struct RawRecommendationPreferences {
     preferred_applications: Vec<String>,
     #[serde(default)]
     extensions: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
+    handlers: Vec<HandlerRecommendationPreference>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -824,9 +837,40 @@ fn normalize_recommendation_preferences(
             bail!("duplicate recommendation extension .{extension}");
         }
     }
+    let mut seen_handlers = BTreeSet::new();
+    let mut handlers = Vec::with_capacity(raw.handlers.len());
+    for handler in raw.handlers {
+        let target = AssociationTarget::new(handler.kind, &handler.identifier, handler.role)?;
+        if target.kind == AssociationKind::Extension {
+            bail!(
+                "recommendation handler {target} must use UTI, MIME, or URL-scheme kind; use recommendations.extensions for filename extensions"
+            );
+        }
+        if !seen_handlers.insert(target.clone()) {
+            bail!("duplicate recommendation handler {target}");
+        }
+        let applications = normalize_nonempty_ordered(
+            handler.applications,
+            &format!("recommendation application for {target}"),
+        )?;
+        handlers.push(HandlerRecommendationPreference {
+            kind: target.kind,
+            identifier: target.identifier,
+            role: target.role,
+            applications,
+        });
+    }
+    handlers.sort_by(|left, right| {
+        (&left.kind, &left.identifier, &left.role).cmp(&(
+            &right.kind,
+            &right.identifier,
+            &right.role,
+        ))
+    });
     Ok(RecommendationPreferences {
         preferred_applications,
         extensions,
+        handlers,
     })
 }
 
@@ -951,6 +995,12 @@ mod tests {
 
                 [recommendations.extensions]
                 ".MD" = ["com.example.TeamEditor", "com.example.Editor"]
+
+                [[recommendations.handlers]]
+                kind = "uti"
+                identifier = "Public.HTML"
+                role = "viewer"
+                applications = [" com.example.Browser "]
             "#,
         )
         .unwrap();
@@ -963,6 +1013,16 @@ mod tests {
         assert_eq!(
             policy.recommendations.extensions["md"],
             ["com.example.TeamEditor", "com.example.Editor"]
+        );
+        assert_eq!(policy.recommendations.handlers.len(), 1);
+        assert_eq!(
+            policy.recommendations.handlers[0],
+            HandlerRecommendationPreference {
+                kind: AssociationKind::Uti,
+                identifier: "public.html".to_owned(),
+                role: HandlerRole::Viewer,
+                applications: vec!["com.example.Browser".to_owned()],
+            }
         );
     }
 
@@ -980,6 +1040,18 @@ mod tests {
                 .to_string()
                 .contains("cannot be empty")
         );
+        assert!(Policy::parse(
+            "version = 1\n[[recommendations.handlers]]\nkind = 'extension'\nidentifier = 'md'\napplications = ['com.example.App']\n"
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("use recommendations.extensions"));
+        assert!(Policy::parse(
+            "version = 1\n[[recommendations.handlers]]\nkind = 'uti'\nidentifier = 'Public.HTML'\napplications = ['com.example.App']\n[[recommendations.handlers]]\nkind = 'uti'\nidentifier = 'public.html'\napplications = ['com.example.Other']\n"
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("duplicate recommendation handler"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ use dutis::planner::{
     PlannedApplication,
 };
 use dutis::profiles::{
-    find_profile, profiles, recommend_profile_with_policy, ProfileRecommendation,
+    find_profile, profiles, recommend_profile_with_policy_typed, ProfileRecommendation,
 };
 use dutis::snapshot::{
     build_rollback_plan, capture_targets, SnapshotReason, SnapshotStore, SnapshotSummary,
@@ -1084,10 +1084,10 @@ fn run_recommend(args: RecommendArgs) -> Result<(), CliError> {
     system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
     let policy = LoadedPolicy::from_environment()
         .map_err(|error| CliError::usage(format!("failed to load policy: {error:#}")))?;
-    let recommendation = recommend_profile_with_policy(
+    let recommendation = recommend_profile_with_policy_typed(
         &profile,
         &catalog.applications,
-        system::query_default_app,
+        system::query_default_handler,
         &policy.policy,
     )
     .map_err(|error| CliError::operation(format!("failed to build recommendation: {error:#}")))?;
@@ -1109,8 +1109,8 @@ fn run_recommend(args: RecommendArgs) -> Result<(), CliError> {
         println!("{}", result.recommendation.description);
         for item in &result.recommendation.recommendations {
             println!(
-                "\n{:?} .{}: {}",
-                item.action, item.extension, item.explanation
+                "\n{:?} {}: {}",
+                item.action, item.association, item.explanation
             );
             for candidate in &item.evidence {
                 let status = if candidate.selected {
@@ -1130,14 +1130,14 @@ fn run_recommend(args: RecommendArgs) -> Result<(), CliError> {
                     format!("blocked: {}", candidate.policy_reasons.join(", "))
                 };
                 println!(
-                    "  {}. {} [{}; source={}; policy={}; installed={}; declares_extension={}]{}",
+                    "  {}. {} [{}; source={}; policy={}; installed={}; declares_target={}]{}",
                     candidate.priority,
                     candidate.bundle_id,
                     status,
                     candidate.source.as_str(),
                     policy_status,
                     candidate.installed_paths.len(),
-                    candidate.declares_extension,
+                    candidate.declares_target,
                     if paths.is_empty() {
                         String::new()
                     } else {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -11,7 +11,7 @@ use crate::governance::{
 };
 use crate::launch_services;
 use crate::planner::{build_plan, AssociationPlan};
-use crate::profiles::{find_profile, profiles, recommend_profile_with_policy};
+use crate::profiles::{find_profile, profiles, recommend_profile_with_policy_typed};
 use crate::snapshot::{build_rollback_plan, SnapshotReason, SnapshotStore};
 use crate::system;
 use anyhow::{anyhow, Context, Result};
@@ -130,10 +130,10 @@ impl McpBackend for SystemBackend {
         let catalog = ApplicationCatalog::scan()?;
         system::duti_version()?;
         let policy = LoadedPolicy::from_environment()?;
-        let recommendation = recommend_profile_with_policy(
+        let recommendation = recommend_profile_with_policy_typed(
             &profile,
             &catalog.applications,
-            system::query_default_app,
+            system::query_default_handler,
             &policy.policy,
         )?;
         Ok(json!({

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,6 +1,7 @@
 use crate::application::Application;
+use crate::association::AssociationTarget;
 use crate::association::{AssociationKind, HandlerRole};
-use crate::config::{DutisConfig, CONFIG_VERSION};
+use crate::config::{AssociationRule, DutisConfig, CONFIG_VERSION};
 use crate::governance::Policy;
 use crate::planner::{assemble_plan, AssociationPlan, PlanAction, PlanEntry, PlannedApplication};
 use crate::system::DefaultApplication;
@@ -42,6 +43,7 @@ pub enum RecommendationAction {
 pub enum CandidateSource {
     ProtectedPolicy,
     ExtensionPreference,
+    HandlerPreference,
     GlobalPreference,
     Profile,
 }
@@ -51,6 +53,7 @@ impl CandidateSource {
         match self {
             Self::ProtectedPolicy => "protected_policy",
             Self::ExtensionPreference => "extension_preference",
+            Self::HandlerPreference => "handler_preference",
             Self::GlobalPreference => "global_preference",
             Self::Profile => "profile",
         }
@@ -64,6 +67,7 @@ pub struct CandidateEvidence {
     pub source: CandidateSource,
     pub installed_paths: Vec<PathBuf>,
     pub declares_extension: bool,
+    pub declares_target: bool,
     pub policy_eligible: bool,
     pub policy_reasons: Vec<String>,
     pub selected: bool,
@@ -72,6 +76,7 @@ pub struct CandidateEvidence {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct AssociationRecommendation {
+    pub association: AssociationTarget,
     pub extension: String,
     pub action: RecommendationAction,
     pub current: Option<DefaultApplication>,
@@ -124,7 +129,13 @@ pub fn recommend_profile<F>(
 where
     F: FnMut(&str) -> Result<Option<DefaultApplication>>,
 {
-    recommend_profile_internal(profile, applications, &mut query_default, None)
+    recommend_profile_internal(
+        profile,
+        applications,
+        &mut |target| query_default(&target.identifier),
+        None,
+        false,
+    )
 }
 
 pub fn recommend_profile_with_policy<F>(
@@ -136,7 +147,31 @@ pub fn recommend_profile_with_policy<F>(
 where
     F: FnMut(&str) -> Result<Option<DefaultApplication>>,
 {
-    recommend_profile_internal(profile, applications, &mut query_default, Some(policy))
+    recommend_profile_internal(
+        profile,
+        applications,
+        &mut |target| query_default(&target.identifier),
+        Some(policy),
+        false,
+    )
+}
+
+pub fn recommend_profile_with_policy_typed<F>(
+    profile: &ProfileDefinition,
+    applications: &[Application],
+    mut query_default: F,
+    policy: &Policy,
+) -> Result<ProfileRecommendation>
+where
+    F: FnMut(&AssociationTarget) -> Result<Option<DefaultApplication>>,
+{
+    recommend_profile_internal(
+        profile,
+        applications,
+        &mut query_default,
+        Some(policy),
+        true,
+    )
 }
 
 fn recommend_profile_internal<F>(
@@ -144,19 +179,55 @@ fn recommend_profile_internal<F>(
     applications: &[Application],
     query_default: &mut F,
     policy: Option<&Policy>,
+    include_typed_preferences: bool,
 ) -> Result<ProfileRecommendation>
 where
-    F: FnMut(&str) -> Result<Option<DefaultApplication>>,
+    F: FnMut(&AssociationTarget) -> Result<Option<DefaultApplication>>,
 {
     let mut proposed_associations = BTreeMap::new();
+    let mut proposed_handlers = Vec::new();
     let mut plan_entries = Vec::new();
-    let mut recommendations = Vec::with_capacity(profile.associations.len());
+    let mut inputs = profile
+        .associations
+        .iter()
+        .map(|association| {
+            Ok(RecommendationInput {
+                target: AssociationTarget::extension(association.extension)?,
+                profile_candidates: association
+                    .candidates
+                    .iter()
+                    .map(|candidate| OwnedProfileCandidate {
+                        bundle_id: candidate.bundle_id.to_owned(),
+                        rationale: candidate.rationale.to_owned(),
+                    })
+                    .collect(),
+                requires_declaration: false,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if include_typed_preferences {
+        if let Some(policy) = policy {
+            for preference in &policy.recommendations.handlers {
+                let target = AssociationTarget::new(
+                    preference.kind,
+                    &preference.identifier,
+                    preference.role,
+                )?;
+                inputs.push(RecommendationInput {
+                    target,
+                    profile_candidates: Vec::new(),
+                    requires_declaration: true,
+                });
+            }
+        }
+    }
+    let mut recommendations = Vec::with_capacity(inputs.len());
 
-    for association in &profile.associations {
-        let current = query_default(association.extension)?;
-        let required =
-            policy.and_then(|policy| required_application(policy, association.extension));
-        let candidates = ordered_candidates(association, policy, required);
+    for input in inputs {
+        let association = &input.target;
+        let current = query_default(association)?;
+        let required = policy.and_then(|policy| required_application(policy, association));
+        let candidates = ordered_candidates(&input, policy, required);
         let candidates = candidates
             .into_iter()
             .enumerate()
@@ -168,13 +239,11 @@ where
                     })
                     .collect::<Vec<_>>();
                 let policy_reasons = policy.map_or_else(Vec::new, |policy| {
-                    policy_reasons(
-                        policy,
-                        association.extension,
-                        &candidate.bundle_id,
-                        required,
-                    )
+                    policy_reasons(policy, association, &candidate.bundle_id, required)
                 });
+                let declares_target = matches
+                    .iter()
+                    .any(|application| application_declares_target(application, association));
                 CandidateEvidence {
                     bundle_id: candidate.bundle_id,
                     priority: index + 1,
@@ -183,12 +252,9 @@ where
                         .iter()
                         .map(|application| application.path.clone())
                         .collect(),
-                    declares_extension: matches.iter().any(|application| {
-                        application
-                            .extensions
-                            .iter()
-                            .any(|extension| extension.eq_ignore_ascii_case(association.extension))
-                    }),
+                    declares_extension: association.kind == AssociationKind::Extension
+                        && declares_target,
+                    declares_target,
                     policy_eligible: policy_reasons.is_empty(),
                     policy_reasons,
                     selected: false,
@@ -208,16 +274,20 @@ where
                 candidate.source != CandidateSource::Profile
                     && candidate.policy_eligible
                     && candidate.installed_paths.len() == 1
+                    && (!input.requires_declaration || candidate.declares_target)
             })
             .or_else(|| {
                 current_candidate.filter(|index| {
                     candidates[*index].policy_eligible
                         && candidates[*index].installed_paths.len() == 1
+                        && (!input.requires_declaration || candidates[*index].declares_target)
                 })
             })
             .or_else(|| {
                 candidates.iter().position(|candidate| {
-                    candidate.policy_eligible && candidate.installed_paths.len() == 1
+                    candidate.policy_eligible
+                        && candidate.installed_paths.len() == 1
+                        && (!input.requires_declaration || candidate.declares_target)
                 })
             });
         let mut evidence = candidates;
@@ -256,27 +326,40 @@ where
             } else {
                 match selected.source {
                     CandidateSource::ProtectedPolicy => format!(
-                        "Recommend {} because local policy requires .{} to use {}.",
-                        application.name, association.extension, selected.bundle_id
+                        "Recommend {} because local policy requires {} to use {}.",
+                        application.name, association, selected.bundle_id
                     ),
-                    CandidateSource::ExtensionPreference | CandidateSource::GlobalPreference => {
+                    CandidateSource::ExtensionPreference
+                    | CandidateSource::HandlerPreference
+                    | CandidateSource::GlobalPreference => {
                         format!(
-                            "Recommend {} because it is the highest-priority uniquely installed local-policy preference for .{}.",
-                            application.name, association.extension
+                            "Recommend {} because it is the highest-priority uniquely installed local-policy preference for {}.",
+                            application.name, association
                         )
                     }
                     CandidateSource::Profile => format!(
-                        "Recommend {} because it is the highest-priority uniquely installed candidate for .{}: {}",
-                        application.name, association.extension, selected.rationale
+                        "Recommend {} because it is the highest-priority uniquely installed candidate for {}: {}",
+                        application.name, association, selected.rationale
                     ),
                 }
             };
-            proposed_associations
-                .insert(association.extension.to_owned(), selected.bundle_id.clone());
+            if association.kind == AssociationKind::Extension
+                && association.role == HandlerRole::All
+            {
+                proposed_associations
+                    .insert(association.identifier.clone(), selected.bundle_id.clone());
+            } else {
+                proposed_handlers.push(AssociationRule {
+                    kind: association.kind,
+                    identifier: association.identifier.clone(),
+                    role: association.role,
+                    application: selected.bundle_id.clone(),
+                });
+            }
             plan_entries.push(PlanEntry {
-                kind: AssociationKind::Extension,
-                role: HandlerRole::All,
-                extension: association.extension.to_owned(),
+                kind: association.kind,
+                role: association.role,
+                extension: association.identifier.clone(),
                 selector: selected.bundle_id.clone(),
                 current: current.clone(),
                 target: Some(target.clone()),
@@ -299,20 +382,26 @@ where
             };
             let explanation = if blocked {
                 format!(
-                    "Installed candidates for .{} are excluded by local policy; no change is proposed.",
-                    association.extension
+                    "Installed candidates for {} are excluded by local policy; no change is proposed.",
+                    association
+                )
+            } else if input.requires_declaration {
+                format!(
+                    "No uniquely installed policy-eligible candidate with a matching declaration is available for {}; no change is proposed.",
+                    association
                 )
             } else {
                 format!(
-                    "No uniquely installed policy-eligible candidate is available for .{}; no change is proposed.",
-                    association.extension
+                    "No uniquely installed policy-eligible candidate is available for {}; no change is proposed.",
+                    association
                 )
             };
             (action, None, explanation)
         };
 
         recommendations.push(AssociationRecommendation {
-            extension: association.extension.to_owned(),
+            association: association.clone(),
+            extension: association.identifier.clone(),
             action,
             current,
             target,
@@ -324,7 +413,7 @@ where
     let proposed_config = DutisConfig {
         version: CONFIG_VERSION,
         associations: proposed_associations,
-        handlers: Vec::new(),
+        handlers: proposed_handlers,
     };
     let proposed_toml = toml::to_string_pretty(&proposed_config)?;
     let plan = assemble_plan(CONFIG_VERSION, plan_entries)?;
@@ -370,11 +459,25 @@ struct OrderedCandidate {
     rationale: String,
 }
 
+#[derive(Debug)]
+struct OwnedProfileCandidate {
+    bundle_id: String,
+    rationale: String,
+}
+
+#[derive(Debug)]
+struct RecommendationInput {
+    target: AssociationTarget,
+    profile_candidates: Vec<OwnedProfileCandidate>,
+    requires_declaration: bool,
+}
+
 fn ordered_candidates(
-    association: &ProfileAssociation,
+    input: &RecommendationInput,
     policy: Option<&Policy>,
     required: Option<&str>,
 ) -> Vec<OrderedCandidate> {
+    let association = &input.target;
     let mut candidates = Vec::new();
     let mut seen = std::collections::BTreeSet::new();
     let mut push = |bundle_id: &str, source: CandidateSource, rationale: String| {
@@ -394,20 +497,38 @@ fn ordered_candidates(
         );
     }
     if let Some(policy) = policy {
-        if let Some(preferences) = policy.recommendations.extensions.get(association.extension) {
-            for bundle_id in preferences {
+        if association.kind == AssociationKind::Extension {
+            if let Some(preferences) = policy
+                .recommendations
+                .extensions
+                .get(&association.identifier)
+            {
+                for bundle_id in preferences {
+                    push(
+                        bundle_id,
+                        CandidateSource::ExtensionPreference,
+                        format!("Preferred by local policy for {association}."),
+                    );
+                }
+            }
+        } else if let Some(preference) = policy.recommendations.handlers.iter().find(|preference| {
+            preference.kind == association.kind
+                && preference.identifier == association.identifier
+                && preference.role == association.role
+        }) {
+            for bundle_id in &preference.applications {
                 push(
                     bundle_id,
-                    CandidateSource::ExtensionPreference,
-                    format!("Preferred by local policy for .{}.", association.extension),
+                    CandidateSource::HandlerPreference,
+                    format!("Preferred by local policy for {association}."),
                 );
             }
         }
         for bundle_id in &policy.recommendations.preferred_applications {
-            if association
-                .candidates
+            if input
+                .profile_candidates
                 .iter()
-                .any(|candidate| candidate.bundle_id == bundle_id)
+                .any(|candidate| &candidate.bundle_id == bundle_id)
             {
                 push(
                     bundle_id,
@@ -417,29 +538,32 @@ fn ordered_candidates(
             }
         }
     }
-    for candidate in &association.candidates {
+    for candidate in &input.profile_candidates {
         push(
-            candidate.bundle_id,
+            &candidate.bundle_id,
             CandidateSource::Profile,
-            candidate.rationale.to_owned(),
+            candidate.rationale.clone(),
         );
     }
     candidates
 }
 
-fn required_application<'a>(policy: &'a Policy, extension: &str) -> Option<&'a str> {
-    policy
-        .protected_associations
-        .get(extension)
+fn required_application<'a>(
+    policy: &'a Policy,
+    association: &AssociationTarget,
+) -> Option<&'a str> {
+    (association.kind == AssociationKind::Extension && association.role == HandlerRole::All)
+        .then(|| policy.protected_associations.get(&association.identifier))
+        .flatten()
         .map(String::as_str)
         .or_else(|| {
             policy
                 .protected_handlers
                 .iter()
                 .find(|handler| {
-                    handler.kind == AssociationKind::Extension
-                        && handler.identifier == extension
-                        && handler.role == HandlerRole::All
+                    handler.kind == association.kind
+                        && handler.identifier == association.identifier
+                        && handler.role == association.role
                 })
                 .map(|handler| handler.application.as_str())
         })
@@ -447,7 +571,7 @@ fn required_application<'a>(policy: &'a Policy, extension: &str) -> Option<&'a s
 
 fn policy_reasons(
     policy: &Policy,
-    extension: &str,
+    association: &AssociationTarget,
     bundle_id: &str,
     required: Option<&str>,
 ) -> Vec<String> {
@@ -455,16 +579,20 @@ fn policy_reasons(
     if policy
         .allowed_kinds
         .as_ref()
-        .is_some_and(|kinds| !kinds.contains(&AssociationKind::Extension))
+        .is_some_and(|kinds| !kinds.contains(&association.kind))
     {
-        reasons.push("extension associations are not allowed".to_owned());
+        reasons.push(format!("{} associations are not allowed", association.kind));
     }
-    if policy
-        .allowed_extensions
-        .as_ref()
-        .is_some_and(|extensions| !extensions.contains(extension))
+    if association.kind == AssociationKind::Extension
+        && policy
+            .allowed_extensions
+            .as_ref()
+            .is_some_and(|extensions| !extensions.contains(&association.identifier))
     {
-        reasons.push(format!("extension .{extension} is not allowed"));
+        reasons.push(format!(
+            "extension .{} is not allowed",
+            association.identifier
+        ));
     }
     if policy
         .allowed_applications
@@ -476,11 +604,30 @@ fn policy_reasons(
     if let Some(required) = required {
         if required != bundle_id {
             reasons.push(format!(
-                "protected association .{extension} requires {required}"
+                "protected association {association} requires {required}"
             ));
         }
     }
     reasons
+}
+
+fn application_declares_target(application: &Application, association: &AssociationTarget) -> bool {
+    if association.kind == AssociationKind::Extension
+        && application
+            .extensions
+            .iter()
+            .any(|extension| extension.eq_ignore_ascii_case(&association.identifier))
+    {
+        return true;
+    }
+    application.handlers.iter().any(|handler| {
+        handler.kind == association.kind
+            && handler.identifier == association.identifier
+            && (handler.role == HandlerRole::All
+                || association.role == HandlerRole::All
+                || handler.role == association.role
+                || (association.role == HandlerRole::Viewer && handler.role == HandlerRole::Editor))
+    })
 }
 
 fn developer_profile() -> ProfileDefinition {
@@ -967,5 +1114,156 @@ mod tests {
         assert_eq!(recommendation.summary.policy_blocked, 1);
         assert_eq!(recommendation.summary.unavailable, 0);
         assert_eq!(recommendation.plan.summary.total, 0);
+    }
+
+    #[test]
+    fn typed_policy_preference_builds_a_declared_handler_proposal() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: Vec::new(),
+        };
+        let mut browser = app("Browser", "com.example.Browser", &[]);
+        browser.handlers.push(crate::plist_parser::DeclaredHandler {
+            kind: AssociationKind::Uti,
+            identifier: "public.html".to_owned(),
+            role: HandlerRole::Editor,
+            source: crate::plist_parser::HandlerDeclarationSource::DocumentType,
+        });
+        let policy = Policy::parse(
+            r#"
+                version = 1
+                allowed_kinds = ["uti"]
+
+                [[recommendations.handlers]]
+                kind = "uti"
+                identifier = "Public.HTML"
+                role = "viewer"
+                applications = ["com.example.Browser"]
+            "#,
+        )
+        .unwrap();
+        let recommendation = recommend_profile_with_policy_typed(
+            &profile,
+            &[browser],
+            |association| {
+                assert_eq!(association.kind, AssociationKind::Uti);
+                assert_eq!(association.identifier, "public.html");
+                assert_eq!(association.role, HandlerRole::Viewer);
+                Ok(None)
+            },
+            &policy,
+        )
+        .unwrap();
+
+        let result = &recommendation.recommendations[0];
+        assert_eq!(result.association.kind, AssociationKind::Uti);
+        assert_eq!(result.association.role, HandlerRole::Viewer);
+        assert_eq!(result.extension, "public.html");
+        assert_eq!(result.action, RecommendationAction::Change);
+        assert_eq!(
+            result.evidence[0].source,
+            CandidateSource::HandlerPreference
+        );
+        assert!(result.evidence[0].declares_target);
+        assert!(result.evidence[0].selected);
+        assert_eq!(recommendation.proposed_config.handlers.len(), 1);
+        assert_eq!(recommendation.plan.entries[0].kind, AssociationKind::Uti);
+        assert_eq!(recommendation.plan.entries[0].role, HandlerRole::Viewer);
+        assert!(policy.assess(&recommendation.plan).allowed);
+    }
+
+    #[test]
+    fn typed_policy_preference_requires_matching_application_metadata() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: Vec::new(),
+        };
+        let policy = Policy::parse(
+            r#"
+                version = 1
+                [[recommendations.handlers]]
+                kind = "url_scheme"
+                identifier = "HTTPS://"
+                applications = ["com.example.Browser"]
+            "#,
+        )
+        .unwrap();
+        let recommendation = recommend_profile_with_policy_typed(
+            &profile,
+            &[app("Browser", "com.example.Browser", &[])],
+            |_| Ok(None),
+            &policy,
+        )
+        .unwrap();
+
+        let result = &recommendation.recommendations[0];
+        assert_eq!(result.action, RecommendationAction::Unavailable);
+        assert!(!result.evidence[0].declares_target);
+        assert!(!result.evidence[0].selected);
+        assert!(recommendation.proposed_config.handlers.is_empty());
+        assert_eq!(recommendation.plan.summary.total, 0);
+    }
+
+    #[test]
+    fn typed_preferences_cover_mime_and_url_scheme_targets() {
+        let profile = ProfileDefinition {
+            name: "test",
+            description: "test profile",
+            associations: Vec::new(),
+        };
+        let mut application = app("Universal", "com.example.Universal", &[]);
+        application.handlers.extend([
+            crate::plist_parser::DeclaredHandler {
+                kind: AssociationKind::Mime,
+                identifier: "text/plain".to_owned(),
+                role: HandlerRole::Editor,
+                source: crate::plist_parser::HandlerDeclarationSource::DocumentType,
+            },
+            crate::plist_parser::DeclaredHandler {
+                kind: AssociationKind::UrlScheme,
+                identifier: "example".to_owned(),
+                role: HandlerRole::All,
+                source: crate::plist_parser::HandlerDeclarationSource::UrlType,
+            },
+        ]);
+        let policy = Policy::parse(
+            r#"
+                version = 1
+                [[recommendations.handlers]]
+                kind = "mime"
+                identifier = "Text/Plain"
+                role = "editor"
+                applications = ["com.example.Universal"]
+
+                [[recommendations.handlers]]
+                kind = "url_scheme"
+                identifier = "EXAMPLE://"
+                applications = ["com.example.Universal"]
+            "#,
+        )
+        .unwrap();
+        let recommendation =
+            recommend_profile_with_policy_typed(&profile, &[application], |_| Ok(None), &policy)
+                .unwrap();
+
+        assert_eq!(recommendation.summary.changes, 2);
+        assert_eq!(recommendation.proposed_config.handlers.len(), 2);
+        assert_eq!(
+            recommendation
+                .recommendations
+                .iter()
+                .map(|item| (&item.association.kind, item.association.identifier.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (&AssociationKind::Mime, "text/plain"),
+                (&AssociationKind::UrlScheme, "example")
+            ]
+        );
+        assert!(recommendation
+            .recommendations
+            .iter()
+            .all(|item| item.evidence[0].declares_target && item.evidence[0].selected));
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -931,7 +931,7 @@ fn policy_show_redacts_token_hash_and_audit_starts_empty() {
     fs::write(
         &policy_path,
         format!(
-            "version = 1\napproval_mode = 'token'\napproval_token_sha256 = '{secret_hash}'\n[recommendations]\npreferred_applications = ['com.example.TeamEditor']\n[recommendations.extensions]\nmd = ['com.example.Markdown']\n"
+            "version = 1\napproval_mode = 'token'\napproval_token_sha256 = '{secret_hash}'\n[recommendations]\npreferred_applications = ['com.example.TeamEditor']\n[recommendations.extensions]\nmd = ['com.example.Markdown']\n[[recommendations.handlers]]\nkind = 'uti'\nidentifier = 'Public.HTML'\nrole = 'viewer'\napplications = ['com.example.Browser']\n"
         ),
     )
     .unwrap();
@@ -952,6 +952,18 @@ fn policy_show_redacts_token_hash_and_audit_starts_empty() {
     assert_eq!(
         policy["data"]["recommendations"]["extensions"]["md"][0],
         "com.example.Markdown"
+    );
+    assert_eq!(
+        policy["data"]["recommendations"]["handlers"][0]["kind"],
+        "uti"
+    );
+    assert_eq!(
+        policy["data"]["recommendations"]["handlers"][0]["identifier"],
+        "public.html"
+    );
+    assert_eq!(
+        policy["data"]["recommendations"]["handlers"][0]["applications"][0],
+        "com.example.Browser"
     );
     assert!(!String::from_utf8(policy_output.stdout)
         .unwrap()


### PR DESCRIPTION
## Summary
- add ordered UTI, MIME, and URL-scheme preferences to the version-one local policy schema
- generate typed CLI and MCP recommendation proposals through role-aware default queries
- require exact compatible application declarations before selecting typed candidates
- preserve legacy extension recommendation fields while adding normalized association evidence
- document Phase 16 and bump the release version to 2.20.0

## Safety
- recommendations remain read-only proposals
- typed targets pass through existing allowlists and protected-handler rules
- malformed, duplicate, empty, or extension-kind typed preferences fail closed
- no new MCP mutation tool or remote policy path is introduced

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline (135 passed)
- cargo build --release --bins --locked --offline
- cargo package --allow-dirty --locked --offline
- ruby -c scripts/render_homebrew_formula.rb
- git diff --check