### PR TITLE
feat: add configurable profile overlays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.21.0"
+version = "2.22.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.21.0"
+version = "2.22.0"
 edition = "2021"
 rust-version = "1.88"
 default-run = "dutis"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 - 🛡️ **Policy and Audit**: Enforce local allowlists and approvals with durable, verified mutation records
 - 💡 **Explainable Profiles**: Generate evidence-backed developer, designer, media, or minimal proposals without changing the system
 - 🏢 **Fleet-Aware Recommendations**: Apply local allowlists, protected targets, and ordered team preferences before proposing applications
+- 🧩 **Profile Overlays**: Extend built-in profiles or add typed team profiles from a strict local configuration
 - 👀 **Drift Monitoring**: Detect association changes continuously, notify through macOS, and optionally remediate through snapshots and policy
 - 🔗 **Typed Associations**: Manage extensions, UTIs, MIME types, URL schemes, and Launch Services roles through one verified pipeline
 - 📡 **Event Sinks**: Stream versioned drift and mutation lifecycle events to private JSONL logs or trusted local commands
@@ -189,6 +190,12 @@ dutis profile list
 dutis profile show developer --json
 dutis recommend developer --json
 ```
+
+Customize built-ins or add team profiles with
+`$DUTIS_STATE_DIR/profiles.toml` (or `DUTIS_PROFILE_FILE`). Start from
+[`dutis.profiles.example.toml`](dutis.profiles.example.toml); overlays support
+extensions, UTIs, MIME types, URL schemes, roles, ordered candidates, and
+explicit replacement of built-in candidates.
 
 Recommendations use the effective local policy before selecting a target.
 Teams can deploy preferences without a remote control plane:

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -365,10 +365,30 @@ Acceptance criteria:
 - Health inspection never replays, archives, purges, or otherwise changes an
   event record.
 
+## Phase 18: Configurable profile overlays
+
+Status: implemented for v2.22.0
+
+Let teams extend built-in recommendations or add reusable local profiles
+without recompiling Dutis or weakening the policy boundary.
+
+Acceptance criteria:
+
+- A strict version-one local overlay schema supports extending and replacing
+  built-in profiles plus defining named custom profiles.
+- Overlay associations use the same normalized extension, UTI, MIME,
+  URL-scheme, and role model as declarative configuration.
+- Overlay candidate order is deterministic, duplicate applications and targets
+  fail closed, and typed candidates still require matching bundle metadata.
+- CLI and MCP load the same effective profile catalog; MCP callers cannot
+  inject overlays through tool arguments.
+- Missing explicitly configured files, unsupported versions, oversized files,
+  symlinks, and malformed entries fail before recommendation.
+
 ## Near-term engineering sequence
 
-1. Release Phase 17 and validate health summaries in operator dashboards.
-2. Add configurable profile overlays only after typed preference usage shows
-   which reusable association groups are stable across fleets.
-3. Evaluate bounded concurrency controls for replay after observing real sink
+1. Release Phase 18 and validate overlay composition across team presets.
+2. Evaluate bounded concurrency controls for replay after observing real sink
    latency and failure patterns.
+3. Add signed profile distribution only if local deployment workflows prove
+   insufficient; do not introduce an implicit remote control plane.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -66,7 +66,9 @@ Profile recommendations are also read-only. A recommendation is evidence, not
 approval: it does not register a mutation tool call or change an association.
 Candidate ordering uses the server's effective local policy, including
 recommendation preferences, allowlists, and protected associations. Callers
-cannot supply or replace fleet policy through the tool request.
+cannot supply or replace fleet policy through the tool request. Profile list,
+inspection, and recommendation tools also load the server's local
+`profiles.toml` overlay; callers cannot inject overlay content or paths.
 To use one, review its `proposed_toml`, rebuild it with `dutis_diff`, run
 `dutis_policy_check`, and follow the normal write approval flow.
 

--- a/docs/profiles-and-recommendations.md
+++ b/docs/profiles-and-recommendations.md
@@ -16,6 +16,54 @@ dutis profile show developer
 dutis profile show developer --json
 ```
 
+## Local profile overlays
+
+Dutis loads an optional version-one overlay from
+`$DUTIS_STATE_DIR/profiles.toml`, or from the path in `DUTIS_PROFILE_FILE`.
+Without either environment variable it checks
+`~/Library/Application Support/dutis/profiles.toml`.
+Use [`dutis.profiles.example.toml`](../dutis.profiles.example.toml) as a
+starting point:
+
+```toml
+version = 1
+
+[[profiles]]
+name = "developer"
+description = "Team development defaults."
+
+[[profiles.associations]]
+kind = "extension"
+identifier = "md"
+applications = ["com.example.TeamEditor", "dev.zed.Zed"]
+
+[[profiles.associations]]
+kind = "uti"
+identifier = "public.source-code"
+role = "editor"
+applications = ["com.example.TeamEditor"]
+
+[[profiles]]
+name = "support-team"
+description = "Support documents and web links."
+
+[[profiles.associations]]
+kind = "url_scheme"
+identifier = "https"
+applications = ["com.apple.Safari"]
+```
+
+An overlay with a built-in name extends that profile. Its applications are
+placed before built-in candidates, with duplicate bundle IDs removed. Set
+`replace_candidates = true` on an association to replace that target's
+candidates, or `replace = true` on a profile to replace all its associations.
+A new profile requires a description and at least one association.
+
+Names, identifiers, roles, candidate lists, duplicate targets, file type, and
+the 1 MiB file-size limit are validated before any profile is returned. An
+explicitly configured missing file is an error. MCP clients use the server's
+local overlay and cannot submit an overlay in a tool call.
+
 ## Generate a proposal
 
 ```bash
@@ -25,8 +73,9 @@ dutis recommend developer --json
 
 Recommendation scans installed applications and reads current handlers. It
 does not change Launch Services. It loads the effective local policy before
-ranking candidates. Built-in profiles contribute extension targets; local
-policy can additionally contribute typed UTI, MIME, and URL-scheme targets.
+ranking candidates. Built-in and overlaid profiles contribute association
+targets; local policy can additionally contribute typed UTI, MIME, and
+URL-scheme targets.
 For each target, Dutis:
 
 1. Honors a protected association as the required target.

--- a/dutis.profiles.example.toml
+++ b/dutis.profiles.example.toml
@@ -1,0 +1,33 @@
+version = 1
+
+# Extend an existing built-in profile. Overlay applications are considered
+# before built-in candidates; duplicate bundle IDs are removed.
+[[profiles]]
+name = "developer"
+description = "Team development defaults."
+
+[[profiles.associations]]
+kind = "extension"
+identifier = "md"
+applications = ["com.example.TeamEditor", "dev.zed.Zed"]
+
+[[profiles.associations]]
+kind = "uti"
+identifier = "public.source-code"
+role = "editor"
+applications = ["com.example.TeamEditor"]
+
+# Add a custom profile. New profiles require a non-empty description.
+[[profiles]]
+name = "support-team"
+description = "Support documents and web links."
+
+[[profiles.associations]]
+kind = "extension"
+identifier = "txt"
+applications = ["com.apple.TextEdit"]
+
+[[profiles.associations]]
+kind = "url_scheme"
+identifier = "https"
+applications = ["com.apple.Safari"]

--- a/skills/dutis/SKILL.md
+++ b/skills/dutis/SKILL.md
@@ -29,6 +29,9 @@ Use Dutis for macOS Launch Services associations. Preserve its
    inspect `dutis_profiles` / `dutis_profile`, then use `dutis_recommend` (or
    the equivalent CLI commands). Present candidate evidence and treat the
    recommendation strictly as a proposal, never as approval.
+   Treat profiles returned by Dutis as the effective catalog: local
+   `profiles.toml` overlays may extend built-ins or add custom typed profiles.
+   Never accept caller-supplied overlay contents through MCP.
    Treat candidate `policy_eligible`, `policy_reasons`, and `source` fields as
    required evidence; do not substitute caller-provided preferences for the
    effective local policy. For UTI, MIME, and URL-scheme recommendations,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,8 @@ use dutis::planner::{
     PlannedApplication,
 };
 use dutis::profiles::{
-    find_profile, profiles, recommend_profile_with_policy_typed, ProfileRecommendation,
+    effective_profiles, find_effective_profile, recommend_effective_profile_with_policy,
+    ProfileRecommendation,
 };
 use dutis::snapshot::{
     build_rollback_plan, capture_targets, SnapshotReason, SnapshotStore, SnapshotSummary,
@@ -1069,7 +1070,8 @@ fn run_profile(args: ProfileArgs) -> Result<(), CliError> {
 }
 
 fn run_profile_list(args: OutputArgs) -> Result<(), CliError> {
-    let available = profiles();
+    let available = effective_profiles()
+        .map_err(|error| CliError::usage(format!("failed to load profiles: {error:#}")))?;
     if args.json {
         write_json(&JsonEnvelope {
             api_version: API_VERSION,
@@ -1085,7 +1087,8 @@ fn run_profile_list(args: OutputArgs) -> Result<(), CliError> {
 }
 
 fn run_profile_show(args: ProfileShowArgs) -> Result<(), CliError> {
-    let profile = find_profile(&args.name)
+    let profile = find_effective_profile(&args.name)
+        .map_err(|error| CliError::usage(format!("failed to load profiles: {error:#}")))?
         .ok_or_else(|| CliError::not_found(format!("unknown profile '{}'", args.name)))?;
     if args.json {
         write_json(&JsonEnvelope {
@@ -1111,14 +1114,15 @@ fn run_profile_show(args: ProfileShowArgs) -> Result<(), CliError> {
 }
 
 fn run_recommend(args: RecommendArgs) -> Result<(), CliError> {
-    let profile = find_profile(&args.profile)
+    let profile = find_effective_profile(&args.profile)
+        .map_err(|error| CliError::usage(format!("failed to load profiles: {error:#}")))?
         .ok_or_else(|| CliError::not_found(format!("unknown profile '{}'", args.profile)))?;
     let catalog = scan_catalog()?;
     report_metadata_failures(catalog.metadata_failures);
     system::duti_version().map_err(|error| CliError::dependency(format!("{error:#}")))?;
     let policy = LoadedPolicy::from_environment()
         .map_err(|error| CliError::usage(format!("failed to load policy: {error:#}")))?;
-    let recommendation = recommend_profile_with_policy_typed(
+    let recommendation = recommend_effective_profile_with_policy(
         &profile,
         &catalog.applications,
         system::query_default_handler,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -11,7 +11,9 @@ use crate::governance::{
 };
 use crate::launch_services;
 use crate::planner::{build_plan, AssociationPlan};
-use crate::profiles::{find_profile, profiles, recommend_profile_with_policy_typed};
+use crate::profiles::{
+    effective_profiles, find_effective_profile, recommend_effective_profile_with_policy,
+};
 use crate::snapshot::{build_rollback_plan, SnapshotReason, SnapshotStore};
 use crate::system;
 use anyhow::{anyhow, Context, Result};
@@ -83,6 +85,7 @@ pub struct McpAuditEvent {
 trait McpBackend {
     fn list(&mut self) -> Result<Value>;
     fn profiles(&mut self) -> Result<Value>;
+    fn profile_exists(&mut self, name: &str) -> Result<bool>;
     fn profile(&mut self, name: &str) -> Result<Value>;
     fn recommend(&mut self, name: &str) -> Result<Value>;
     fn event_health(&mut self) -> Result<Value>;
@@ -118,20 +121,26 @@ impl McpBackend for SystemBackend {
     }
 
     fn profiles(&mut self) -> Result<Value> {
-        serde_json::to_value(profiles()).context("failed to serialize built-in profiles")
+        serde_json::to_value(effective_profiles()?).context("failed to serialize profiles")
+    }
+
+    fn profile_exists(&mut self, name: &str) -> Result<bool> {
+        Ok(find_effective_profile(name)?.is_some())
     }
 
     fn profile(&mut self, name: &str) -> Result<Value> {
-        let profile = find_profile(name).ok_or_else(|| anyhow!("unknown profile '{name}'"))?;
+        let profile =
+            find_effective_profile(name)?.ok_or_else(|| anyhow!("unknown profile '{name}'"))?;
         serde_json::to_value(profile).context("failed to serialize profile")
     }
 
     fn recommend(&mut self, name: &str) -> Result<Value> {
-        let profile = find_profile(name).ok_or_else(|| anyhow!("unknown profile '{name}'"))?;
+        let profile =
+            find_effective_profile(name)?.ok_or_else(|| anyhow!("unknown profile '{name}'"))?;
         let catalog = ApplicationCatalog::scan()?;
         system::duti_version()?;
         let policy = LoadedPolicy::from_environment()?;
-        let recommendation = recommend_profile_with_policy_typed(
+        let recommendation = recommend_effective_profile_with_policy(
             &profile,
             &catalog.applications,
             system::query_default_handler,
@@ -375,7 +384,11 @@ impl<B: McpBackend> McpServer<B> {
             "dutis_profiles" => self.backend.profiles().map_err(operation_error),
             "dutis_profile" => {
                 let profile = argument_string(arguments, "profile")?;
-                if find_profile(profile).is_none() {
+                if !self
+                    .backend
+                    .profile_exists(profile)
+                    .map_err(operation_error)?
+                {
                     return Err(ToolError::new(
                         "not_found",
                         format!("unknown profile '{profile}'"),
@@ -385,7 +398,11 @@ impl<B: McpBackend> McpServer<B> {
             }
             "dutis_recommend" => {
                 let profile = argument_string(arguments, "profile")?;
-                if find_profile(profile).is_none() {
+                if !self
+                    .backend
+                    .profile_exists(profile)
+                    .map_err(operation_error)?
+                {
                     return Err(ToolError::new(
                         "not_found",
                         format!("unknown profile '{profile}'"),
@@ -1009,6 +1026,7 @@ where
 mod tests {
     use super::*;
     use crate::planner::PlanSummary;
+    use crate::profiles::{find_profile, profiles};
 
     struct FakeBackend {
         plan: AssociationPlan,
@@ -1044,11 +1062,19 @@ mod tests {
             serde_json::to_value(profiles()).map_err(Into::into)
         }
 
+        fn profile_exists(&mut self, name: &str) -> Result<bool> {
+            Ok(find_profile(name).is_some())
+        }
+
         fn profile(&mut self, name: &str) -> Result<Value> {
-            serde_json::to_value(find_profile(name)).map_err(Into::into)
+            serde_json::to_value(
+                find_profile(name).ok_or_else(|| anyhow!("unknown profile '{name}'"))?,
+            )
+            .map_err(Into::into)
         }
 
         fn recommend(&mut self, name: &str) -> Result<Value> {
+            find_profile(name).ok_or_else(|| anyhow!("unknown profile '{name}'"))?;
             Ok(json!({"profile": name, "proposal_only": true}))
         }
 

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -5,10 +5,14 @@ use crate::config::{AssociationRule, DutisConfig, CONFIG_VERSION};
 use crate::governance::Policy;
 use crate::planner::{assemble_plan, AssociationPlan, PlanAction, PlanEntry, PlannedApplication};
 use crate::system::DefaultApplication;
-use anyhow::Result;
-use serde::Serialize;
-use std::collections::BTreeMap;
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+
+pub const PROFILE_OVERLAY_VERSION: u32 = 1;
+pub const PROFILE_FILE_ENV: &str = "DUTIS_PROFILE_FILE";
+const MAX_PROFILE_FILE_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct ProfileDefinition {
@@ -27,6 +31,58 @@ pub struct ProfileAssociation {
 pub struct ProfileCandidate {
     pub bundle_id: &'static str,
     pub rationale: &'static str,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct EffectiveProfileDefinition {
+    pub name: String,
+    pub description: String,
+    pub associations: Vec<EffectiveProfileAssociation>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct EffectiveProfileAssociation {
+    pub association: AssociationTarget,
+    pub extension: String,
+    pub candidates: Vec<EffectiveProfileCandidate>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct EffectiveProfileCandidate {
+    pub bundle_id: String,
+    pub rationale: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProfileOverlayDocument {
+    version: u32,
+    #[serde(default)]
+    profiles: Vec<ProfileOverlay>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProfileOverlay {
+    name: String,
+    description: Option<String>,
+    #[serde(default)]
+    replace: bool,
+    #[serde(default)]
+    associations: Vec<ProfileAssociationOverlay>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProfileAssociationOverlay {
+    #[serde(default)]
+    kind: AssociationKind,
+    identifier: String,
+    #[serde(default)]
+    role: HandlerRole,
+    #[serde(default)]
+    replace_candidates: bool,
+    applications: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
@@ -121,6 +177,233 @@ pub fn find_profile(name: &str) -> Option<ProfileDefinition> {
         .find(|profile| profile.name.eq_ignore_ascii_case(name.trim()))
 }
 
+pub fn effective_profiles() -> Result<Vec<EffectiveProfileDefinition>> {
+    let mut effective = profiles()
+        .into_iter()
+        .map(EffectiveProfileDefinition::from)
+        .collect::<Vec<_>>();
+    let Some(path) = profile_overlay_path()? else {
+        return Ok(effective);
+    };
+    let metadata = std::fs::symlink_metadata(&path)
+        .with_context(|| format!("failed to inspect profile overlay {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!("profile overlay is not a regular file: {}", path.display());
+    }
+    if metadata.len() > MAX_PROFILE_FILE_BYTES {
+        bail!("profile overlay {} exceeds the 1 MiB limit", path.display());
+    }
+    let contents = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read profile overlay {}", path.display()))?;
+    apply_profile_overlay_document(&mut effective, &contents)
+        .with_context(|| format!("invalid profile overlay {}", path.display()))?;
+    Ok(effective)
+}
+
+fn apply_profile_overlay_document(
+    effective: &mut Vec<EffectiveProfileDefinition>,
+    contents: &str,
+) -> Result<()> {
+    let document: ProfileOverlayDocument =
+        toml::from_str(contents).context("failed to parse profile overlay TOML")?;
+    if document.version != PROFILE_OVERLAY_VERSION {
+        bail!(
+            "unsupported profile overlay version {}; expected {}",
+            document.version,
+            PROFILE_OVERLAY_VERSION
+        );
+    }
+    apply_profile_overlays(effective, document.profiles)?;
+    Ok(())
+}
+
+pub fn find_effective_profile(name: &str) -> Result<Option<EffectiveProfileDefinition>> {
+    let name = normalize_profile_name(name)?;
+    Ok(effective_profiles()?
+        .into_iter()
+        .find(|profile| profile.name == name))
+}
+
+impl From<ProfileDefinition> for EffectiveProfileDefinition {
+    fn from(profile: ProfileDefinition) -> Self {
+        Self {
+            name: profile.name.to_owned(),
+            description: profile.description.to_owned(),
+            associations: profile
+                .associations
+                .into_iter()
+                .map(|association| {
+                    let target = AssociationTarget::extension(association.extension)
+                        .expect("built-in profile extension is valid");
+                    EffectiveProfileAssociation {
+                        extension: target.identifier.clone(),
+                        association: target,
+                        candidates: association
+                            .candidates
+                            .into_iter()
+                            .map(|candidate| EffectiveProfileCandidate {
+                                bundle_id: candidate.bundle_id.to_owned(),
+                                rationale: candidate.rationale.to_owned(),
+                            })
+                            .collect(),
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+fn profile_overlay_path() -> Result<Option<PathBuf>> {
+    if let Some(path) = std::env::var_os(PROFILE_FILE_ENV).filter(|value| !value.is_empty()) {
+        let path = PathBuf::from(path);
+        if !path.exists() {
+            bail!("profile overlay does not exist: {}", path.display());
+        }
+        return Ok(Some(path));
+    }
+    let path = if let Some(state) =
+        std::env::var_os("DUTIS_STATE_DIR").filter(|value| !value.is_empty())
+    {
+        PathBuf::from(state).join("profiles.toml")
+    } else if let Some(home) = std::env::var_os("HOME") {
+        PathBuf::from(home).join("Library/Application Support/dutis/profiles.toml")
+    } else {
+        return Ok(None);
+    };
+    Ok(path.exists().then_some(path))
+}
+
+fn apply_profile_overlays(
+    profiles: &mut Vec<EffectiveProfileDefinition>,
+    overlays: Vec<ProfileOverlay>,
+) -> Result<()> {
+    let mut seen_profiles = BTreeSet::new();
+    for overlay in overlays {
+        let name = normalize_profile_name(&overlay.name)?;
+        if !seen_profiles.insert(name.clone()) {
+            bail!("duplicate profile overlay '{name}'");
+        }
+        let existing = profiles.iter().position(|profile| profile.name == name);
+        let description = overlay
+            .description
+            .map(|value| normalize_nonempty(&value, "profile description"))
+            .transpose()?;
+        let index = if let Some(index) = existing {
+            if let Some(description) = description {
+                profiles[index].description = description;
+            }
+            if overlay.replace {
+                profiles[index].associations.clear();
+            }
+            index
+        } else {
+            let description = description
+                .ok_or_else(|| anyhow::anyhow!("custom profile '{name}' requires a description"))?;
+            profiles.push(EffectiveProfileDefinition {
+                name: name.clone(),
+                description,
+                associations: Vec::new(),
+            });
+            profiles.len() - 1
+        };
+
+        let mut seen_targets = BTreeSet::new();
+        for association in overlay.associations {
+            let target = AssociationTarget::new(
+                association.kind,
+                &association.identifier,
+                association.role,
+            )?;
+            if !seen_targets.insert(target.clone()) {
+                bail!("duplicate profile target {target} in '{name}'");
+            }
+            let candidates = normalize_overlay_candidates(association.applications, &target)?;
+            let profile = &mut profiles[index];
+            if let Some(existing) = profile
+                .associations
+                .iter_mut()
+                .find(|item| item.association == target)
+            {
+                if association.replace_candidates {
+                    existing.candidates = candidates;
+                } else {
+                    let mut merged = candidates;
+                    let mut seen = merged
+                        .iter()
+                        .map(|candidate| candidate.bundle_id.clone())
+                        .collect::<BTreeSet<_>>();
+                    merged.extend(
+                        existing
+                            .candidates
+                            .iter()
+                            .filter(|candidate| seen.insert(candidate.bundle_id.clone()))
+                            .cloned(),
+                    );
+                    existing.candidates = merged;
+                }
+            } else {
+                profile.associations.push(EffectiveProfileAssociation {
+                    extension: target.identifier.clone(),
+                    association: target,
+                    candidates,
+                });
+            }
+        }
+        if profiles[index].associations.is_empty() {
+            bail!("profile '{name}' must contain at least one association");
+        }
+    }
+    Ok(())
+}
+
+fn normalize_profile_name(value: &str) -> Result<String> {
+    let name = value.trim().to_ascii_lowercase();
+    if name.is_empty()
+        || name.len() > 64
+        || !name
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_alphanumeric())
+        || !name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        bail!("invalid profile name '{value}'");
+    }
+    Ok(name)
+}
+
+fn normalize_nonempty(value: &str, label: &str) -> Result<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        bail!("{label} cannot be empty");
+    }
+    Ok(value.to_owned())
+}
+
+fn normalize_overlay_candidates(
+    applications: Vec<String>,
+    target: &AssociationTarget,
+) -> Result<Vec<EffectiveProfileCandidate>> {
+    if applications.is_empty() {
+        bail!("profile target {target} requires at least one application");
+    }
+    let mut seen = BTreeSet::new();
+    applications
+        .into_iter()
+        .map(|application| {
+            let bundle_id = normalize_nonempty(&application, "profile application")?;
+            if !seen.insert(bundle_id.clone()) {
+                bail!("duplicate profile application '{bundle_id}' for {target}");
+            }
+            Ok(EffectiveProfileCandidate {
+                rationale: "Configured by the local profile overlay.".to_owned(),
+                bundle_id,
+            })
+        })
+        .collect()
+}
+
 pub fn recommend_profile<F>(
     profile: &ProfileDefinition,
     applications: &[Application],
@@ -129,8 +412,9 @@ pub fn recommend_profile<F>(
 where
     F: FnMut(&str) -> Result<Option<DefaultApplication>>,
 {
+    let profile = EffectiveProfileDefinition::from(profile.clone());
     recommend_profile_internal(
-        profile,
+        &profile,
         applications,
         &mut |target| query_default(&target.identifier),
         None,
@@ -147,8 +431,9 @@ pub fn recommend_profile_with_policy<F>(
 where
     F: FnMut(&str) -> Result<Option<DefaultApplication>>,
 {
+    let profile = EffectiveProfileDefinition::from(profile.clone());
     recommend_profile_internal(
-        profile,
+        &profile,
         applications,
         &mut |target| query_default(&target.identifier),
         Some(policy),
@@ -158,6 +443,25 @@ where
 
 pub fn recommend_profile_with_policy_typed<F>(
     profile: &ProfileDefinition,
+    applications: &[Application],
+    mut query_default: F,
+    policy: &Policy,
+) -> Result<ProfileRecommendation>
+where
+    F: FnMut(&AssociationTarget) -> Result<Option<DefaultApplication>>,
+{
+    let profile = EffectiveProfileDefinition::from(profile.clone());
+    recommend_profile_internal(
+        &profile,
+        applications,
+        &mut query_default,
+        Some(policy),
+        true,
+    )
+}
+
+pub fn recommend_effective_profile_with_policy<F>(
+    profile: &EffectiveProfileDefinition,
     applications: &[Application],
     mut query_default: F,
     policy: &Policy,
@@ -175,7 +479,7 @@ where
 }
 
 fn recommend_profile_internal<F>(
-    profile: &ProfileDefinition,
+    profile: &EffectiveProfileDefinition,
     applications: &[Application],
     query_default: &mut F,
     policy: Option<&Policy>,
@@ -190,21 +494,19 @@ where
     let mut inputs = profile
         .associations
         .iter()
-        .map(|association| {
-            Ok(RecommendationInput {
-                target: AssociationTarget::extension(association.extension)?,
-                profile_candidates: association
-                    .candidates
-                    .iter()
-                    .map(|candidate| OwnedProfileCandidate {
-                        bundle_id: candidate.bundle_id.to_owned(),
-                        rationale: candidate.rationale.to_owned(),
-                    })
-                    .collect(),
-                requires_declaration: false,
-            })
+        .map(|association| RecommendationInput {
+            target: association.association.clone(),
+            profile_candidates: association
+                .candidates
+                .iter()
+                .map(|candidate| OwnedProfileCandidate {
+                    bundle_id: candidate.bundle_id.clone(),
+                    rationale: candidate.rationale.clone(),
+                })
+                .collect(),
+            requires_declaration: association.association.kind != AssociationKind::Extension,
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<Vec<_>>();
     if include_typed_preferences {
         if let Some(policy) = policy {
             for preference in &policy.recommendations.handlers {
@@ -213,6 +515,9 @@ where
                     &preference.identifier,
                     preference.role,
                 )?;
+                if inputs.iter().any(|input| input.target == target) {
+                    continue;
+                }
                 inputs.push(RecommendationInput {
                     target,
                     profile_candidates: Vec::new(),
@@ -853,6 +1158,191 @@ mod tests {
         );
         assert!(find_profile("DEVELOPER").is_some());
         assert!(find_profile("unknown").is_none());
+    }
+
+    #[test]
+    fn profile_overlays_extend_builtins_and_add_typed_custom_profiles() {
+        let mut effective = profiles()
+            .into_iter()
+            .map(EffectiveProfileDefinition::from)
+            .collect::<Vec<_>>();
+        apply_profile_overlay_document(
+            &mut effective,
+            r#"
+                version = 1
+
+                [[profiles]]
+                name = "Developer"
+                description = "Team development defaults."
+
+                [[profiles.associations]]
+                kind = "extension"
+                identifier = ".MD"
+                applications = ["com.example.TeamEditor", "dev.zed.Zed"]
+
+                [[profiles.associations]]
+                kind = "uti"
+                identifier = "Public.Source-Code"
+                role = "editor"
+                applications = ["com.example.TeamEditor"]
+
+                [[profiles]]
+                name = "support-team"
+                description = "Support links and text."
+
+                [[profiles.associations]]
+                kind = "url_scheme"
+                identifier = "HTTPS://"
+                applications = ["com.example.Browser"]
+            "#,
+        )
+        .unwrap();
+
+        let developer = effective
+            .iter()
+            .find(|profile| profile.name == "developer")
+            .unwrap();
+        assert_eq!(developer.description, "Team development defaults.");
+        let markdown = developer
+            .associations
+            .iter()
+            .find(|item| item.association.identifier == "md")
+            .unwrap();
+        assert_eq!(markdown.candidates[0].bundle_id, "com.example.TeamEditor");
+        assert_eq!(markdown.candidates[1].bundle_id, "dev.zed.Zed");
+        assert_eq!(
+            markdown
+                .candidates
+                .iter()
+                .filter(|candidate| candidate.bundle_id == "dev.zed.Zed")
+                .count(),
+            1
+        );
+        assert!(developer.associations.iter().any(|item| {
+            item.association.kind == AssociationKind::Uti
+                && item.association.identifier == "public.source-code"
+                && item.association.role == HandlerRole::Editor
+        }));
+
+        let custom = effective
+            .iter()
+            .find(|profile| profile.name == "support-team")
+            .unwrap();
+        assert_eq!(custom.associations.len(), 1);
+        assert_eq!(
+            custom.associations[0].association.kind,
+            AssociationKind::UrlScheme
+        );
+        assert_eq!(custom.associations[0].association.identifier, "https");
+    }
+
+    #[test]
+    fn repository_profile_overlay_example_uses_the_current_schema() {
+        let mut effective = profiles()
+            .into_iter()
+            .map(EffectiveProfileDefinition::from)
+            .collect::<Vec<_>>();
+        apply_profile_overlay_document(
+            &mut effective,
+            include_str!("../dutis.profiles.example.toml"),
+        )
+        .unwrap();
+        assert!(effective
+            .iter()
+            .any(|profile| profile.name == "support-team"));
+    }
+
+    #[test]
+    fn profile_overlay_can_replace_builtin_candidates_and_rejects_invalid_input() {
+        let mut effective = profiles()
+            .into_iter()
+            .map(EffectiveProfileDefinition::from)
+            .collect::<Vec<_>>();
+        apply_profile_overlay_document(
+            &mut effective,
+            r#"
+                version = 1
+                [[profiles]]
+                name = "minimal"
+                replace = true
+                [[profiles.associations]]
+                identifier = "txt"
+                replace_candidates = true
+                applications = ["com.example.Editor"]
+            "#,
+        )
+        .unwrap();
+        let minimal = effective
+            .iter()
+            .find(|profile| profile.name == "minimal")
+            .unwrap();
+        assert_eq!(minimal.associations.len(), 1);
+        assert_eq!(minimal.associations[0].candidates.len(), 1);
+        assert_eq!(
+            minimal.associations[0].candidates[0].bundle_id,
+            "com.example.Editor"
+        );
+
+        let invalid_documents = [
+            "version = 2",
+            "version = 1\n[[profiles]]\nname = 'new'",
+            "version = 1\n[[profiles]]\nname = '--'\ndescription = 'invalid'\n[[profiles.associations]]\nidentifier = 'txt'\napplications = ['x']",
+            "version = 1\n[[profiles]]\nname = 'developer'\n[[profiles.associations]]\nidentifier = 'md'\napplications = ['x', 'x']",
+            "version = 1\n[[profiles]]\nname = 'developer'\n[[profiles.associations]]\nkind = 'url_scheme'\nidentifier = 'https'\nrole = 'viewer'\napplications = ['x']",
+        ];
+        for document in invalid_documents {
+            let mut effective = profiles()
+                .into_iter()
+                .map(EffectiveProfileDefinition::from)
+                .collect::<Vec<_>>();
+            assert!(apply_profile_overlay_document(&mut effective, document).is_err());
+        }
+    }
+
+    #[test]
+    fn typed_overlay_profile_uses_the_governed_recommendation_pipeline() {
+        let mut effective = profiles()
+            .into_iter()
+            .map(EffectiveProfileDefinition::from)
+            .collect::<Vec<_>>();
+        apply_profile_overlay_document(
+            &mut effective,
+            r#"
+                version = 1
+                [[profiles]]
+                name = "writers"
+                description = "Local writing tools."
+                [[profiles.associations]]
+                kind = "mime"
+                identifier = "Text/Plain"
+                role = "editor"
+                applications = ["com.example.Writer"]
+            "#,
+        )
+        .unwrap();
+        let profile = effective
+            .iter()
+            .find(|profile| profile.name == "writers")
+            .unwrap();
+        let mut writer = app("Writer", "com.example.Writer", &[]);
+        writer.handlers.push(crate::plist_parser::DeclaredHandler {
+            kind: AssociationKind::Mime,
+            identifier: "text/plain".to_owned(),
+            role: HandlerRole::Editor,
+            source: crate::plist_parser::HandlerDeclarationSource::DocumentType,
+        });
+
+        let recommendation = recommend_effective_profile_with_policy(
+            profile,
+            &[writer],
+            |_| Ok(None),
+            &Policy::default(),
+        )
+        .unwrap();
+        assert_eq!(recommendation.summary.changes, 1);
+        assert_eq!(recommendation.plan.entries[0].kind, AssociationKind::Mime);
+        assert_eq!(recommendation.plan.entries[0].extension, "text/plain");
+        assert!(recommendation.recommendations[0].evidence[0].declares_target);
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -409,9 +409,33 @@ fn event_archive_and_purge_require_explicit_confirmation() {
 }
 
 #[test]
-fn profile_list_and_show_are_available_without_duti() {
+fn profile_overlays_are_available_without_duti() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let state = std::env::temp_dir().join(format!(
+        "dutis-profile-overlay-{}-{unique}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&state).unwrap();
+    fs::write(
+        state.join("profiles.toml"),
+        r#"
+            version = 1
+            [[profiles]]
+            name = "team"
+            description = "Team browser defaults."
+            [[profiles.associations]]
+            kind = "url_scheme"
+            identifier = "HTTPS://"
+            applications = ["com.example.Browser"]
+        "#,
+    )
+    .unwrap();
     let list = dutis()
         .env("PATH", "")
+        .env("DUTIS_STATE_DIR", &state)
         .args(["profile", "list", "--json"])
         .output()
         .unwrap();
@@ -423,17 +447,26 @@ fn profile_list_and_show_are_available_without_duti() {
         .iter()
         .map(|profile| profile["name"].as_str().unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(names, ["developer", "designer", "media", "minimal"]);
+    assert_eq!(names, ["developer", "designer", "media", "minimal", "team"]);
 
     let show = dutis()
         .env("PATH", "")
-        .args(["profile", "show", "developer", "--json"])
+        .env("DUTIS_STATE_DIR", &state)
+        .args(["profile", "show", "team", "--json"])
         .output()
         .unwrap();
     assert!(show.status.success());
     let response: Value = serde_json::from_slice(&show.stdout).unwrap();
-    assert_eq!(response["data"]["name"], "developer");
-    assert!(response["data"]["associations"].as_array().unwrap().len() >= 5);
+    assert_eq!(response["data"]["name"], "team");
+    assert_eq!(
+        response["data"]["associations"][0]["association"]["kind"],
+        "url_scheme"
+    );
+    assert_eq!(
+        response["data"]["associations"][0]["association"]["identifier"],
+        "https"
+    );
+    fs::remove_dir_all(state).unwrap();
 }
 
 #[test]
@@ -446,6 +479,41 @@ fn unknown_profile_has_stable_json_error() {
     let response: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(response["command"], "profile");
     assert_eq!(response["error"]["kind"], "not_found");
+}
+
+#[cfg(unix)]
+#[test]
+fn invalid_profile_overlay_fails_closed_with_a_structured_error() {
+    use std::os::unix::fs::symlink;
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "dutis-profile-overlay-invalid-{}-{unique}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    let target = root.join("target.toml");
+    let overlay = root.join("profiles.toml");
+    fs::write(&target, "version = 1\n").unwrap();
+    symlink(&target, &overlay).unwrap();
+
+    let output = dutis()
+        .env("DUTIS_PROFILE_FILE", &overlay)
+        .args(["profile", "list", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(response["command"], "profile");
+    assert_eq!(response["error"]["kind"], "usage");
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("not a regular file"));
+    fs::remove_dir_all(root).unwrap();
 }
 
 #[cfg(unix)]
@@ -883,6 +951,12 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         "dutis-mcp-integration-{}-{unique}",
         std::process::id()
     ));
+    fs::create_dir_all(&state).unwrap();
+    fs::write(
+        state.join("profiles.toml"),
+        "version = 1\n[[profiles]]\nname = 'team'\ndescription = 'Team defaults.'\n[[profiles.associations]]\nidentifier = 'md'\napplications = ['com.example.Editor']\n",
+    )
+    .unwrap();
     let mut child = dutis()
         .arg("mcp")
         .env("DUTIS_STATE_DIR", &state)
@@ -897,7 +971,7 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
         "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}\n",
         "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_history\",\"arguments\":{}}}\n",
         "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_policy\",\"arguments\":{}}}\n",
-        "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_profile\",\"arguments\":{\"profile\":\"minimal\"}}}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_profile\",\"arguments\":{\"profile\":\"team\"}}}\n",
         "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"dutis_event_health\",\"arguments\":{}}}\n"
     );
     child
@@ -938,7 +1012,7 @@ fn mcp_stdio_initializes_and_advertises_read_only_tools() {
     );
     assert_eq!(
         responses[4]["result"]["structuredContent"]["data"]["name"],
-        "minimal"
+        "team"
     );
     assert_eq!(
         responses[5]["result"]["structuredContent"]["data"]["status"],


### PR DESCRIPTION
## Summary
- add a strict version-one local `profiles.toml` overlay schema
- support extending or replacing built-in profiles and defining custom profiles
- support extension, UTI, MIME, and URL-scheme associations with ordered candidates
- load the same effective profile catalog in CLI and MCP workflows
- add a documented example and bump the release version to 2.22.0

## Safety
- overlays only shape read-only recommendations and never authorize mutations
- typed candidates still require an exact compatible bundle declaration
- policy, plan digest, approval, snapshot, audit, and verification remain unchanged
- malformed, duplicate, oversized, missing explicit, and symlinked overlay files fail closed
- MCP callers cannot inject overlay contents or paths

## Verification
- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline (143 passed)
- cargo build --release --bins --locked --offline
- cargo package --allow-dirty --locked --offline
- ruby -c scripts/render_homebrew_formula.rb
- git diff --check