### PR TITLE
feat: add event delivery health metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.20.0"
+version = "2.21.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.20.0"
+version = "2.21.0"
 edition = "2021"
 rust-version = "1.88"
 default-run = "dutis"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 - 📡 **Event Sinks**: Stream versioned drift and mutation lifecycle events to private JSONL logs or trusted local commands
 - 🌐 **HTTPS Event Adapter**: Forward events with environment-only credentials, bounded retries, and idempotency headers
 - 📦 **Durable Event Replay**: Queue failed command deliveries locally and replay them without repeating the original mutation
+- 📊 **Delivery Health**: Summarize pending and dead-letter counts without exposing event payloads
 - 🍎 **Native Role Inspection**: Read separate viewer, editor, and shell defaults directly from macOS Launch Services
 
 ## Installation
@@ -263,6 +264,7 @@ export DUTIS_EVENT_COMMAND="$(command -v dutis-event-http)"
 dutis-event-http --check --json
 
 # Inspect and replay failed command deliveries
+dutis events health --json
 dutis events pending --json
 dutis events replay --limit 100 --json
 dutis events archive --max-attempts 5 --older-than-days 30 --json
@@ -278,6 +280,9 @@ directory. Override that location with `--event-outbox` or
 can deduplicate retries. See [durable event replay](docs/event-replay.md).
 Archive and purge commands are previews unless `--yes` is present, so pending
 deliveries are never removed by an implicit retention policy.
+`events health` is read-only and reports stable counts, retry totals, time
+ranges, and type/source breakdowns without event IDs or payload contents. The
+same summary is available to read-only MCP clients as `dutis_event_health`.
 
 All write paths enforce the same local policy before mutation and record the
 requester, reviewed plan, result, and verification. See the

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -345,11 +345,30 @@ Acceptance criteria:
   `declares_extension` fields while additive typed fields identify every target
   consistently.
 
+## Phase 17: Event delivery health summaries
+
+Status: implemented for v2.21.0
+
+Provide compact operational visibility into the local event outbox without
+exposing the event bodies that may contain paths, identities, or plans.
+
+Acceptance criteria:
+
+- CLI and read-only MCP expose the same versioned health summary without event
+  IDs, payloads, retention reasons, or local storage paths.
+- Health includes pending and dead-letter counts, total and maximum attempts,
+  timestamp ranges, and stable breakdowns by event type and source.
+- Status distinguishes an empty healthy outbox, a retryable pending backlog,
+  and dead letters that require operator attention.
+- Metrics reuse strict outbox validation and fail closed on malformed,
+  oversized, mismatched, or non-regular records.
+- Health inspection never replays, archives, purges, or otherwise changes an
+  event record.
+
 ## Near-term engineering sequence
 
-1. Release Phase 16 and validate typed preference declarations against a
-   representative fleet application catalog.
-2. Add optional metrics summaries for event delivery health without exposing
-   payload contents.
-3. Add configurable profile overlays only after typed preference usage shows
+1. Release Phase 17 and validate health summaries in operator dashboards.
+2. Add configurable profile overlays only after typed preference usage shows
    which reusable association groups are stable across fleets.
+3. Evaluate bounded concurrency controls for replay after observing real sink
+   latency and failure patterns.

--- a/docs/event-replay.md
+++ b/docs/event-replay.md
@@ -31,6 +31,27 @@ does not contain HTTP endpoint or credential configuration. Event payloads can
 still contain local paths, bundle identifiers, requester identity, and plans,
 so the directory should remain private.
 
+## Inspect delivery health
+
+Use the payload-free health summary for dashboards, periodic checks, and agent
+triage:
+
+```bash
+dutis events health
+dutis events health --json
+```
+
+The versioned result reports `healthy` when both stores are empty, `degraded`
+when deliveries are pending, and `attention_required` when at least one dead
+letter exists. It includes pending and dead-letter counts, total and maximum
+attempts, oldest/latest timestamps, and stable zero-filled breakdowns by event
+type and source. It never includes event IDs, retention reasons, payloads, or
+outbox paths.
+
+Read-only MCP servers expose the same data through `dutis_event_health`. Both
+interfaces validate every stored record first and fail closed if an entry is
+malformed, oversized, mismatched, or not a regular file.
+
 ## Inspect pending events
 
 ```bash

--- a/docs/event-sinks.md
+++ b/docs/event-sinks.md
@@ -118,12 +118,17 @@ The default location is `event-outbox` inside `DUTIS_STATE_DIR`, or
 `DUTIS_EVENT_OUTBOX` to select another directory. JSONL write failures are not
 queued because the outbox is specifically a command-delivery queue.
 
-Inspect and replay the oldest pending events with:
+Inspect delivery health and replay the oldest pending events with:
 
 ```bash
+dutis events health --json
 dutis events pending --json
 dutis --event-command /absolute/path/to/handler events replay --limit 100 --json
 ```
+
+`events health` and the read-only MCP tool `dutis_event_health` expose only
+aggregate counts, attempts, timestamp ranges, and type/source buckets. They
+omit event IDs, payloads, retention reasons, and filesystem paths.
 
 See [durable event replay](event-replay.md) for persistence, retry, and
 at-least-once delivery guarantees, dead-letter retention, and explicit cleanup.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -33,6 +33,8 @@ The server advertises these read tools:
 - `dutis_profiles`: list built-in profiles and ordered candidates.
 - `dutis_profile`: inspect one profile by its `profile` name.
 - `dutis_recommend`: generate an explainable policy-aware proposal, plan digest, and policy assessment by `profile` name.
+- `dutis_event_health`: summarize pending deliveries and dead letters without
+  returning event IDs or payload contents.
 - `dutis_drift`: check inline TOML for drift and return a timestamped report with policy assessment.
 - `dutis_query`: find installed handlers for one extension.
 - `dutis_get`: inspect the current default handler.
@@ -71,6 +73,11 @@ To use one, review its `proposed_toml`, rebuild it with `dutis_diff`, run
 `dutis_drift` accepts the same `config_toml` input as `dutis_diff`. It reports
 `in_sync`, `drift_detected`, or `unresolved` and never remediates. MCP clients
 must use the separately gated apply workflow for any change.
+
+`dutis_event_health` accepts no arguments. It is a local, read-only view over
+the validated event outbox and reports counts, attempt totals, timestamp ranges,
+and event type/source breakdowns. It does not expose replay, archive, or purge
+through MCP.
 
 ## Enable writes explicitly
 

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -19,8 +19,10 @@ Use Dutis for macOS Launch Services associations. Preserve its
    When roles may differ, use `handler defaults` or
    `dutis_handler_defaults` to inspect the native Launch Services role matrix
    before planning a change.
-   If an event command reports a delivery failure, inspect `events pending`
-   and use `events replay` only after confirming the configured sink is healthy.
+   If an event command reports a delivery failure, inspect `events health`
+   (`dutis_event_health` over MCP), then inspect `events pending` only when
+   event-level details are necessary. Use `events replay` only after confirming
+   the configured sink is healthy.
    Preview `events archive` and `events purge` before using `--yes`; purge is
    permanent and applies only to events already moved into dead-letter storage.
 2. If the user asks for a general setup or is unsure which application to use,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -334,6 +334,8 @@ pub struct EventsArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum EventsCommand {
+    /// Summarize event delivery health without exposing event payloads
+    Health(OutputArgs),
     /// List events waiting in the durable outbox
     Pending(OutputArgs),
     /// Deliver pending events through the configured event command
@@ -524,6 +526,13 @@ mod tests {
 
     #[test]
     fn parses_event_outbox_commands() {
+        let cli = Cli::try_parse_from(["dutis", "events", "health", "--json"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Events(EventsArgs {
+                command: EventsCommand::Health(OutputArgs { json: true })
+            }))
+        ));
         let cli = Cli::try_parse_from(["dutis", "events", "pending", "--json"]).unwrap();
         assert!(matches!(
             cli.command,

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::fs::{self, OpenOptions};
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
@@ -15,6 +16,7 @@ pub const EVENT_COMMAND_ENV: &str = "DUTIS_EVENT_COMMAND";
 pub const EVENT_OUTBOX_ENV: &str = "DUTIS_EVENT_OUTBOX";
 pub const PENDING_EVENT_SCHEMA_VERSION: u32 = 1;
 pub const DEAD_LETTER_SCHEMA_VERSION: u32 = 1;
+pub const EVENT_HEALTH_SCHEMA_VERSION: u32 = 1;
 
 const MAX_EVENT_RECORD_BYTES: u64 = 4 * 1024 * 1024;
 
@@ -52,6 +54,16 @@ pub enum EventSource {
     Watcher,
     Mcp,
     Governance,
+}
+
+impl EventSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Watcher => "watcher",
+            Self::Mcp => "mcp",
+            Self::Governance => "governance",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -137,6 +149,59 @@ pub struct OutboxMaintenanceReport {
     pub pending: usize,
     pub dead_letters: usize,
     pub events: Vec<OutboxMaintenanceItem>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventDeliveryHealthStatus {
+    Healthy,
+    Degraded,
+    AttentionRequired,
+}
+
+impl EventDeliveryHealthStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Healthy => "healthy",
+            Self::Degraded => "degraded",
+            Self::AttentionRequired => "attention_required",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct PendingDeliveryMetrics {
+    pub count: usize,
+    pub total_attempts: u64,
+    pub max_attempts: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_queued_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_attempted_at: Option<String>,
+    pub by_event_type: BTreeMap<String, usize>,
+    pub by_source: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct DeadLetterMetrics {
+    pub count: usize,
+    pub total_attempts: u64,
+    pub max_attempts: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_dead_lettered_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_dead_lettered_at: Option<String>,
+    pub by_event_type: BTreeMap<String, usize>,
+    pub by_source: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct EventDeliveryHealth {
+    pub schema_version: u32,
+    pub generated_at: String,
+    pub status: EventDeliveryHealthStatus,
+    pub pending: PendingDeliveryMetrics,
+    pub dead_letters: DeadLetterMetrics,
 }
 
 impl EventEnvelope {
@@ -392,6 +457,86 @@ impl EventOutbox {
                 reasons: record.reasons,
             })
             .collect())
+    }
+
+    pub fn health(&self) -> Result<EventDeliveryHealth> {
+        let pending = self.load_all()?;
+        let dead_letters = self.load_all_dead_letters()?;
+        let (oldest_queued_at, _) = timestamp_range(
+            pending.iter().map(|record| record.queued_at.as_str()),
+            "queued_at",
+        )?;
+        let (_, latest_attempted_at) = timestamp_range(
+            pending
+                .iter()
+                .map(|record| record.last_attempted_at.as_str()),
+            "last_attempted_at",
+        )?;
+        let (oldest_dead_lettered_at, latest_dead_lettered_at) = timestamp_range(
+            dead_letters
+                .iter()
+                .map(|record| record.dead_lettered_at.as_str()),
+            "dead_lettered_at",
+        )?;
+
+        let mut pending_by_event_type = empty_event_type_counts();
+        let mut pending_by_source = empty_event_source_counts();
+        let mut pending_attempts = 0_u64;
+        let mut pending_max_attempts = 0_u64;
+        for record in &pending {
+            increment(&mut pending_by_event_type, record.event.event_type.as_str());
+            increment(&mut pending_by_source, record.event.source.as_str());
+            pending_attempts = pending_attempts.saturating_add(record.attempts);
+            pending_max_attempts = pending_max_attempts.max(record.attempts);
+        }
+
+        let mut dead_letter_by_event_type = empty_event_type_counts();
+        let mut dead_letter_by_source = empty_event_source_counts();
+        let mut dead_letter_attempts = 0_u64;
+        let mut dead_letter_max_attempts = 0_u64;
+        for record in &dead_letters {
+            increment(
+                &mut dead_letter_by_event_type,
+                record.pending.event.event_type.as_str(),
+            );
+            increment(
+                &mut dead_letter_by_source,
+                record.pending.event.source.as_str(),
+            );
+            dead_letter_attempts = dead_letter_attempts.saturating_add(record.pending.attempts);
+            dead_letter_max_attempts = dead_letter_max_attempts.max(record.pending.attempts);
+        }
+
+        let status = if !dead_letters.is_empty() {
+            EventDeliveryHealthStatus::AttentionRequired
+        } else if !pending.is_empty() {
+            EventDeliveryHealthStatus::Degraded
+        } else {
+            EventDeliveryHealthStatus::Healthy
+        };
+        Ok(EventDeliveryHealth {
+            schema_version: EVENT_HEALTH_SCHEMA_VERSION,
+            generated_at: current_timestamp()?,
+            status,
+            pending: PendingDeliveryMetrics {
+                count: pending.len(),
+                total_attempts: pending_attempts,
+                max_attempts: pending_max_attempts,
+                oldest_queued_at,
+                latest_attempted_at,
+                by_event_type: pending_by_event_type,
+                by_source: pending_by_source,
+            },
+            dead_letters: DeadLetterMetrics {
+                count: dead_letters.len(),
+                total_attempts: dead_letter_attempts,
+                max_attempts: dead_letter_max_attempts,
+                oldest_dead_lettered_at,
+                latest_dead_lettered_at,
+                by_event_type: dead_letter_by_event_type,
+                by_source: dead_letter_by_source,
+            },
+        })
     }
 
     pub fn archive(
@@ -768,6 +913,64 @@ fn cutoff_from_days(days: u64) -> Result<OffsetDateTime> {
 
 fn parse_timestamp(value: &str, field: &str) -> Result<OffsetDateTime> {
     OffsetDateTime::parse(value, &Rfc3339).with_context(|| format!("invalid {field} timestamp"))
+}
+
+fn timestamp_range<'a>(
+    values: impl IntoIterator<Item = &'a str>,
+    field: &str,
+) -> Result<(Option<String>, Option<String>)> {
+    let mut oldest: Option<(OffsetDateTime, String)> = None;
+    let mut latest: Option<(OffsetDateTime, String)> = None;
+    for value in values {
+        let parsed = parse_timestamp(value, field)?;
+        if oldest
+            .as_ref()
+            .is_none_or(|(timestamp, _)| parsed < *timestamp)
+        {
+            oldest = Some((parsed, value.to_owned()));
+        }
+        if latest
+            .as_ref()
+            .is_none_or(|(timestamp, _)| parsed > *timestamp)
+        {
+            latest = Some((parsed, value.to_owned()));
+        }
+    }
+    Ok((
+        oldest.map(|(_, value)| value),
+        latest.map(|(_, value)| value),
+    ))
+}
+
+fn empty_event_type_counts() -> BTreeMap<String, usize> {
+    [
+        EventType::DriftChecked,
+        EventType::MutationPending,
+        EventType::MutationDenied,
+        EventType::MutationFailed,
+        EventType::MutationCompleted,
+    ]
+    .into_iter()
+    .map(|event_type| (event_type.as_str().to_owned(), 0))
+    .collect()
+}
+
+fn empty_event_source_counts() -> BTreeMap<String, usize> {
+    [
+        EventSource::Watcher,
+        EventSource::Mcp,
+        EventSource::Governance,
+    ]
+    .into_iter()
+    .map(|source| (source.as_str().to_owned(), 0))
+    .collect()
+}
+
+fn increment(counts: &mut BTreeMap<String, usize>, key: &str) {
+    counts
+        .entry(key.to_owned())
+        .and_modify(|count| *count = count.saturating_add(1))
+        .or_insert(1);
 }
 
 fn validate_pending_event(pending: &PendingEvent) -> Result<()> {
@@ -1169,6 +1372,11 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("does not match its filename"));
+        assert!(outbox
+            .health()
+            .unwrap_err()
+            .to_string()
+            .contains("does not match its filename"));
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1184,6 +1392,8 @@ mod tests {
         fs::write(&external, b"{}\n").unwrap();
         symlink(&external, directory.join("linked.json")).unwrap();
         let error = EventOutbox::new(&directory).pending().unwrap_err();
+        assert!(error.to_string().contains("not a regular file"));
+        let error = EventOutbox::new(&directory).health().unwrap_err();
         assert!(error.to_string().contains("not a regular file"));
         fs::remove_dir_all(root).unwrap();
     }
@@ -1252,6 +1462,66 @@ mod tests {
         assert!(outbox.dead_letters().unwrap().is_empty());
 
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn health_summarizes_backlog_without_exposing_event_contents() {
+        let root = temp_root("outbox-health");
+        let outbox = EventOutbox::new(root.join("outbox"));
+        let pending = EventEnvelope::new(
+            EventType::DriftChecked,
+            EventSource::Watcher,
+            &json!({"sensitive_payload": "must-not-leak"}),
+        )
+        .unwrap();
+        let dead_letter = EventEnvelope::new(
+            EventType::MutationFailed,
+            EventSource::Governance,
+            &json!({"secret": "also-must-not-leak"}),
+        )
+        .unwrap();
+        outbox.enqueue(&pending).unwrap();
+        outbox.enqueue(&dead_letter).unwrap();
+        outbox.enqueue(&dead_letter).unwrap();
+        outbox.archive(Some(2), None, true).unwrap();
+
+        let health = outbox.health().unwrap();
+        assert_eq!(health.status, EventDeliveryHealthStatus::AttentionRequired);
+        assert_eq!(health.schema_version, EVENT_HEALTH_SCHEMA_VERSION);
+        assert_eq!(health.pending.count, 1);
+        assert_eq!(health.pending.total_attempts, 1);
+        assert_eq!(health.pending.max_attempts, 1);
+        assert_eq!(health.pending.by_event_type["drift.checked"], 1);
+        assert_eq!(health.pending.by_event_type["mutation.failed"], 0);
+        assert_eq!(health.pending.by_source["watcher"], 1);
+        assert!(health.pending.oldest_queued_at.is_some());
+        assert!(health.pending.latest_attempted_at.is_some());
+        assert_eq!(health.dead_letters.count, 1);
+        assert_eq!(health.dead_letters.total_attempts, 2);
+        assert_eq!(health.dead_letters.max_attempts, 2);
+        assert_eq!(health.dead_letters.by_event_type["mutation.failed"], 1);
+        assert_eq!(health.dead_letters.by_source["governance"], 1);
+        assert!(health.dead_letters.oldest_dead_lettered_at.is_some());
+        assert!(health.dead_letters.latest_dead_lettered_at.is_some());
+
+        let encoded = serde_json::to_string(&health).unwrap();
+        assert!(!encoded.contains("must-not-leak"));
+        assert!(!encoded.contains(&pending.id));
+        assert!(!encoded.contains(&dead_letter.id));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn empty_outbox_health_is_healthy_with_stable_zero_buckets() {
+        let outbox = EventOutbox::new(temp_root("outbox-health-empty"));
+        let health = outbox.health().unwrap();
+        assert_eq!(health.status, EventDeliveryHealthStatus::Healthy);
+        assert_eq!(health.pending.count, 0);
+        assert_eq!(health.dead_letters.count, 0);
+        assert_eq!(health.pending.by_event_type.len(), 5);
+        assert_eq!(health.dead_letters.by_source.len(), 3);
+        assert!(health.pending.oldest_queued_at.is_none());
+        assert!(health.dead_letters.oldest_dead_lettered_at.is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,6 +357,7 @@ fn command_uses_json(command: &CliCommand) -> bool {
         },
         CliCommand::Watch(args) => args.json,
         CliCommand::Events(args) => match &args.command {
+            EventsCommand::Health(args) => args.json,
             EventsCommand::Pending(args) => args.json,
             EventsCommand::Replay(args) => args.json,
             EventsCommand::Archive(args) => args.json,
@@ -373,12 +374,45 @@ fn command_uses_json(command: &CliCommand) -> bool {
 
 fn run_events(args: EventsArgs) -> Result<(), CliError> {
     match args.command {
+        EventsCommand::Health(args) => run_events_health(args),
         EventsCommand::Pending(args) => run_events_pending(args),
         EventsCommand::Replay(args) => run_events_replay(args),
         EventsCommand::Archive(args) => run_events_archive(args),
         EventsCommand::DeadLetters(args) => run_events_dead_letters(args),
         EventsCommand::Purge(args) => run_events_purge(args),
     }
+}
+
+fn run_events_health(args: OutputArgs) -> Result<(), CliError> {
+    let health = event_outbox()?
+        .health()
+        .map_err(|error| CliError::operation(format!("failed to read event health: {error:#}")))?;
+    if args.json {
+        write_json(&JsonEnvelope {
+            api_version: API_VERSION,
+            command: "events",
+            data: health,
+        })?;
+    } else {
+        println!("Event delivery health: {}", health.status.as_str());
+        println!(
+            "Pending: {} (attempts={}, max_attempts={})",
+            health.pending.count, health.pending.total_attempts, health.pending.max_attempts
+        );
+        println!(
+            "Dead letters: {} (attempts={}, max_attempts={})",
+            health.dead_letters.count,
+            health.dead_letters.total_attempts,
+            health.dead_letters.max_attempts
+        );
+        if let Some(oldest) = health.pending.oldest_queued_at {
+            println!("Oldest pending: {oldest}");
+        }
+        if let Some(oldest) = health.dead_letters.oldest_dead_lettered_at {
+            println!("Oldest dead letter: {oldest}");
+        }
+    }
+    Ok(())
 }
 
 fn run_events_pending(args: OutputArgs) -> Result<(), CliError> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -4,7 +4,7 @@ use crate::application::{
 use crate::association::{AssociationKind, AssociationTarget, HandlerRole};
 use crate::config::DutisConfig;
 use crate::drift::DriftReport;
-use crate::events::{emit_best_effort, EventSource, EventType};
+use crate::events::{emit_best_effort, EventOutbox, EventSource, EventType};
 use crate::governance::{
     execute_governed_plan, AuditStore, GovernanceError, GovernanceErrorKind, LoadedPolicy,
     MutationChannel, MutationOperation, MutationRequest,
@@ -85,6 +85,7 @@ trait McpBackend {
     fn profiles(&mut self) -> Result<Value>;
     fn profile(&mut self, name: &str) -> Result<Value>;
     fn recommend(&mut self, name: &str) -> Result<Value>;
+    fn event_health(&mut self) -> Result<Value>;
     fn drift(&mut self, config: &DutisConfig) -> Result<Value>;
     fn query(&mut self, extension: &str) -> Result<Value>;
     fn get(&mut self, extension: &str) -> Result<Value>;
@@ -142,6 +143,11 @@ impl McpBackend for SystemBackend {
             "policy": policy.summary(),
             "recommendation": recommendation,
         }))
+    }
+
+    fn event_health(&mut self) -> Result<Value> {
+        serde_json::to_value(EventOutbox::from_environment()?.health()?)
+            .context("failed to serialize event delivery health")
     }
 
     fn drift(&mut self, config: &DutisConfig) -> Result<Value> {
@@ -387,6 +393,7 @@ impl<B: McpBackend> McpServer<B> {
                 }
                 self.backend.recommend(profile).map_err(operation_error)
             }
+            "dutis_event_health" => self.backend.event_health().map_err(operation_error),
             "dutis_drift" => {
                 let config = parse_config(arguments)?;
                 let report = self.backend.drift(&config).map_err(operation_error)?;
@@ -810,6 +817,12 @@ fn tool_definitions(allow_writes: bool) -> Vec<Value> {
             read_annotations.clone(),
         ),
         tool_definition(
+            "dutis_event_health",
+            "Summarize local event delivery backlog and dead letters without exposing event payloads.",
+            empty_schema.clone(),
+            read_annotations.clone(),
+        ),
+        tool_definition(
             "dutis_drift",
             "Check an inline configuration for drift and return a timestamped report with policy assessment without changing the system.",
             config_schema.clone(),
@@ -1039,6 +1052,15 @@ mod tests {
             Ok(json!({"profile": name, "proposal_only": true}))
         }
 
+        fn event_health(&mut self) -> Result<Value> {
+            Ok(json!({
+                "schema_version": 1,
+                "status": "healthy",
+                "pending": {"count": 0},
+                "dead_letters": {"count": 0}
+            }))
+        }
+
         fn drift(&mut self, _config: &DutisConfig) -> Result<Value> {
             Ok(json!({
                 "schema_version": 1,
@@ -1156,6 +1178,7 @@ mod tests {
         assert!(names.contains(&"dutis_profiles"));
         assert!(names.contains(&"dutis_profile"));
         assert!(names.contains(&"dutis_recommend"));
+        assert!(names.contains(&"dutis_event_health"));
         assert!(names.contains(&"dutis_drift"));
         assert!(names.contains(&"dutis_handler_get"));
         assert!(names.contains(&"dutis_handler_query"));
@@ -1200,6 +1223,23 @@ mod tests {
             missing.response.unwrap()["result"]["structuredContent"]["error"]["kind"],
             "not_found"
         );
+    }
+
+    #[test]
+    fn event_health_tool_is_read_only_and_payload_free() {
+        let mut server = McpServer::new(FakeBackend::new(), McpOptions::read_only());
+        let outcome = server.handle(request(
+            6,
+            "tools/call",
+            json!({"name": "dutis_event_health", "arguments": {}}),
+        ));
+        let response = outcome.response.unwrap();
+        let data = &response["result"]["structuredContent"]["data"];
+        assert_eq!(data["schema_version"], 1);
+        assert_eq!(data["status"], "healthy");
+        assert_eq!(data["pending"]["count"], 0);
+        assert!(data.get("payload").is_none());
+        assert_eq!(outcome.audit.unwrap().access, "read");
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -145,6 +145,27 @@ fn pending_events_can_be_inspected_and_replayed_from_the_cli() {
     .unwrap();
     outbox.enqueue(&event).unwrap();
 
+    let health = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "health",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(health.status.success());
+    let response: Value = serde_json::from_slice(&health.stdout).unwrap();
+    assert_eq!(response["data"]["schema_version"], 1);
+    assert_eq!(response["data"]["status"], "degraded");
+    assert_eq!(response["data"]["pending"]["count"], 1);
+    assert_eq!(response["data"]["dead_letters"]["count"], 0);
+    assert!(response["data"].get("payload").is_none());
+    let health_output = String::from_utf8_lossy(&health.stdout);
+    assert!(!health_output.contains("drift_detected"));
+    assert!(!health_output.contains(&event.id));
+
     let pending = dutis()
         .args([
             "--event-outbox",
@@ -225,6 +246,19 @@ fn pending_events_can_be_inspected_and_replayed_from_the_cli() {
         serde_json::from_str(fs::read_to_string(received).unwrap().trim()).unwrap();
     assert_eq!(delivered["id"], event.id);
     assert!(outbox.pending().unwrap().is_empty());
+
+    let health = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "health",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let response: Value = serde_json::from_slice(&health.stdout).unwrap();
+    assert_eq!(response["data"]["status"], "healthy");
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -296,6 +330,21 @@ fn event_archive_and_purge_require_explicit_confirmation() {
         .unwrap();
     assert!(archive.status.success());
     assert!(outbox.pending().unwrap().is_empty());
+
+    let health = dutis()
+        .args([
+            "--event-outbox",
+            outbox_path.to_str().unwrap(),
+            "events",
+            "health",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let response: Value = serde_json::from_slice(&health.stdout).unwrap();
+    assert_eq!(response["data"]["status"], "attention_required");
+    assert_eq!(response["data"]["pending"]["count"], 0);
+    assert_eq!(response["data"]["dead_letters"]["count"], 1);
 
     let dead_letters = dutis()
         .args([
@@ -836,7 +885,7 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
     ));
     let mut child = dutis()
         .arg("mcp")
-        .env("DUTIS_STATE_DIR", state)
+        .env("DUTIS_STATE_DIR", &state)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -848,7 +897,8 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n",
         "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_history\",\"arguments\":{}}}\n",
         "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_policy\",\"arguments\":{}}}\n",
-        "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_profile\",\"arguments\":{\"profile\":\"minimal\"}}}\n"
+        "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_profile\",\"arguments\":{\"profile\":\"minimal\"}}}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_event_health\",\"arguments\":{}}}\n"
     );
     child
         .stdin
@@ -864,13 +914,16 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         .lines()
         .map(|line| serde_json::from_str::<Value>(line).unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(responses.len(), 5);
+    assert_eq!(responses.len(), 6);
     assert_eq!(responses[0]["result"]["protocolVersion"], "2024-11-05");
     let tools = responses[1]["result"]["tools"].as_array().unwrap();
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_diff"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_policy"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_profiles"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_recommend"));
+    assert!(tools
+        .iter()
+        .any(|tool| tool["name"] == "dutis_event_health"));
     assert!(tools.iter().any(|tool| tool["name"] == "dutis_drift"));
     assert!(tools
         .iter()
@@ -887,18 +940,30 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         responses[4]["result"]["structuredContent"]["data"]["name"],
         "minimal"
     );
+    assert_eq!(
+        responses[5]["result"]["structuredContent"]["data"]["status"],
+        "healthy"
+    );
+    assert_eq!(
+        responses[5]["result"]["structuredContent"]["data"]["pending"]["count"],
+        0
+    );
 
     let audit = String::from_utf8(output.stderr)
         .unwrap()
         .lines()
         .map(|line| serde_json::from_str::<Value>(line).unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(audit.len(), 3);
+    assert_eq!(audit.len(), 4);
     assert_eq!(audit[0]["schema_version"], 1);
     assert_eq!(audit[0]["tool"], "dutis_history");
     assert_eq!(audit[1]["tool"], "dutis_policy");
     assert_eq!(audit[2]["tool"], "dutis_profile");
+    assert_eq!(audit[3]["tool"], "dutis_event_health");
     assert!(audit.iter().all(|event| event["access"] == "read"));
+    if state.exists() {
+        fs::remove_dir_all(state).unwrap();
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a versioned, payload-free event delivery health summary
- expose `dutis events health` for human and JSON output
- expose the same read-only summary through `dutis_event_health` over MCP
- report pending/dead-letter counts, attempts, timestamp ranges, and stable type/source buckets
- document Phase 17 and bump the release version to 2.21.0

## Safety
- health output excludes event IDs, payloads, retention reasons, and outbox paths
- all stored records pass existing schema, size, filename, and regular-file validation
- health inspection never replays, archives, purges, or mutates records
- MCP receives no new write capability

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline (138 passed)
- cargo build --release --bins --locked --offline
- cargo package --allow-dirty --locked --offline
- ruby -c scripts/render_homebrew_formula.rb
- git diff --check