### PR TITLE
feat: add keyboard-first terminal UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -131,7 +131,20 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -160,6 +173,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "shell-words",
+ "thiserror",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,11 +196,12 @@ dependencies = [
 
 [[package]]
 name = "dutis"
-version = "2.23.0"
+version = "2.24.0"
 dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "dialoguer",
  "plist",
  "serde",
  "serde_json",
@@ -185,10 +211,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
 
 [[package]]
 name = "generic-array"
@@ -251,6 +292,12 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -368,6 +415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +446,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -479,6 +561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,12 +586,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dutis"
-version = "2.23.0"
+version = "2.24.0"
 edition = "2021"
 rust-version = "1.88"
 default-run = "dutis"
@@ -32,3 +32,4 @@ toml = "0.8"
 
 # Terminal output formatting
 colored = "3.1"
+dialoguer = { version = "0.11", default-features = false, features = ["fuzzy-select"] }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,6 +74,10 @@ The application will:
 4. Show the current and proposed handler before asking you to confirm a change
 5. Check for `duti` only when reading or changing a default
 
+In a terminal, use the arrow keys and Enter to select an action, Esc or `q` to
+go back, and type to filter long application lists. For a numbered text menu,
+run `DUTIS_TUI=plain dutis`. Piped input selects that mode automatically.
+
 ## Updating
 
 ### Via Homebrew

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Rust application for inspecting and safely managing macOS default handlers for
 
 - 🔍 **Scan System Applications**: Automatically discovers all installed applications on macOS
 - 📱 **Application Capability Discovery**: Reads declared extensions, UTIs, MIME types, URL schemes, and roles
-- 🎯 **Guided Interactive Mode**: Inspect defaults, browse applications, and review changes before confirming them
+- 🎯 **Keyboard-first TUI**: Navigate with arrow keys, search applications as you type, and review changes before confirming them
 - ⚙️ **Default App Setting**: Set default applications for file types using the `duti` command
 - 🧭 **Accurate App Selection**: Preserves full application paths, including nested and duplicate names
 - 🧩 **Modern Metadata Support**: Reads legacy document types and modern UTI declarations
@@ -98,6 +98,14 @@ Run `dutis` without a subcommand to open the guided terminal menu. It lets you:
 Every interactive mutation passes through the same policy, safety snapshot,
 audit, and post-change verification pipeline as the non-interactive CLI. Every
 submenu supports a clear path back to the main menu.
+
+When stdin, stdout, and stderr are attached to a capable terminal, Dutis uses a compact
+keyboard-first interface: arrow keys move the selection, Enter opens it, Esc or
+`q` returns, and application lists support type-to-filter fuzzy search. When
+input is piped or the terminal is non-interactive, Dutis automatically falls
+back to the numbered text interface so scripts and accessibility workflows
+remain predictable. Set `DUTIS_TUI=plain` to request the text interface
+explicitly.
 
 ### Command Line Mode
 
@@ -347,6 +355,7 @@ MCP, agent policies, profiles, drift detection, and event delivery is documented
 
 - **anyhow**: Error handling and propagation
 - **colored**: Terminal output formatting and colors
+- **dialoguer**: Keyboard navigation, searchable selectors, and confirmations
 - **plist**: Native XML and binary plist parsing
 - **clap**: Command parsing and generated help
 - **serde / serde_json**: Versioned machine-readable output

--- a/docs/agent-roadmap.md
+++ b/docs/agent-roadmap.md
@@ -406,9 +406,31 @@ Acceptance criteria:
   pipeline remains shared with non-interactive commands.
 - Input parsing and the guided entry point are covered by automated tests.
 
+## Phase 20: Keyboard-first terminal UI
+
+Status: implemented for v2.24.0
+
+Add a compact interaction model inspired by modern coding-agent terminals while
+preserving the stable CLI and non-TTY behavior.
+
+Acceptance criteria:
+
+- Real terminals provide arrow-key navigation, highlighted selections, Enter
+  activation, and Esc or `q` cancellation without entering an alternate screen.
+- Long application lists support live fuzzy filtering by application name and
+  bundle identifier.
+- Confirmation remains explicit and defaults to no before any governed
+  mutation.
+- Piped input, redirected output, and `TERM=dumb` automatically use the
+  numbered plain-text flow.
+- `DUTIS_TUI=plain` provides a documented manual fallback for accessibility,
+  recording, and terminal compatibility.
+- TUI capability selection is tested independently from the host terminal.
+
 ## Near-term engineering sequence
 
-1. Release Phase 19 and observe where users still fall back to command help.
+1. Release Phase 20 and observe keyboard navigation and search behavior across
+   common macOS terminals.
 2. Evaluate bounded concurrency controls for replay after observing real sink
    latency and failure patterns.
 3. Add signed profile distribution only if local deployment workflows prove

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use cli::{
     SnapshotCreateArgs, WatchArgs,
 };
 use colored::*;
+use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect, Input, Select};
 use dutis::application::{
     find_apps_for_extension, find_fuzzy_matches, find_handler_candidates, normalize_extension,
     resolve_app, Application, ApplicationCatalog, HandlerCandidate,
@@ -42,7 +43,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::Duration;
@@ -2030,7 +2031,12 @@ fn shell_display(arguments: &[String]) -> String {
 }
 
 fn run_interactive() -> Result<()> {
-    println!("Dutis — macOS Default Application Manager");
+    let enhanced_tui = interactive_tui_available();
+    if enhanced_tui {
+        print_tui_banner();
+    } else {
+        println!("Dutis — macOS Default Application Manager");
+    }
     println!("Scanning installed applications...\n");
 
     let catalog = ApplicationCatalog::scan()?;
@@ -2042,7 +2048,63 @@ fn run_interactive() -> Result<()> {
         );
     }
     println!("No system setting changes until you review and confirm them.");
-    interactive_main_menu(&catalog.applications)
+    if enhanced_tui {
+        interactive_tui_main_menu(&catalog.applications)
+    } else {
+        interactive_main_menu(&catalog.applications)
+    }
+}
+
+fn interactive_tui_available() -> bool {
+    terminal_supports_tui(
+        io::stdin().is_terminal(),
+        io::stdout().is_terminal(),
+        io::stderr().is_terminal(),
+        std::env::var("TERM").ok().as_deref(),
+        std::env::var("DUTIS_TUI").ok().as_deref(),
+    )
+}
+
+fn terminal_supports_tui(
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+    stderr_is_terminal: bool,
+    term: Option<&str>,
+    override_value: Option<&str>,
+) -> bool {
+    if override_value.is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "plain"
+        )
+    }) {
+        return false;
+    }
+    stdin_is_terminal
+        && stdout_is_terminal
+        && stderr_is_terminal
+        && !term.is_some_and(|value| value.eq_ignore_ascii_case("dumb"))
+}
+
+fn print_tui_banner() {
+    println!(
+        "{}",
+        "╭──────────────────────────────────────────────╮".bright_cyan()
+    );
+    println!(
+        "{}",
+        "│  DUTIS                                       │"
+            .bright_cyan()
+            .bold()
+    );
+    println!(
+        "{}",
+        "│  macOS default application manager           │".bright_cyan()
+    );
+    println!(
+        "{}",
+        "╰──────────────────────────────────────────────╯".bright_cyan()
+    );
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -2065,6 +2127,106 @@ fn parse_interactive_menu_choice(input: &str) -> Option<InteractiveMenuChoice> {
         "q" | "quit" | "exit" => Some(InteractiveMenuChoice::Quit),
         _ => None,
     }
+}
+
+fn interactive_tui_main_menu(applications: &[Application]) -> Result<()> {
+    let theme = ColorfulTheme::default();
+    let items = [
+        "Manage a file extension       inspect, compare, and change",
+        "Browse installed applications search names, paths, and bundle IDs",
+        "System information            scan coverage and mutation readiness",
+        "Advanced workflows            profiles, policies, drift, and MCP",
+        "Quit",
+    ];
+
+    loop {
+        println!("\n{}", "↑↓ navigate  •  Enter select  •  Esc back".dimmed());
+        let selection = Select::with_theme(&theme)
+            .with_prompt("What would you like to do?")
+            .items(&items)
+            .default(0)
+            .interact_opt()?;
+        match selection {
+            Some(0) => interactive_tui_extension(applications)?,
+            Some(1) => browse_applications_tui(applications)?,
+            Some(2) => display_system_info(applications),
+            Some(3) => display_advanced_workflows(),
+            Some(4) | None => {
+                println!("Goodbye!");
+                return Ok(());
+            }
+            Some(_) => unreachable!("menu selection is bounded by its items"),
+        }
+    }
+}
+
+fn interactive_tui_extension(applications: &[Application]) -> Result<()> {
+    let theme = ColorfulTheme::default();
+    loop {
+        println!("\n{}", "Type b to return to the main menu".dimmed());
+        let input: String = Input::with_theme(&theme)
+            .with_prompt("File extension")
+            .interact_text()?;
+        if matches!(input.trim().to_ascii_lowercase().as_str(), "b" | "back") {
+            return Ok(());
+        }
+        let extension = match normalize_extension(&input) {
+            Ok(extension) => extension,
+            Err(error) => {
+                println!("{} {error}", "Invalid extension:".red().bold());
+                continue;
+            }
+        };
+
+        println!("\n{} .{}", "Association".bold(), extension.yellow());
+        display_current_default(&extension);
+        let supporting_apps = find_apps_for_extension(applications, &extension);
+        if supporting_apps.is_empty() {
+            println!("No installed application explicitly declares this extension.");
+            let choices = ["Search all installed applications…", "Back"];
+            println!("{}", "↑↓ navigate  •  Enter select  •  Esc back".dimmed());
+            match Select::with_theme(&theme)
+                .with_prompt("Next step")
+                .items(&choices)
+                .default(0)
+                .interact_opt()?
+            {
+                Some(0) => show_all_apps_tui(&extension, applications)?,
+                Some(1) | None => {}
+                Some(_) => unreachable!("menu selection is bounded by its items"),
+            }
+            return Ok(());
+        }
+
+        let mut choices = supporting_apps
+            .iter()
+            .map(|app| application_choice_label(app))
+            .collect::<Vec<_>>();
+        choices.push("Search all installed applications…".to_owned());
+        choices.push("Back".to_owned());
+        println!("{}", "↑↓ navigate  •  Enter select  •  Esc back".dimmed());
+        let selection = Select::with_theme(&theme)
+            .with_prompt(format!("Applications declaring .{extension}"))
+            .items(&choices)
+            .default(0)
+            .max_length(12)
+            .interact_opt()?;
+        match selection {
+            Some(index) if index < supporting_apps.len() => {
+                set_default_and_report(&extension, supporting_apps[index]);
+            }
+            Some(index) if index == supporting_apps.len() => {
+                show_all_apps_tui(&extension, applications)?;
+            }
+            Some(_) | None => {}
+        }
+        return Ok(());
+    }
+}
+
+fn application_choice_label(app: &Application) -> String {
+    let bundle_id = app.bundle_id.as_deref().unwrap_or("bundle ID unavailable");
+    format!("{}  ·  {bundle_id}", app.name)
 }
 
 fn interactive_main_menu(applications: &[Application]) -> Result<()> {
@@ -2361,6 +2523,13 @@ fn parse_confirmation(input: &str) -> ConfirmationChoice {
 }
 
 fn confirm_change() -> Result<bool> {
+    if interactive_tui_available() {
+        return Ok(Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Apply this change?")
+            .default(false)
+            .interact_opt()?
+            .unwrap_or(false));
+    }
     loop {
         let Some(input) = read_prompt("Apply this change? [y/N]: ")? else {
             return Ok(false);
@@ -2371,6 +2540,79 @@ fn confirm_change() -> Result<bool> {
             ConfirmationChoice::Invalid => println!("Enter y to apply, or n to cancel."),
         }
     }
+}
+
+fn browse_applications_tui(applications: &[Application]) -> Result<()> {
+    if applications.is_empty() {
+        println!("No applications were found.");
+        return Ok(());
+    }
+
+    let theme = ColorfulTheme::default();
+    let choices = applications
+        .iter()
+        .map(application_choice_label)
+        .collect::<Vec<_>>();
+    loop {
+        println!(
+            "\n{}",
+            "Type to filter  •  ↑↓ navigate  •  Enter inspect  •  Esc back".dimmed()
+        );
+        let Some(index) = FuzzySelect::with_theme(&theme)
+            .with_prompt("Installed applications")
+            .items(&choices)
+            .default(0)
+            .max_length(12)
+            .interact_opt()?
+        else {
+            return Ok(());
+        };
+        let app = &applications[index];
+        println!("\n{}", app.name.bright_blue().bold());
+        println!("  Path: {}", app.path.display());
+        println!(
+            "  Bundle ID: {}",
+            app.bundle_id.as_deref().unwrap_or("unavailable")
+        );
+        println!("  Declared extensions: {}", app.extensions.len());
+
+        let actions = ["Browse another application", "Back to main menu"];
+        match Select::with_theme(&theme)
+            .with_prompt("Next step")
+            .items(&actions)
+            .default(0)
+            .interact_opt()?
+        {
+            Some(0) => {}
+            Some(1) | None => return Ok(()),
+            Some(_) => unreachable!("menu selection is bounded by its items"),
+        }
+    }
+}
+
+fn show_all_apps_tui(extension: &str, applications: &[Application]) -> Result<()> {
+    if applications.is_empty() {
+        println!("No applications were found.");
+        return Ok(());
+    }
+    let choices = applications
+        .iter()
+        .map(application_choice_label)
+        .collect::<Vec<_>>();
+    println!(
+        "\n{}",
+        "Type to filter  •  ↑↓ navigate  •  Enter select  •  Esc back".dimmed()
+    );
+    if let Some(index) = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("Choose the default application for .{extension}"))
+        .items(&choices)
+        .default(0)
+        .max_length(12)
+        .interact_opt()?
+    {
+        set_default_and_report(extension, &applications[index]);
+    }
+    Ok(())
 }
 
 fn browse_applications_menu(applications: &[Application]) -> Result<()> {
@@ -2536,6 +2778,46 @@ mod tests {
         assert_eq!(parse_confirmation(""), ConfirmationChoice::Decline);
         assert_eq!(parse_confirmation("n"), ConfirmationChoice::Decline);
         assert_eq!(parse_confirmation("later"), ConfirmationChoice::Invalid);
+    }
+
+    #[test]
+    fn enhanced_tui_requires_real_terminals_and_supports_plain_override() {
+        assert!(terminal_supports_tui(
+            true,
+            true,
+            true,
+            Some("xterm-256color"),
+            None
+        ));
+        assert!(!terminal_supports_tui(
+            false,
+            true,
+            true,
+            Some("xterm-256color"),
+            None
+        ));
+        assert!(!terminal_supports_tui(
+            true,
+            false,
+            true,
+            Some("xterm-256color"),
+            None
+        ));
+        assert!(!terminal_supports_tui(
+            true,
+            true,
+            false,
+            Some("xterm-256color"),
+            None
+        ));
+        assert!(!terminal_supports_tui(true, true, true, Some("dumb"), None));
+        assert!(!terminal_supports_tui(
+            true,
+            true,
+            true,
+            Some("xterm-256color"),
+            Some("plain")
+        ));
     }
 
     #[test]

--- a/website/index.html
+++ b/website/index.html
@@ -110,7 +110,7 @@
       </section>
 
       <div class="signal-strip" aria-hidden="true">
-        <span>SCAN</span><i></i><span>INSPECT</span><i></i><span>SELECT</span><i></i><span>VERIFY</span><i></i><span>DONE</span>
+        <span>SCAN</span><i></i><span>INSPECT</span><i></i><span>REVIEW</span><i></i><span>VERIFY</span><i></i><span>DONE</span>
       </div>
 
       <section class="manifesto section-pad reveal">


### PR DESCRIPTION
## Summary

- add a compact coding-agent-style interactive terminal with arrow-key navigation and highlighted selections
- add live fuzzy search for installed applications by name and bundle identifier
- support Enter selection plus Esc or q cancellation without taking over the alternate screen
- preserve explicit safe-default confirmation before governed mutations
- automatically retain the numbered text interface for pipes, redirected streams, and TERM=dumb
- document DUTIS_TUI=plain as an explicit accessibility and compatibility fallback
- bump the release version to v2.24.0

## Validation

- cargo fmt --all -- --check
- cargo check --all-targets --locked --offline
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline
- cargo build --release --bins --locked --offline
- cargo package --allow-dirty --locked --offline
- ruby -c scripts/render_homebrew_formula.rb
- git diff --check
- real PTY smoke test: arrow navigation, live filtering, Enter selection, Esc return, default-no cancellation
- real PTY smoke test: DUTIS_TUI=plain fallback